### PR TITLE
Felis Cleanups

### DIFF
--- a/yml/baselineSchema.yaml
+++ b/yml/baselineSchema.yaml
@@ -161,7 +161,7 @@ tables:
     "@id": "#DiaObject.pmParallaxNdata"
     datatype: int
     description: The number of data points used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: uPSFluxMean
     "@id": "#DiaObject.uPSFluxMean"
     datatype: float
@@ -193,7 +193,7 @@ tables:
     "@id": "#DiaObject.uPSFluxNdata"
     datatype: int
     description: The number of data points used to compute uPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: uFPFluxMean
     "@id": "#DiaObject.uFPFluxMean"
     datatype: float
@@ -246,7 +246,7 @@ tables:
     "@id": "#DiaObject.gPSFluxNdata"
     datatype: int
     description: The number of data points used to compute gPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: gFPFluxMean
     "@id": "#DiaObject.gFPFluxMean"
     datatype: float
@@ -299,7 +299,7 @@ tables:
     "@id": "#DiaObject.rPSFluxNdata"
     datatype: int
     description: The number of data points used to compute rPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: rFPFluxMean
     "@id": "#DiaObject.rFPFluxMean"
     datatype: float
@@ -352,7 +352,7 @@ tables:
     "@id": "#DiaObject.iPSFluxNdata"
     datatype: int
     description: The number of data points used to compute iPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: iFPFluxMean
     "@id": "#DiaObject.iFPFluxMean"
     datatype: float
@@ -405,7 +405,7 @@ tables:
     "@id": "#DiaObject.zPSFluxNdata"
     datatype: int
     description: The number of data points used to compute zPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: zFPFluxMean
     "@id": "#DiaObject.zFPFluxMean"
     datatype: float
@@ -458,7 +458,7 @@ tables:
     "@id": "#DiaObject.yPSFluxNdata"
     datatype: int
     description: The number of data points used to compute yPSFluxChi2.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: yFPFluxMean
     "@id": "#DiaObject.yFPFluxMean"
     datatype: float
@@ -1082,7 +1082,7 @@ tables:
     datatype: int
     description: Position of this diaSource in the processing order relative to other
       diaSources within a given diaObjectId or ssObjectId.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
     datatype: timestamp
@@ -1268,7 +1268,7 @@ tables:
     "@id": "#DiaSource.psNdata"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: trailFlux
     "@id": "#DiaSource.trailFlux"
     datatype: float
@@ -1412,7 +1412,7 @@ tables:
     "@id": "#DiaSource.trailNdata"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: dipMeanFlux
     "@id": "#DiaSource.dipMeanFlux"
     datatype: float
@@ -1605,7 +1605,7 @@ tables:
     "@id": "#DiaSource.dipNdata"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: totFlux
     "@id": "#DiaSource.totFlux"
     datatype: float
@@ -1897,7 +1897,7 @@ tables:
     datatype: int
     description: Pointer to prv_InputType. Indicates which input was used to produce
       a given object.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: psRa
     "@id": "#Object.psRa"
     datatype: double
@@ -2069,7 +2069,7 @@ tables:
     "@id": "#Object.psN"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: uBbdRa
     "@id": "#Object.uBbdRa"
     datatype: double
@@ -2191,7 +2191,7 @@ tables:
     "@id": "#Object.uBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For u filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: gBbdRa
     "@id": "#Object.gBbdRa"
     datatype: double
@@ -2313,7 +2313,7 @@ tables:
     "@id": "#Object.gBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For g filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: rBbdRa
     "@id": "#Object.rBbdRa"
     datatype: double
@@ -2435,7 +2435,7 @@ tables:
     "@id": "#Object.rBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For r filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: iBbdRa
     "@id": "#Object.iBbdRa"
     datatype: double
@@ -2557,7 +2557,7 @@ tables:
     "@id": "#Object.iBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For i filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: zBbdRa
     "@id": "#Object.zBbdRa"
     datatype: double
@@ -2679,7 +2679,7 @@ tables:
     "@id": "#Object.zBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For z filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: yBbdRa
     "@id": "#Object.yBbdRa"
     datatype: double
@@ -2801,7 +2801,7 @@ tables:
     "@id": "#Object.yBdN"
     datatype: int
     description: The number of data points (pixels) used to fit the model. For y filter.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: ugStd
     "@id": "#Object.ugStd"
     datatype: float
@@ -4263,7 +4263,7 @@ tables:
     "@id": "#Source.psN"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: psRa
     "@id": "#Source.psRa"
     datatype: double
@@ -5026,7 +5026,7 @@ tables:
     datatype: int
     description: Observing program id (e.g., universal cadence, or one of the deep
       drilling programs, etc.).
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: exposureType
     "@id": "#RawExposure.exposureType"
     datatype: byte
@@ -5168,7 +5168,7 @@ tables:
     "@id": "#CcdVisit.nExposures"
     datatype: int
     description: Number of exposures combined to produce this visit.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: ra
     "@id": "#CcdVisit.ra"
     datatype: double
@@ -5396,7 +5396,7 @@ tables:
     "@id": "#Visit.nExposures"
     datatype: int
     description: Number of exposures combined to produce this visit.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: ra
     "@id": "#Visit.ra"
     datatype: double
@@ -5434,7 +5434,7 @@ tables:
     datatype: int
     description: Observing program id (e.g., universal cadence, or one of the deep
       drilling programs, etc.).
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: exposureType
     "@id": "#Visit.exposureType"
     datatype: byte
@@ -5624,7 +5624,7 @@ tables:
     "@id": "#prv_Pipeline.pipelineId"
     datatype: int
     description: Unique id
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
     ivoa:ucd: meta.id;src
   - name: pipelineName
     "@id": "#prv_Pipeline.pipelineName"
@@ -5644,13 +5644,13 @@ tables:
     "@id": "#prv_cnf_Pipeline.pipelineCnfId"
     datatype: int
     description: Unique id
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
     ivoa:ucd: meta.id;src
   - name: pipelineId
     "@id": "#prv_cnf_Pipeline.pipelineId"
     datatype: int
     description: Id of the pipeline this configuration is for.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: validityBegin
     "@id": "#prv_cnf_Pipeline.validityBegin"
     datatype: timestamp
@@ -5691,7 +5691,7 @@ tables:
     "@id": "#prv_Task.taskId"
     datatype: int
     description: Unique id
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
     ivoa:ucd: meta.id;src
   - name: taskName
     "@id": "#prv_Task.taskName"
@@ -5713,22 +5713,22 @@ tables:
   - name: pipelineCnfId
     "@id": "#prv_cnf_Pipeline_Tasks.pipelineCnfId"
     datatype: int
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: taskId
     "@id": "#prv_cnf_Pipeline_Tasks.taskId"
     datatype: int
     description: Id of the corresponding task.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: parentTaskId
     "@id": "#prv_cnf_Pipeline_Tasks.parentTaskId"
     datatype: int
     description: Id of the parent task, or NULL if there is no parent task.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: taskPosition
     "@id": "#prv_cnf_Pipeline_Tasks.taskPosition"
     datatype: int
     description: Position of the task in the pipeline. Starts with 1.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   constraints:
   - name: FK_cnfPipeTasks_taskId
     "@id": "#FK_cnfPipeTasks_taskId"
@@ -5765,13 +5765,13 @@ tables:
     "@id": "#prv_cnf_Task.taskCnfId"
     datatype: int
     description: Unique id
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
     ivoa:ucd: meta.id;src
   - name: taskId
     "@id": "#prv_cnf_Task.taskId"
     datatype: int
     description: Id of the corresponding task.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: validityBegin
     "@id": "#prv_cnf_Task.validityBegin"
     datatype: timestamp
@@ -5788,7 +5788,7 @@ tables:
     description: Version of the config (in case there is more than one configuration
       that is valid for a given validity range.
     defaultValue: '1'
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: gitSHA
     "@id": "#prv_cnf_Task.gitSHA"
     datatype: string
@@ -5826,7 +5826,7 @@ tables:
     "@id": "#prv_cnf_Task_Columns.taskCnfId"
     datatype: int
     description: If of the corresponding task configuration.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: tcName
     "@id": "#prv_cnf_Task_Columns.tcName"
     datatype: text
@@ -5858,7 +5858,7 @@ tables:
     "@id": "#prv_cnf_Task_Files.taskCnfId"
     datatype: int
     description: If of the corresponding task configuration.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: fileUrl
     "@id": "#prv_cnf_Task_Files.fileUrl"
     datatype: text
@@ -5888,7 +5888,7 @@ tables:
     "@id": "#prv_cnf_Task_KVParams.taskCnfId"
     datatype: int
     description: If of the corresponding task configuration.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: theKey
     "@id": "#prv_cnf_Task_KVParams.theKey"
     datatype: string
@@ -5924,7 +5924,7 @@ tables:
     "@id": "#prv_Node.nodeId"
     datatype: int
     description: Unique id
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
     ivoa:ucd: meta.id;src
   - name: nodeName
     "@id": "#prv_Node.nodeName"
@@ -5943,7 +5943,7 @@ tables:
     "@id": "#prv_cnf_Node.nodeId"
     datatype: int
     description: Id of the node this configuration is for.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: validityBegin
     "@id": "#prv_cnf_Node.validityBegin"
     datatype: timestamp
@@ -5970,12 +5970,12 @@ tables:
     "@id": "#prv_cnf_Node.cores"
     datatype: int
     description: Number of cores.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: ram
     "@id": "#prv_cnf_Node.ram"
     datatype: int
     description: Size of memory [GB].
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   constraints:
   - name: FK_cnfNode_nodeId
     "@id": "#FK_cnfNode_nodeId"
@@ -6068,12 +6068,12 @@ tables:
     "@id": "#prv_TaskExecution.taskId"
     datatype: int
     description: Id of the task that is executed.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: nodeId
     "@id": "#prv_TaskExecution.nodeId"
     datatype: int
     description: Id of the node where the task is executed.
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   - name: theTime
     "@id": "#prv_TaskExecution.theTime"
     datatype: timestamp
@@ -6086,7 +6086,7 @@ tables:
       some rare cases when manual patching in required, we can end up with more than
       one valid config version.
     defaultValue: '1'
-    mysql:datatype: INT
+    mysql:datatype: INTEGER
   primaryKey: "#prv_TaskExecution.taskExecId"
   constraints:
   - name: FK_taskExec_taskId

--- a/yml/sdss_stripe82_01.yml
+++ b/yml/sdss_stripe82_01.yml
@@ -50,7 +50,7 @@ tables:
     "@id": "#DeepCoadd.tract"
     datatype: int
     description: Sky-tract number.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: patch
     "@id": "#DeepCoadd.patch"
     datatype: char
@@ -298,7 +298,7 @@ tables:
   - name: intValue
     "@id": "#DeepCoadd_Metadata.intValue"
     datatype: int
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: doubleValue
     "@id": "#DeepCoadd_Metadata.doubleValue"
     datatype: double
@@ -325,7 +325,7 @@ tables:
     datatype: int
     description: ID for Level 10 HTM triangle overlapping exposure. For each exposure
       in DeepCoadd,  there will be one row for every overlapping triangle.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     ivoa:ucd: pos.HTM
   mysql:charset: latin1
 - name: LeapSeconds
@@ -890,7 +890,7 @@ tables:
     "@id": "#RunDeepForcedSource.exposure_filter_id"
     datatype: int
     description: Id of the filter for the band.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     ivoa:ucd: meta.id;instr.filter
   - name: exposure_time
     "@id": "#RunDeepForcedSource.exposure_time"
@@ -994,7 +994,7 @@ tables:
     datatype: int
     description: Number of children that this source has. Zero if it's the final deblending
       product.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: deblend_deblended_as_psf
     "@id": "#RunDeepSource.deblend_deblended_as_psf"
     datatype: boolean
@@ -1780,7 +1780,7 @@ tables:
     datatype: int
     description: ID of filter used for the coadd the source was detected and measured
       on (pointer to DeepCoadd).
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     ivoa:ucd: meta.id;instr.filter
   primaryKey: "#RunDeepSource.id"
   mysql:charset: latin1
@@ -1797,7 +1797,7 @@ tables:
     "@id": "#Science_Ccd_Exposure.run"
     datatype: int
     description: Run number.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: camcol
     "@id": "#Science_Ccd_Exposure.camcol"
     datatype: byte
@@ -1813,7 +1813,7 @@ tables:
     "@id": "#Science_Ccd_Exposure.field"
     datatype: int
     description: Field number.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: filterName
     "@id": "#Science_Ccd_Exposure.filterName"
     datatype: char
@@ -2020,19 +2020,19 @@ tables:
     "@id": "#Science_Ccd_Exposure.nCombine"
     datatype: int
     description: Number of images co-added to create a deeper image.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: binX
     "@id": "#Science_Ccd_Exposure.binX"
     datatype: int
     description: Binning of the CCD in x.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     fits:tunit: pixel
     ivoa:ucd: meta.number
   - name: binY
     "@id": "#Science_Ccd_Exposure.binY"
     datatype: int
     description: Binning of the CCD in y.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     fits:tunit: pixel
     ivoa:ucd: meta.number
   - name: fluxMag0
@@ -2092,7 +2092,7 @@ tables:
   - name: intValue
     "@id": "#Science_Ccd_Exposure_Metadata.intValue"
     datatype: int
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: doubleValue
     "@id": "#Science_Ccd_Exposure_Metadata.doubleValue"
     datatype: double
@@ -2116,7 +2116,7 @@ tables:
   - name: run
     "@id": "#Science_Ccd_Exposure_NoFile.run"
     datatype: int
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: filterId
     "@id": "#Science_Ccd_Exposure_NoFile.filterId"
     datatype: byte
@@ -2128,7 +2128,7 @@ tables:
   - name: field
     "@id": "#Science_Ccd_Exposure_NoFile.field"
     datatype: int
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
   - name: path
     "@id": "#Science_Ccd_Exposure_NoFile.path"
     datatype: string
@@ -2149,7 +2149,7 @@ tables:
     datatype: int
     description: ID for Level 10 HTM triangle overlapping exposure. For each exposure
       in DeepCoadd, there will be one row for every overlapping triangle.
-    mysql:datatype: INT(11)
+    mysql:datatype: INTEGER(11)
     ivoa:ucd: pos.HTM
   mysql:charset: latin1
 - name: ZZZ_Db_Description


### PR DESCRIPTION
This PR fixes a few small issues with the felis description files.

* `mysql:datatype` should be `INTEGER` instead of `INT` - this is just because sqlalchemy doesn't recognize the `INT` alias as a data type for mysql
* Some `@id` 's had some copy/paste errors
* Constraint types were missing. The constraint types could probably be inferred by their attributes but currently they are required for constraints.