### PR TITLE
Remove a non-ASCII character and fix a typo.

### DIFF
--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -1,7 +1,7 @@
 ---
 name: dp01_dc2_catalogs
 '@id': dc2
-description: Data Preview 0 includes five tables based on the DESC’S Data Challenge 2 simulation of 300 square degrees of the wide-fast-deep LSST survey region after 5 years. All tables contain objects detected in coadded images.
+description: Data Preview 0 includes five tables based on the DESC's Data Challenge 2 simulation of 300 square degrees of the wide-fast-deep LSST survey region after 5 years. All tables contain objects detected in coadded images.
 tables:
 - name: position
   '@id': '#position'


### PR DESCRIPTION
We will have to review UTF-8-cleanliness of our whole metadata chain in the future.