### PR TITLE
DM-31093: Updated TAP_SCHEMA for NCSA to be closer to Qserv reality

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 ./build mock
-./build stable dp01_dc2.yaml hsc_gen2.yaml hsc.yaml sdss_stripe82_01.yml wise_00.yml
-./build int dp01_dc2.yaml hsc_gen2.yaml hsc.yaml sdss_stripe82_01.yml wise_00.yml
+./build stable hsc_gen2.yaml hsc.yaml wise_01.yml
+./build int hsc_gen2.yaml hsc.yaml wise_01.yml
 ./build idfprod dp01_dc2.yaml
 ./build idfint dp01_dc2.yaml

--- a/yml/wise_01.yml
+++ b/yml/wise_01.yml
@@ -1,6 +1,6 @@
 ---
 name: wise_01
-description: Key catalogs from the 2013 AllWISE data release: Source Catalog and Multi-Epoch Photometry
+description: 'Key catalogs from the 2013 AllWISE data release: Source Catalog and Multi-Epoch Photometry'
 tables:
 - name: allwise_p3as_mep
   "@id": "#allwise_p3as_mep"


### PR DESCRIPTION
The NCSA instances use Qserv-small.  This means:
* The newer "wise_01" database is used, superseding "wise_00".
* The DP0.1 tables are not available.
* No SDSS tables are available any longer.