### PR TITLE
DM-31077: Assign "principal" values to a subset of DP0.1 columns

### DIFF
--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -13,12 +13,16 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Unique id.
   - name: coord_ra
     '@id': '#position.coord_ra'
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: RA-coordinate
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -27,6 +31,8 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Decl-coordinate
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -35,18 +41,24 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: unique ID of parent source
     fits:tunit: ''
   - name: deblend_nChild
     '@id': '#position.deblend_nChild'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of children this object has (defaults to 0)
     fits:tunit: ''
   - name: detect_isPrimary
     '@id': '#position.detect_isPrimary'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: true if source has no children and is in the inner region of a coadd
       patch and is in the inner region of a coadd tract and is not "detected" in a
       pseudo-filter (see config.pseudoFilterList)
@@ -55,138 +67,184 @@ tables:
     '@id': '#position.extinction_bv'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Milky Way dust extinction, E(B-V)
     fits:tunit: mag
   - name: detect_isPatchInner
     '@id': '#position.detect_isPatchInner'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: true if source is in the inner region of a coadd patch
     fits:tunit: ''
   - name: detect_isTractInner
     '@id': '#position.detect_isTractInner'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: true if source is in the inner region of a coadd tract
     fits:tunit: ''
   - name: merge_footprint_i
     '@id': '#position.merge_footprint_i'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter i
     fits:tunit: ''
   - name: merge_footprint_r
     '@id': '#position.merge_footprint_r'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter r
     fits:tunit: ''
   - name: merge_footprint_z
     '@id': '#position.merge_footprint_z'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter z
     fits:tunit: ''
   - name: merge_footprint_y
     '@id': '#position.merge_footprint_y'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter y
     fits:tunit: ''
   - name: merge_footprint_g
     '@id': '#position.merge_footprint_g'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter g
     fits:tunit: ''
   - name: merge_footprint_u
     '@id': '#position.merge_footprint_u'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter u
     fits:tunit: ''
   - name: merge_footprint_sky
     '@id': '#position.merge_footprint_sky'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Detection footprint overlapped with a detection from filter sky
     fits:tunit: ''
   - name: merge_peak_i
     '@id': '#position.merge_peak_i'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter i
     fits:tunit: ''
   - name: merge_peak_r
     '@id': '#position.merge_peak_r'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter r
     fits:tunit: ''
   - name: merge_peak_z
     '@id': '#position.merge_peak_z'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter z
     fits:tunit: ''
   - name: merge_peak_y
     '@id': '#position.merge_peak_y'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter y
     fits:tunit: ''
   - name: merge_peak_g
     '@id': '#position.merge_peak_g'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter g
     fits:tunit: ''
   - name: merge_peak_u
     '@id': '#position.merge_peak_u'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter u
     fits:tunit: ''
   - name: merge_peak_sky
     '@id': '#position.merge_peak_sky'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Peak detected in filter sky
     fits:tunit: ''
   - name: merge_measurement_i
     '@id': '#position.merge_measurement_i'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the i filter
     fits:tunit: ''
   - name: merge_measurement_r
     '@id': '#position.merge_measurement_r'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the r filter
     fits:tunit: ''
   - name: merge_measurement_z
     '@id': '#position.merge_measurement_z'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the z filter
     fits:tunit: ''
   - name: merge_measurement_y
     '@id': '#position.merge_measurement_y'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the y filter
     fits:tunit: ''
   - name: merge_measurement_g
     '@id': '#position.merge_measurement_g'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the g filter
     fits:tunit: ''
   - name: merge_measurement_u
     '@id': '#position.merge_measurement_u'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag field set if the measurements here are from the u filter
     fits:tunit: ''
 - name: reference
@@ -199,12 +257,16 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Unique id.
   - name: coord_ra
     '@id': '#reference.coord_ra'
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -213,6 +275,8 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -220,108 +284,144 @@ tables:
     '@id': '#reference.base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: base_SdssCentroid_y
     '@id': '#reference.base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: base_SdssCentroid_xErr
     '@id': '#reference.base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: base_SdssCentroid_yErr
     '@id': '#reference.base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: base_SdssCentroid_flag
     '@id': '#reference.base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_SdssCentroid_flag_edge
     '@id': '#reference.base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: base_SdssCentroid_flag_noSecondDerivative
     '@id': '#reference.base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#reference.base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: base_SdssCentroid_flag_notAtMaximum
     '@id': '#reference.base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: base_SdssCentroid_flag_resetToPeak
     '@id': '#reference.base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: base_PsfFlux_instFlux
     '@id': '#reference.base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: base_PsfFlux_instFluxErr
     '@id': '#reference.base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: base_PsfFlux_area
     '@id': '#reference.base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: base_PsfFlux_apCorr
     '@id': '#reference.base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: base_PsfFlux_apCorrErr
     '@id': '#reference.base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: base_PsfFlux_flag
     '@id': '#reference.base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_PsfFlux_flag_noGoodPixels
     '@id': '#reference.base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: base_PsfFlux_flag_edge
     '@id': '#reference.base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -329,24 +429,32 @@ tables:
     '@id': '#reference.base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: base_PsfFlux_flag_badCentroid
     '@id': '#reference.base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_Blendedness_raw_instFlux
     '@id': '#reference.base_Blendedness_raw_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 'measure of how instFlux is affected by neighbors: (1 - instFlux.child/instFlux.parent)'
     fits:tunit: ''
   - name: base_Blendedness_raw_instFlux_child
     '@id': '#reference.base_Blendedness_raw_instFlux_child'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux of the child, measured with a Gaussian weight matched to
       the child
     fits:tunit: count
@@ -354,6 +462,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_instFlux_parent'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux of the parent, measured with a Gaussian weight matched to
       the child
     fits:tunit: count
@@ -361,12 +471,16 @@ tables:
     '@id': '#reference.base_Blendedness_abs_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 'measure of how instFlux is affected by neighbors: (1 - instFlux.child/instFlux.parent)'
     fits:tunit: ''
   - name: base_Blendedness_abs_instFlux_child
     '@id': '#reference.base_Blendedness_abs_instFlux_child'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux of the child, measured with a Gaussian weight matched to
       the child
     fits:tunit: count
@@ -374,6 +488,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_instFlux_parent'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux of the parent, measured with a Gaussian weight matched to
       the child
     fits:tunit: count
@@ -381,6 +497,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_child_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -388,6 +506,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_child_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -395,6 +515,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_child_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -402,6 +524,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_parent_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -409,6 +533,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_parent_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -416,6 +542,8 @@ tables:
     '@id': '#reference.base_Blendedness_raw_parent_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
     fits:tunit: pixel^2
@@ -423,6 +551,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_child_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -431,6 +561,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_child_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -439,6 +571,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_child_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -447,6 +581,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_parent_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -455,6 +591,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_parent_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -463,6 +601,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs_parent_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
@@ -471,18 +611,24 @@ tables:
     '@id': '#reference.base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: base_ClassificationExtendedness_flag
     '@id': '#reference.base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: base_Blendedness_old
     '@id': '#reference.base_Blendedness_old'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 'Blendedness from dot products: (child.dot(parent)/child.dot(child)
       - 1)'
     fits:tunit: ''
@@ -490,6 +636,8 @@ tables:
     '@id': '#reference.base_Blendedness_abs'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 'Measure of how much the flux is affected by neighbors: (1 - child_instFlux/parent_instFlux).  Operates
       on the absolute value of the pixels to try to obtain a "de-noised" value.  See
       section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.'
@@ -498,503 +646,671 @@ tables:
     '@id': '#reference.base_Blendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_Blendedness_flag_noCentroid
     '@id': '#reference.base_Blendedness_flag_noCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object has no centroid
     fits:tunit: ''
   - name: base_Blendedness_flag_noShape
     '@id': '#reference.base_Blendedness_flag_noShape'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object has no shape
     fits:tunit: ''
   - name: base_PixelFlags_flag
     '@id': '#reference.base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: base_PixelFlags_flag_offimage
     '@id': '#reference.base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: base_PixelFlags_flag_edge
     '@id': '#reference.base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: base_PixelFlags_flag_interpolated
     '@id': '#reference.base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: base_PixelFlags_flag_saturated
     '@id': '#reference.base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: base_PixelFlags_flag_cr
     '@id': '#reference.base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: base_PixelFlags_flag_bad
     '@id': '#reference.base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: base_PixelFlags_flag_suspect
     '@id': '#reference.base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_interpolatedCenter
     '@id': '#reference.base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: base_PixelFlags_flag_saturatedCenter
     '@id': '#reference.base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: base_PixelFlags_flag_crCenter
     '@id': '#reference.base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: base_PixelFlags_flag_suspectCenter
     '@id': '#reference.base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_clippedCenter
     '@id': '#reference.base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#reference.base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_inexact_psfCenter
     '@id': '#reference.base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_bright_objectCenter
     '@id': '#reference.base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_clipped
     '@id': '#reference.base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_sensor_edge
     '@id': '#reference.base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_inexact_psf
     '@id': '#reference.base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: base_PixelFlags_flag_bright_object
     '@id': '#reference.base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: good
     '@id': '#reference.good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: ext_shapeHSM_HsmSourceMoments_x
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmSourceMoments_y
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmSourceMoments_xx
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMoments_flag
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: general failure flag, set if anything went wrong
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMoments_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_no_pixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no pixels to measure
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMoments_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_not_contained'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: center not contained in footprint bounding box
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMoments_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_parent_source'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: parent source, ignored
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMoments_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_x
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmPsfMoments_y
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmPsfMoments_xx
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmPsfMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmPsfMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmShapeRegauss_e1
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_e1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) ''regaussianization
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_e2
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_e2'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) ''regaussianization
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_sigma
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_sigma'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) ''regaussianization
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_resolution
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_resolution'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: resolution factor (0=unresolved, 1=resolved)
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_x
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmSourceMomentsRound_y
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM Centroid
     fits:tunit: pixel
   - name: ext_shapeHSM_HsmSourceMomentsRound_xx
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMomentsRound_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMomentsRound_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM moments
     fits:tunit: pixel^2
   - name: ext_shapeHSM_HsmSourceMomentsRound_Flux
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_Flux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: HSM flux
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_flag
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: general failure flag, set if anything went wrong
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_no_pixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no pixels to measure
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_not_contained'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: center not contained in footprint bounding box
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_parent_source'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: parent source, ignored
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: general failure flag, set if anything went wrong
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_no_pixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no pixels to measure
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_not_contained'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: center not contained in footprint bounding box
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_parent_source'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: parent source, ignored
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag_galsim
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_galsim'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: GalSim failure
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: general failure flag, set if anything went wrong
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_no_pixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no pixels to measure
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_not_contained'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: center not contained in footprint bounding box
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_parent_source'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: parent source, ignored
     fits:tunit: ''
   - name: ext_shapeHSM_HsmPsfMoments_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: ext_shapeHSM_HsmShapeRegauss_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_SdssShape_xx
     '@id': '#reference.base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: base_SdssShape_yy
     '@id': '#reference.base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: base_SdssShape_xy
     '@id': '#reference.base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: base_SdssShape_xxErr
     '@id': '#reference.base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: base_SdssShape_yyErr
     '@id': '#reference.base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: base_SdssShape_xyErr
     '@id': '#reference.base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: base_SdssShape_x
     '@id': '#reference.base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: base_SdssShape_y
     '@id': '#reference.base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: base_SdssShape_instFlux
     '@id': '#reference.base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: base_SdssShape_instFluxErr
     '@id': '#reference.base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: base_SdssShape_psf_xx
     '@id': '#reference.base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: base_SdssShape_psf_yy
     '@id': '#reference.base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: base_SdssShape_psf_xy
     '@id': '#reference.base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: base_SdssShape_instFlux_xx_Cov
     '@id': '#reference.base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: base_SdssShape_instFlux_yy_Cov
     '@id': '#reference.base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: base_SdssShape_instFlux_xy_Cov
     '@id': '#reference.base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: base_SdssShape_flag
     '@id': '#reference.base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: base_SdssShape_flag_unweightedBad
     '@id': '#reference.base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: base_SdssShape_flag_unweighted
     '@id': '#reference.base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -1002,78 +1318,104 @@ tables:
     '@id': '#reference.base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: base_SdssShape_flag_maxIter
     '@id': '#reference.base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: base_SdssShape_flag_psf
     '@id': '#reference.base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: base_SdssShape_flag_badCentroid
     '@id': '#reference.base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: deblend_psfCenter_x
     '@id': '#reference.deblend_psfCenter_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: If deblended-as-psf, the PSF centroid
     fits:tunit: pixel
   - name: deblend_psfCenter_y
     '@id': '#reference.deblend_psfCenter_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: If deblended-as-psf, the PSF centroid
     fits:tunit: pixel
   - name: deblend_psf_instFlux
     '@id': '#reference.deblend_psf_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: If deblended-as-psf, the instrumental PSF flux
     fits:tunit: count
   - name: deblend_deblendedAsPsf
     '@id': '#reference.deblend_deblendedAsPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Deblender thought this source looked like a PSF
     fits:tunit: ''
   - name: deblend_tooManyPeaks
     '@id': '#reference.deblend_tooManyPeaks'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source had too many peaks; only the brightest were included
     fits:tunit: ''
   - name: deblend_parentTooBig
     '@id': '#reference.deblend_parentTooBig'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Parent footprint covered too many pixels
     fits:tunit: ''
   - name: deblend_masked
     '@id': '#reference.deblend_masked'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Parent footprint was predominantly masked
     fits:tunit: ''
   - name: deblend_skipped
     '@id': '#reference.deblend_skipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Deblender skipped this source
     fits:tunit: ''
   - name: deblend_rampedTemplate
     '@id': '#reference.deblend_rampedTemplate'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: This source was near an image edge and the deblender used "ramp"
       edge-handling.
     fits:tunit: ''
@@ -1081,6 +1423,8 @@ tables:
     '@id': '#reference.deblend_patchedTemplate'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: This source was near an image edge and the deblender used "patched"
       edge-handling.
     fits:tunit: ''
@@ -1088,318 +1432,424 @@ tables:
     '@id': '#reference.deblend_hasStrayFlux'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: This source was assigned some stray flux
     fits:tunit: ''
   - name: deblend_psfflux
     '@id': '#reference.deblend_psfflux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: If deblended-as-psf, the instrumental PSF flux
     fits:tunit: count
   - name: modelfit_CModel_initial_instFlux
     '@id': '#reference.modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: modelfit_CModel_initial_instFluxErr
     '@id': '#reference.modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: modelfit_CModel_initial_flux_inner
     '@id': '#reference.modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: modelfit_CModel_initial_ellipse_xx
     '@id': '#reference.modelfit_CModel_initial_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the initial fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_initial_ellipse_yy
     '@id': '#reference.modelfit_CModel_initial_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the initial fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_initial_ellipse_xy
     '@id': '#reference.modelfit_CModel_initial_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the initial fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_initial_objective
     '@id': '#reference.modelfit_CModel_initial_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_nonlinear_0
     '@id': '#reference.modelfit_CModel_initial_nonlinear_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_nonlinear_1
     '@id': '#reference.modelfit_CModel_initial_nonlinear_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_nonlinear_2
     '@id': '#reference.modelfit_CModel_initial_nonlinear_2'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_fixed_0
     '@id': '#reference.modelfit_CModel_initial_fixed_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_fixed_1
     '@id': '#reference.modelfit_CModel_initial_fixed_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the initial fit
     fits:tunit: ''
   - name: modelfit_CModel_initial_nIter
     '@id': '#reference.modelfit_CModel_initial_nIter'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of total iterations in stage
     fits:tunit: ''
   - name: modelfit_CModel_initial_time
     '@id': '#reference.modelfit_CModel_initial_time'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Time spent in stage
     fits:tunit: second
   - name: modelfit_CModel_exp_instFlux
     '@id': '#reference.modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: modelfit_CModel_exp_instFluxErr
     '@id': '#reference.modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: modelfit_CModel_exp_flux_inner
     '@id': '#reference.modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: modelfit_CModel_exp_ellipse_xx
     '@id': '#reference.modelfit_CModel_exp_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the exponential fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_exp_ellipse_yy
     '@id': '#reference.modelfit_CModel_exp_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the exponential fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_exp_ellipse_xy
     '@id': '#reference.modelfit_CModel_exp_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the exponential fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_exp_objective
     '@id': '#reference.modelfit_CModel_exp_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_nonlinear_0
     '@id': '#reference.modelfit_CModel_exp_nonlinear_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_nonlinear_1
     '@id': '#reference.modelfit_CModel_exp_nonlinear_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_nonlinear_2
     '@id': '#reference.modelfit_CModel_exp_nonlinear_2'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_fixed_0
     '@id': '#reference.modelfit_CModel_exp_fixed_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_fixed_1
     '@id': '#reference.modelfit_CModel_exp_fixed_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the exponential fit
     fits:tunit: ''
   - name: modelfit_CModel_exp_nIter
     '@id': '#reference.modelfit_CModel_exp_nIter'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of total iterations in stage
     fits:tunit: ''
   - name: modelfit_CModel_exp_time
     '@id': '#reference.modelfit_CModel_exp_time'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Time spent in stage
     fits:tunit: second
   - name: modelfit_CModel_dev_instFlux
     '@id': '#reference.modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: modelfit_CModel_dev_instFluxErr
     '@id': '#reference.modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: modelfit_CModel_dev_flux_inner
     '@id': '#reference.modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: modelfit_CModel_dev_ellipse_xx
     '@id': '#reference.modelfit_CModel_dev_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_dev_ellipse_yy
     '@id': '#reference.modelfit_CModel_dev_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_dev_ellipse_xy
     '@id': '#reference.modelfit_CModel_dev_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
     fits:tunit: pixel^2
   - name: modelfit_CModel_dev_objective
     '@id': '#reference.modelfit_CModel_dev_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_nonlinear_0
     '@id': '#reference.modelfit_CModel_dev_nonlinear_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_nonlinear_1
     '@id': '#reference.modelfit_CModel_dev_nonlinear_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_nonlinear_2
     '@id': '#reference.modelfit_CModel_dev_nonlinear_2'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_fixed_0
     '@id': '#reference.modelfit_CModel_dev_fixed_0'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_fixed_1
     '@id': '#reference.modelfit_CModel_dev_fixed_1'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fixed parameters for the de Vaucouleur fit
     fits:tunit: ''
   - name: modelfit_CModel_dev_nIter
     '@id': '#reference.modelfit_CModel_dev_nIter'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of total iterations in stage
     fits:tunit: ''
   - name: modelfit_CModel_dev_time
     '@id': '#reference.modelfit_CModel_dev_time'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Time spent in stage
     fits:tunit: second
   - name: modelfit_CModel_instFlux
     '@id': '#reference.modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: modelfit_CModel_instFluxErr
     '@id': '#reference.modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: modelfit_CModel_instFlux_inner
     '@id': '#reference.modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: modelfit_CModel_fracDev
     '@id': '#reference.modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: modelfit_CModel_objective
     '@id': '#reference.modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: modelfit_CModel_ellipse_xx
     '@id': '#reference.modelfit_CModel_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
     fits:tunit: pixel^2
   - name: modelfit_CModel_ellipse_yy
     '@id': '#reference.modelfit_CModel_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
     fits:tunit: pixel^2
   - name: modelfit_CModel_ellipse_xy
     '@id': '#reference.modelfit_CModel_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
     fits:tunit: pixel^2
   - name: modelfit_CModel_region_initial_ellipse_xx
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
     fits:tunit: pixel^2
@@ -1407,6 +1857,8 @@ tables:
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
     fits:tunit: pixel^2
@@ -1414,6 +1866,8 @@ tables:
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
     fits:tunit: pixel^2
@@ -1421,6 +1875,8 @@ tables:
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
     fits:tunit: pixel^2
@@ -1428,6 +1884,8 @@ tables:
     '@id': '#reference.modelfit_CModel_region_final_ellipse_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
     fits:tunit: pixel^2
@@ -1435,6 +1893,8 @@ tables:
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
     fits:tunit: pixel^2
@@ -1442,60 +1902,80 @@ tables:
     '@id': '#reference.modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: modelfit_CModel_exp_apCorrErr
     '@id': '#reference.modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: modelfit_CModel_initial_apCorr
     '@id': '#reference.modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: modelfit_CModel_initial_apCorrErr
     '@id': '#reference.modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: modelfit_CModel_dev_apCorr
     '@id': '#reference.modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: modelfit_CModel_dev_apCorrErr
     '@id': '#reference.modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: modelfit_CModel_apCorr
     '@id': '#reference.modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: modelfit_CModel_apCorrErr
     '@id': '#reference.modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: modelfit_CModel_initial_flag
     '@id': '#reference.modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: modelfit_CModel_initial_flag_trSmall
     '@id': '#reference.modelfit_CModel_initial_flag_trSmall'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
       this is a less-secure result than when the gradient is below the threshold,
       but usually not a problem
@@ -1504,12 +1984,16 @@ tables:
     '@id': '#reference.modelfit_CModel_initial_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
     fits:tunit: ''
   - name: modelfit_CModel_initial_flag_numericError
     '@id': '#reference.modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -1518,12 +2002,16 @@ tables:
     '@id': '#reference.modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: modelfit_CModel_exp_flag_trSmall
     '@id': '#reference.modelfit_CModel_exp_flag_trSmall'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
       this is a less-secure result than when the gradient is below the threshold,
       but usually not a problem
@@ -1532,12 +2020,16 @@ tables:
     '@id': '#reference.modelfit_CModel_exp_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
     fits:tunit: ''
   - name: modelfit_CModel_exp_flag_numericError
     '@id': '#reference.modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -1546,12 +2038,16 @@ tables:
     '@id': '#reference.modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: modelfit_CModel_dev_flag_trSmall
     '@id': '#reference.modelfit_CModel_dev_flag_trSmall'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
       this is a less-secure result than when the gradient is below the threshold,
       but usually not a problem
@@ -1560,12 +2056,16 @@ tables:
     '@id': '#reference.modelfit_CModel_dev_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
     fits:tunit: ''
   - name: modelfit_CModel_dev_flag_numericError
     '@id': '#reference.modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -1574,24 +2074,32 @@ tables:
     '@id': '#reference.modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: modelfit_CModel_flag_region_maxArea
     '@id': '#reference.modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#reference.modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: modelfit_CModel_flags_region_usedFootprintArea
     '@id': '#reference.modelfit_CModel_flags_region_usedFootprintArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the pixel region for the initial fit was defined by the area of the
       Footprint
     fits:tunit: ''
@@ -1599,6 +2107,8 @@ tables:
     '@id': '#reference.modelfit_CModel_flags_region_usedPsfArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the pixel region for the initial fit was set to a fixed factor of
       the PSF area
     fits:tunit: ''
@@ -1606,6 +2116,8 @@ tables:
     '@id': '#reference.modelfit_CModel_flags_region_usedInitialEllipseMin'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the pixel region for the final fit was set to the lower bound defined
       by the initial fit
     fits:tunit: ''
@@ -1613,6 +2125,8 @@ tables:
     '@id': '#reference.modelfit_CModel_flags_region_usedInitialEllipseMax'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the pixel region for the final fit was set to the upper bound defined
       by the initial fit
     fits:tunit: ''
@@ -1620,6 +2134,8 @@ tables:
     '@id': '#reference.modelfit_CModel_flag_noShape'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the shape slot needed to initialize the parameters failed or was
       not defined
     fits:tunit: ''
@@ -1627,6 +2143,8 @@ tables:
     '@id': '#reference.modelfit_CModel_flags_smallShape'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: initial parameter guess resulted in negative radius; used minimum
       of 0.100000 pixels instead.
     fits:tunit: ''
@@ -1634,12 +2152,16 @@ tables:
     '@id': '#reference.modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: modelfit_CModel_flag_badCentroid
     '@id': '#reference.modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -1647,24 +2169,32 @@ tables:
     '@id': '#reference.modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: modelfit_CModel_initial_flag_apCorr
     '@id': '#reference.modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: modelfit_CModel_dev_flag_apCorr
     '@id': '#reference.modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: modelfit_CModel_flag_apCorr
     '@id': '#reference.modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
 - name: forced_photometry
@@ -1677,12 +2207,16 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Unique id.
   - name: coord_ra
     '@id': '#forced_photometry.coord_ra'
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -1691,6 +2225,8 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -1698,227 +2234,303 @@ tables:
     '@id': '#forced_photometry.g_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.g_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.g_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.g_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.g_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.g_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.g_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.g_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.g_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.g_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.g_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: g_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: g_good
     '@id': '#forced_photometry.g_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: g_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.g_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: g_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.g_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: g_modelfit_CModel_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: g_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: g_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: g_modelfit_CModel_fracDev
     '@id': '#forced_photometry.g_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: g_modelfit_CModel_objective
     '@id': '#forced_photometry.g_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: g_modelfit_CModel_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: g_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: g_modelfit_CModel_flag
     '@id': '#forced_photometry.g_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: g_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.g_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: g_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.g_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: g_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: g_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.g_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: g_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.g_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -1926,186 +2538,248 @@ tables:
     '@id': '#forced_photometry.g_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: g_base_SdssCentroid_x
     '@id': '#forced_photometry.g_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: g_base_SdssCentroid_y
     '@id': '#forced_photometry.g_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: g_base_SdssCentroid_xErr
     '@id': '#forced_photometry.g_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: g_base_SdssCentroid_yErr
     '@id': '#forced_photometry.g_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: g_base_SdssCentroid_flag
     '@id': '#forced_photometry.g_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: g_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: g_base_SdssShape_xx
     '@id': '#forced_photometry.g_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: g_base_SdssShape_yy
     '@id': '#forced_photometry.g_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: g_base_SdssShape_xy
     '@id': '#forced_photometry.g_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: g_base_SdssShape_xxErr
     '@id': '#forced_photometry.g_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: g_base_SdssShape_yyErr
     '@id': '#forced_photometry.g_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: g_base_SdssShape_xyErr
     '@id': '#forced_photometry.g_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: g_base_SdssShape_x
     '@id': '#forced_photometry.g_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: g_base_SdssShape_y
     '@id': '#forced_photometry.g_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: g_base_SdssShape_instFlux
     '@id': '#forced_photometry.g_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: g_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.g_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: g_base_SdssShape_psf_xx
     '@id': '#forced_photometry.g_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: g_base_SdssShape_psf_yy
     '@id': '#forced_photometry.g_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: g_base_SdssShape_psf_xy
     '@id': '#forced_photometry.g_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: g_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: g_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: g_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: g_base_SdssShape_flag
     '@id': '#forced_photometry.g_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.g_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: g_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.g_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -2113,72 +2787,96 @@ tables:
     '@id': '#forced_photometry.g_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: g_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.g_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: g_base_SdssShape_flag_psf
     '@id': '#forced_photometry.g_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: g_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.g_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_PsfFlux_instFlux
     '@id': '#forced_photometry.g_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: g_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.g_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: g_base_PsfFlux_area
     '@id': '#forced_photometry.g_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: g_base_PsfFlux_apCorr
     '@id': '#forced_photometry.g_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: g_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.g_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: g_base_PsfFlux_flag
     '@id': '#forced_photometry.g_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.g_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: g_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.g_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -2186,204 +2884,272 @@ tables:
     '@id': '#forced_photometry.g_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: g_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.g_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_InputCount_value
     '@id': '#forced_photometry.g_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: g_base_InputCount_flag
     '@id': '#forced_photometry.g_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: g_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.g_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: g_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.g_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_Variance_value
     '@id': '#forced_photometry.g_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: g_base_Variance_flag
     '@id': '#forced_photometry.g_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: g_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.g_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: g_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.g_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_LocalBackground_instFlux
     '@id': '#forced_photometry.g_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: g_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.g_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: g_base_LocalBackground_flag
     '@id': '#forced_photometry.g_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.g_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: g_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.g_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: g_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.g_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: g_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: g_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: g_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: g_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: g_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: g_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: g_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: g_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: g_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: g_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: g_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: g_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -2392,18 +3158,24 @@ tables:
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: g_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: g_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -2412,18 +3184,24 @@ tables:
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: g_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: g_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -2432,245 +3210,327 @@ tables:
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: g_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: g_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: i_base_PixelFlags_flag
     '@id': '#forced_photometry.i_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.i_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.i_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.i_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.i_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.i_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.i_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.i_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.i_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.i_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.i_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: i_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: i_good
     '@id': '#forced_photometry.i_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: i_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.i_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: i_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.i_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: i_modelfit_CModel_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: i_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: i_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: i_modelfit_CModel_fracDev
     '@id': '#forced_photometry.i_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: i_modelfit_CModel_objective
     '@id': '#forced_photometry.i_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: i_modelfit_CModel_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: i_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: i_modelfit_CModel_flag
     '@id': '#forced_photometry.i_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: i_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.i_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: i_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.i_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: i_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: i_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.i_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: i_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.i_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -2678,186 +3538,248 @@ tables:
     '@id': '#forced_photometry.i_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: i_base_SdssCentroid_x
     '@id': '#forced_photometry.i_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: i_base_SdssCentroid_y
     '@id': '#forced_photometry.i_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: i_base_SdssCentroid_xErr
     '@id': '#forced_photometry.i_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: i_base_SdssCentroid_yErr
     '@id': '#forced_photometry.i_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: i_base_SdssCentroid_flag
     '@id': '#forced_photometry.i_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: i_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: i_base_SdssShape_xx
     '@id': '#forced_photometry.i_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: i_base_SdssShape_yy
     '@id': '#forced_photometry.i_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: i_base_SdssShape_xy
     '@id': '#forced_photometry.i_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: i_base_SdssShape_xxErr
     '@id': '#forced_photometry.i_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: i_base_SdssShape_yyErr
     '@id': '#forced_photometry.i_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: i_base_SdssShape_xyErr
     '@id': '#forced_photometry.i_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: i_base_SdssShape_x
     '@id': '#forced_photometry.i_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: i_base_SdssShape_y
     '@id': '#forced_photometry.i_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: i_base_SdssShape_instFlux
     '@id': '#forced_photometry.i_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: i_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.i_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: i_base_SdssShape_psf_xx
     '@id': '#forced_photometry.i_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: i_base_SdssShape_psf_yy
     '@id': '#forced_photometry.i_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: i_base_SdssShape_psf_xy
     '@id': '#forced_photometry.i_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: i_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: i_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: i_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: i_base_SdssShape_flag
     '@id': '#forced_photometry.i_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.i_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: i_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.i_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -2865,72 +3787,96 @@ tables:
     '@id': '#forced_photometry.i_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: i_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.i_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: i_base_SdssShape_flag_psf
     '@id': '#forced_photometry.i_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: i_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.i_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_PsfFlux_instFlux
     '@id': '#forced_photometry.i_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: i_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.i_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: i_base_PsfFlux_area
     '@id': '#forced_photometry.i_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: i_base_PsfFlux_apCorr
     '@id': '#forced_photometry.i_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: i_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.i_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: i_base_PsfFlux_flag
     '@id': '#forced_photometry.i_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.i_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: i_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.i_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -2938,204 +3884,272 @@ tables:
     '@id': '#forced_photometry.i_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: i_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.i_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_InputCount_value
     '@id': '#forced_photometry.i_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: i_base_InputCount_flag
     '@id': '#forced_photometry.i_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: i_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.i_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: i_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.i_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_Variance_value
     '@id': '#forced_photometry.i_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: i_base_Variance_flag
     '@id': '#forced_photometry.i_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: i_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.i_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: i_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.i_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_LocalBackground_instFlux
     '@id': '#forced_photometry.i_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: i_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.i_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: i_base_LocalBackground_flag
     '@id': '#forced_photometry.i_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.i_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: i_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.i_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: i_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.i_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: i_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: i_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: i_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: i_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: i_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: i_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: i_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: i_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: i_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: i_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: i_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: i_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3144,18 +4158,24 @@ tables:
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: i_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: i_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3164,18 +4184,24 @@ tables:
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: i_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: i_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3184,245 +4210,327 @@ tables:
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: i_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: i_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: r_base_PixelFlags_flag
     '@id': '#forced_photometry.r_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.r_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.r_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.r_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.r_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.r_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.r_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.r_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.r_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.r_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.r_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: r_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: r_good
     '@id': '#forced_photometry.r_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: r_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.r_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: r_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.r_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: r_modelfit_CModel_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: r_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: r_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: r_modelfit_CModel_fracDev
     '@id': '#forced_photometry.r_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: r_modelfit_CModel_objective
     '@id': '#forced_photometry.r_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: r_modelfit_CModel_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: r_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: r_modelfit_CModel_flag
     '@id': '#forced_photometry.r_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: r_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.r_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: r_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.r_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: r_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: r_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.r_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: r_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.r_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -3430,186 +4538,248 @@ tables:
     '@id': '#forced_photometry.r_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: r_base_SdssCentroid_x
     '@id': '#forced_photometry.r_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: r_base_SdssCentroid_y
     '@id': '#forced_photometry.r_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: r_base_SdssCentroid_xErr
     '@id': '#forced_photometry.r_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: r_base_SdssCentroid_yErr
     '@id': '#forced_photometry.r_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: r_base_SdssCentroid_flag
     '@id': '#forced_photometry.r_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: r_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: r_base_SdssShape_xx
     '@id': '#forced_photometry.r_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: r_base_SdssShape_yy
     '@id': '#forced_photometry.r_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: r_base_SdssShape_xy
     '@id': '#forced_photometry.r_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: r_base_SdssShape_xxErr
     '@id': '#forced_photometry.r_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: r_base_SdssShape_yyErr
     '@id': '#forced_photometry.r_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: r_base_SdssShape_xyErr
     '@id': '#forced_photometry.r_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: r_base_SdssShape_x
     '@id': '#forced_photometry.r_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: r_base_SdssShape_y
     '@id': '#forced_photometry.r_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: r_base_SdssShape_instFlux
     '@id': '#forced_photometry.r_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: r_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.r_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: r_base_SdssShape_psf_xx
     '@id': '#forced_photometry.r_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: r_base_SdssShape_psf_yy
     '@id': '#forced_photometry.r_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: r_base_SdssShape_psf_xy
     '@id': '#forced_photometry.r_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: r_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: r_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: r_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: r_base_SdssShape_flag
     '@id': '#forced_photometry.r_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.r_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: r_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.r_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -3617,72 +4787,96 @@ tables:
     '@id': '#forced_photometry.r_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: r_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.r_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: r_base_SdssShape_flag_psf
     '@id': '#forced_photometry.r_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: r_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.r_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_PsfFlux_instFlux
     '@id': '#forced_photometry.r_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: r_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.r_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: r_base_PsfFlux_area
     '@id': '#forced_photometry.r_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: r_base_PsfFlux_apCorr
     '@id': '#forced_photometry.r_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: r_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.r_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: r_base_PsfFlux_flag
     '@id': '#forced_photometry.r_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.r_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: r_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.r_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -3690,204 +4884,272 @@ tables:
     '@id': '#forced_photometry.r_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: r_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.r_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_InputCount_value
     '@id': '#forced_photometry.r_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: r_base_InputCount_flag
     '@id': '#forced_photometry.r_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: r_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.r_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: r_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.r_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_Variance_value
     '@id': '#forced_photometry.r_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: r_base_Variance_flag
     '@id': '#forced_photometry.r_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: r_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.r_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: r_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.r_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_LocalBackground_instFlux
     '@id': '#forced_photometry.r_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: r_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.r_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: r_base_LocalBackground_flag
     '@id': '#forced_photometry.r_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.r_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: r_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.r_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: r_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.r_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: r_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: r_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: r_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: r_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: r_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: r_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: r_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: r_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: r_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: r_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: r_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: r_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3896,18 +5158,24 @@ tables:
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: r_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: r_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3916,18 +5184,24 @@ tables:
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: r_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: r_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -3936,245 +5210,327 @@ tables:
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: r_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: r_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: u_base_PixelFlags_flag
     '@id': '#forced_photometry.u_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.u_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.u_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.u_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.u_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.u_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.u_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.u_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.u_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.u_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.u_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: u_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: u_good
     '@id': '#forced_photometry.u_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: u_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.u_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: u_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.u_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: u_modelfit_CModel_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: u_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: u_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: u_modelfit_CModel_fracDev
     '@id': '#forced_photometry.u_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: u_modelfit_CModel_objective
     '@id': '#forced_photometry.u_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: u_modelfit_CModel_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: u_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: u_modelfit_CModel_flag
     '@id': '#forced_photometry.u_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: u_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.u_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: u_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.u_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: u_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: u_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.u_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: u_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.u_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -4182,186 +5538,248 @@ tables:
     '@id': '#forced_photometry.u_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: u_base_SdssCentroid_x
     '@id': '#forced_photometry.u_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: u_base_SdssCentroid_y
     '@id': '#forced_photometry.u_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: u_base_SdssCentroid_xErr
     '@id': '#forced_photometry.u_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: u_base_SdssCentroid_yErr
     '@id': '#forced_photometry.u_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: u_base_SdssCentroid_flag
     '@id': '#forced_photometry.u_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: u_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: u_base_SdssShape_xx
     '@id': '#forced_photometry.u_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: u_base_SdssShape_yy
     '@id': '#forced_photometry.u_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: u_base_SdssShape_xy
     '@id': '#forced_photometry.u_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: u_base_SdssShape_xxErr
     '@id': '#forced_photometry.u_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: u_base_SdssShape_yyErr
     '@id': '#forced_photometry.u_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: u_base_SdssShape_xyErr
     '@id': '#forced_photometry.u_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: u_base_SdssShape_x
     '@id': '#forced_photometry.u_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: u_base_SdssShape_y
     '@id': '#forced_photometry.u_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: u_base_SdssShape_instFlux
     '@id': '#forced_photometry.u_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: u_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.u_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: u_base_SdssShape_psf_xx
     '@id': '#forced_photometry.u_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: u_base_SdssShape_psf_yy
     '@id': '#forced_photometry.u_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: u_base_SdssShape_psf_xy
     '@id': '#forced_photometry.u_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: u_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: u_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: u_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: u_base_SdssShape_flag
     '@id': '#forced_photometry.u_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.u_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: u_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.u_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -4369,72 +5787,96 @@ tables:
     '@id': '#forced_photometry.u_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: u_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.u_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: u_base_SdssShape_flag_psf
     '@id': '#forced_photometry.u_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: u_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.u_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_PsfFlux_instFlux
     '@id': '#forced_photometry.u_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: u_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.u_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: u_base_PsfFlux_area
     '@id': '#forced_photometry.u_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: u_base_PsfFlux_apCorr
     '@id': '#forced_photometry.u_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: u_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.u_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: u_base_PsfFlux_flag
     '@id': '#forced_photometry.u_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.u_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: u_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.u_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -4442,204 +5884,272 @@ tables:
     '@id': '#forced_photometry.u_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: u_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.u_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_InputCount_value
     '@id': '#forced_photometry.u_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: u_base_InputCount_flag
     '@id': '#forced_photometry.u_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: u_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.u_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: u_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.u_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_Variance_value
     '@id': '#forced_photometry.u_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: u_base_Variance_flag
     '@id': '#forced_photometry.u_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: u_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.u_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: u_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.u_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_LocalBackground_instFlux
     '@id': '#forced_photometry.u_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: u_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.u_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: u_base_LocalBackground_flag
     '@id': '#forced_photometry.u_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.u_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: u_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.u_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: u_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.u_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: u_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: u_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: u_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: u_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: u_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: u_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: u_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: u_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: u_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: u_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: u_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: u_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -4648,18 +6158,24 @@ tables:
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: u_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: u_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -4668,18 +6184,24 @@ tables:
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: u_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: u_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -4688,245 +6210,327 @@ tables:
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: u_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: u_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: y_base_PixelFlags_flag
     '@id': '#forced_photometry.y_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.y_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.y_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.y_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.y_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.y_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.y_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.y_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.y_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.y_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.y_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: y_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: y_good
     '@id': '#forced_photometry.y_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: y_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.y_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: y_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.y_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: y_modelfit_CModel_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: y_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: y_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: y_modelfit_CModel_fracDev
     '@id': '#forced_photometry.y_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: y_modelfit_CModel_objective
     '@id': '#forced_photometry.y_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: y_modelfit_CModel_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: y_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: y_modelfit_CModel_flag
     '@id': '#forced_photometry.y_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: y_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.y_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: y_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.y_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: y_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: y_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.y_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: y_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.y_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -4934,186 +6538,248 @@ tables:
     '@id': '#forced_photometry.y_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: y_base_SdssCentroid_x
     '@id': '#forced_photometry.y_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: y_base_SdssCentroid_y
     '@id': '#forced_photometry.y_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: y_base_SdssCentroid_xErr
     '@id': '#forced_photometry.y_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: y_base_SdssCentroid_yErr
     '@id': '#forced_photometry.y_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: y_base_SdssCentroid_flag
     '@id': '#forced_photometry.y_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: y_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: y_base_SdssShape_xx
     '@id': '#forced_photometry.y_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: y_base_SdssShape_yy
     '@id': '#forced_photometry.y_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: y_base_SdssShape_xy
     '@id': '#forced_photometry.y_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: y_base_SdssShape_xxErr
     '@id': '#forced_photometry.y_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: y_base_SdssShape_yyErr
     '@id': '#forced_photometry.y_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: y_base_SdssShape_xyErr
     '@id': '#forced_photometry.y_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: y_base_SdssShape_x
     '@id': '#forced_photometry.y_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: y_base_SdssShape_y
     '@id': '#forced_photometry.y_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: y_base_SdssShape_instFlux
     '@id': '#forced_photometry.y_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: y_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.y_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: y_base_SdssShape_psf_xx
     '@id': '#forced_photometry.y_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: y_base_SdssShape_psf_yy
     '@id': '#forced_photometry.y_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: y_base_SdssShape_psf_xy
     '@id': '#forced_photometry.y_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: y_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: y_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: y_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: y_base_SdssShape_flag
     '@id': '#forced_photometry.y_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.y_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: y_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.y_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -5121,72 +6787,96 @@ tables:
     '@id': '#forced_photometry.y_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: y_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.y_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: y_base_SdssShape_flag_psf
     '@id': '#forced_photometry.y_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: y_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.y_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_PsfFlux_instFlux
     '@id': '#forced_photometry.y_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: y_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.y_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: y_base_PsfFlux_area
     '@id': '#forced_photometry.y_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: y_base_PsfFlux_apCorr
     '@id': '#forced_photometry.y_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: y_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.y_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: y_base_PsfFlux_flag
     '@id': '#forced_photometry.y_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.y_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: y_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.y_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -5194,204 +6884,272 @@ tables:
     '@id': '#forced_photometry.y_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: y_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.y_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_InputCount_value
     '@id': '#forced_photometry.y_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: y_base_InputCount_flag
     '@id': '#forced_photometry.y_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: y_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.y_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: y_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.y_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_Variance_value
     '@id': '#forced_photometry.y_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: y_base_Variance_flag
     '@id': '#forced_photometry.y_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: y_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.y_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: y_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.y_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_LocalBackground_instFlux
     '@id': '#forced_photometry.y_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: y_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.y_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: y_base_LocalBackground_flag
     '@id': '#forced_photometry.y_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.y_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: y_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.y_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: y_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.y_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: y_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: y_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: y_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: y_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: y_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: y_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: y_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: y_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: y_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: y_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: y_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: y_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -5400,18 +7158,24 @@ tables:
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: y_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: y_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -5420,18 +7184,24 @@ tables:
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: y_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: y_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -5440,245 +7210,327 @@ tables:
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: y_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: y_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
   - name: z_base_PixelFlags_flag
     '@id': '#forced_photometry.z_base_PixelFlags_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General failure flag, set if anything went wrong
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.z_base_PixelFlags_flag_offimage'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is off image
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.z_base_PixelFlags_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.z_base_PixelFlags_flag_interpolated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source footprint
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.z_base_PixelFlags_flag_saturated'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source footprint
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.z_base_PixelFlags_flag_cr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source footprint
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Bad pixel in the Source footprint
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.z_base_PixelFlags_flag_suspect'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s footprint includes suspect pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Interpolated pixel in the Source center
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Saturated pixel in the Source center
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_crCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Cosmic ray in the Source center
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source''s center is close to suspect pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to CLIPPED pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to REJECTED pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.z_base_PixelFlags_flag_clipped'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes CLIPPED pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.z_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.z_base_PixelFlags_flag_rejected'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes REJECTED pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.z_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
     fits:tunit: ''
   - name: z_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bright_object'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
     fits:tunit: ''
   - name: z_good
     '@id': '#forced_photometry.z_good'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if the source has no flagged pixels.
   - name: z_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.z_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: z_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.z_base_ClassificationExtendedness_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: z_modelfit_CModel_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: z_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: z_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_instFlux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux within the fit region, with no extrapolation
     fits:tunit: count
   - name: z_modelfit_CModel_fracDev
     '@id': '#forced_photometry.z_modelfit_CModel_fracDev'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: fraction of flux in de Vaucouleur component
     fits:tunit: ''
   - name: z_modelfit_CModel_objective
     '@id': '#forced_photometry.z_modelfit_CModel_objective'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
     fits:tunit: ''
   - name: z_modelfit_CModel_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: z_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
     fits:tunit: ''
   - name: z_modelfit_CModel_flag
     '@id': '#forced_photometry.z_modelfit_CModel_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: z_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.z_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
     fits:tunit: ''
   - name: z_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.z_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
     fits:tunit: ''
   - name: z_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: z_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.z_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
     fits:tunit: ''
   - name: z_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.z_modelfit_CModel_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
       not within the Footprint)
     fits:tunit: ''
@@ -5686,186 +7538,248 @@ tables:
     '@id': '#forced_photometry.z_modelfit_CModel_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
     fits:tunit: ''
   - name: z_base_SdssCentroid_x
     '@id': '#forced_photometry.z_base_SdssCentroid_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: z_base_SdssCentroid_y
     '@id': '#forced_photometry.z_base_SdssCentroid_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid from Sdss Centroid algorithm
     fits:tunit: pixel
   - name: z_base_SdssCentroid_xErr
     '@id': '#forced_photometry.z_base_SdssCentroid_xErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: z_base_SdssCentroid_yErr
     '@id': '#forced_photometry.z_base_SdssCentroid_yErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: z_base_SdssCentroid_flag
     '@id': '#forced_photometry.z_base_SdssCentroid_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object too close to edge
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Vanishing second derivative
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Almost vanishing second derivative
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Object is not at a maximum
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if CentroidChecker reset the centroid
     fits:tunit: ''
   - name: z_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: whether the reference centroid is marked as bad
     fits:tunit: ''
   - name: z_base_SdssShape_xx
     '@id': '#forced_photometry.z_base_SdssShape_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: z_base_SdssShape_yy
     '@id': '#forced_photometry.z_base_SdssShape_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: z_base_SdssShape_xy
     '@id': '#forced_photometry.z_base_SdssShape_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel^2
   - name: z_base_SdssShape_xxErr
     '@id': '#forced_photometry.z_base_SdssShape_xxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xx moment
     fits:tunit: pixel^2
   - name: z_base_SdssShape_yyErr
     '@id': '#forced_photometry.z_base_SdssShape_yyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of yy moment
     fits:tunit: pixel^2
   - name: z_base_SdssShape_xyErr
     '@id': '#forced_photometry.z_base_SdssShape_xyErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Standard deviation of xy moment
     fits:tunit: pixel^2
   - name: z_base_SdssShape_x
     '@id': '#forced_photometry.z_base_SdssShape_x'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: z_base_SdssShape_y
     '@id': '#forced_photometry.z_base_SdssShape_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: pixel
   - name: z_base_SdssShape_instFlux
     '@id': '#forced_photometry.z_base_SdssShape_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: elliptical Gaussian adaptive moments
     fits:tunit: count
   - name: z_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.z_base_SdssShape_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: z_base_SdssShape_psf_xx
     '@id': '#forced_photometry.z_base_SdssShape_psf_xx'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: z_base_SdssShape_psf_yy
     '@id': '#forced_photometry.z_base_SdssShape_psf_yy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: z_base_SdssShape_psf_xy
     '@id': '#forced_photometry.z_base_SdssShape_psf_xy'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: adaptive moments of the PSF model at the object position
     fits:tunit: pixel^2
   - name: z_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xx_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
     fits:tunit: count*pixel^2
   - name: z_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_yy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
     fits:tunit: count*pixel^2
   - name: z_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xy_Cov'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
     fits:tunit: count*pixel^2
   - name: z_base_SdssShape_flag
     '@id': '#forced_photometry.z_base_SdssShape_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.z_base_SdssShape_flag_unweightedBad'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Both weighted and unweighted moments were invalid
     fits:tunit: ''
   - name: z_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.z_base_SdssShape_flag_unweighted'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
       moments
     fits:tunit: ''
@@ -5873,72 +7787,96 @@ tables:
     '@id': '#forced_photometry.z_base_SdssShape_flag_shift'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
     fits:tunit: ''
   - name: z_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.z_base_SdssShape_flag_maxIter'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Too many iterations in adaptive moments
     fits:tunit: ''
   - name: z_base_SdssShape_flag_psf
     '@id': '#forced_photometry.z_base_SdssShape_flag_psf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Failure in measuring PSF model shape
     fits:tunit: ''
   - name: z_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.z_base_SdssShape_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_PsfFlux_instFlux
     '@id': '#forced_photometry.z_base_PsfFlux_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
     fits:tunit: count
   - name: z_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.z_base_PsfFlux_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: z_base_PsfFlux_area
     '@id': '#forced_photometry.z_base_PsfFlux_area'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: effective area of PSF
     fits:tunit: pixel
   - name: z_base_PsfFlux_apCorr
     '@id': '#forced_photometry.z_base_PsfFlux_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: z_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.z_base_PsfFlux_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
     fits:tunit: ''
   - name: z_base_PsfFlux_flag
     '@id': '#forced_photometry.z_base_PsfFlux_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.z_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
     fits:tunit: ''
   - name: z_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.z_base_PsfFlux_flag_edge'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
       model
     fits:tunit: ''
@@ -5946,204 +7884,272 @@ tables:
     '@id': '#forced_photometry.z_base_PsfFlux_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
     fits:tunit: ''
   - name: z_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.z_base_PsfFlux_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_InputCount_value
     '@id': '#forced_photometry.z_base_InputCount_value'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
     fits:tunit: ''
   - name: z_base_InputCount_flag
     '@id': '#forced_photometry.z_base_InputCount_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: z_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.z_base_InputCount_flag_noInputs'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: No coadd inputs available
     fits:tunit: ''
   - name: z_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.z_base_InputCount_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_Variance_value
     '@id': '#forced_photometry.z_base_Variance_value'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Variance at object position
     fits:tunit: ''
   - name: z_base_Variance_flag
     '@id': '#forced_photometry.z_base_Variance_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set for any fatal failure
     fits:tunit: ''
   - name: z_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.z_base_Variance_flag_emptyFootprint'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Set to True when the footprint has no usable pixels
     fits:tunit: ''
   - name: z_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.z_base_Variance_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_LocalBackground_instFlux
     '@id': '#forced_photometry.z_base_LocalBackground_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: background in annulus around source
     fits:tunit: count
   - name: z_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.z_base_LocalBackground_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: 1-sigma instFlux uncertainty
     fits:tunit: count
   - name: z_base_LocalBackground_flag
     '@id': '#forced_photometry.z_base_LocalBackground_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.z_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no good pixels in the annulus
     fits:tunit: ''
   - name: z_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.z_base_LocalBackground_flag_noPsf'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: no PSF provided
     fits:tunit: ''
   - name: z_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.z_base_LocalBackground_flag_badCentroid'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: General Failure Flag
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_initial_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit
     fits:tunit: count
   - name: z_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the initial fit
     fits:tunit: count
   - name: z_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
     fits:tunit: count
   - name: z_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_exp_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit
     fits:tunit: count
   - name: z_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the exponential fit
     fits:tunit: count
   - name: z_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
     fits:tunit: count
   - name: z_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_dev_instFlux'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit
     fits:tunit: count
   - name: z_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_instFluxErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
     fits:tunit: count
   - name: z_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flux_inner'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
     fits:tunit: count
   - name: z_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: z_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
     fits:tunit: ''
   - name: z_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: z_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_apCorr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_apCorrErr'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the initial flux failed
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -6152,18 +8158,24 @@ tables:
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the exponential flux failed
     fits:tunit: ''
   - name: z_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: z_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -6172,18 +8184,24 @@ tables:
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
     fits:tunit: ''
   - name: z_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: The original fit in the reference catalog failed.
     fits:tunit: ''
   - name: z_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
       means the prior was insufficient to regularize the fit, or all pixel values
       were zero.
@@ -6192,18 +8210,24 @@ tables:
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
     fits:tunit: ''
   - name: z_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
     fits:tunit: ''
   - name: z_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
     fits:tunit: ''
 - name: object
@@ -6217,18 +8241,24 @@ tables:
     nullable: false
     description: Unique id.
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: meta.id;src
   - name: parentObjectId
     '@id': '#object.parentObjectId'
     datatype: long
     description: Id of the parent object this object has been deblended from, if any.
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
   - name: ra
     '@id': '#object.ra'
     datatype: double
     nullable: false
     description: RA-coordinate of the center of the object for the Point Source model.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: dec
@@ -6238,6 +8268,8 @@ tables:
     description: Decl-coordinate of the center of the object for the Point Source
       model.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: tract
@@ -6245,17 +8277,23 @@ tables:
     datatype: long
     description: tract ID
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
   - name: patch
     '@id': '#object.patch'
     datatype: char
     length: 3
     mysql:datatype: CHAR(3)
+    tap:column_index: 999
+    tap:principal: 0
     description: patch ID
   - name: x
     '@id': '#object.x'
     datatype: double
     description: 2D centroid location (x coordinate)
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: pixels
     ivoa:ucd: pos.cartesian.x
   - name: y
@@ -6263,6 +8301,8 @@ tables:
     datatype: double
     description: 2D centroid location (y coordinate)
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: pixels
     ivoa:ucd: pos.cartesian.y
   - name: xErr
@@ -6270,6 +8310,8 @@ tables:
     datatype: float
     description: error on x
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: pixels
     ivoa:ucd: stat.error;pos.cartesian.x
   - name: yErr
@@ -6277,6 +8319,8 @@ tables:
     datatype: float
     description: error on Y
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: pixels
     ivoa:ucd: stat.error;pos.cartesian.y
   - name: xy_flag
@@ -6284,104 +8328,140 @@ tables:
     datatype: boolean
     description: Flag for issues with x and y
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psNdata
     '@id': '#object.psNdata'
     datatype: float
     description: Number of data points (pixels) used to fit the model
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
   - name: extendedness
     '@id': '#object.extendedness'
     datatype: double
     description: 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
   - name: blendedness
     '@id': '#object.blendedness'
     datatype: double
     description: measure of how flux is affected by neighbors (1 - flux.child/flux.parent)
       (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766))
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
   - name: Ixx_pixel
     '@id': '#object.Ixx_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy*asec^2
   - name: Iyy_pixel
     '@id': '#object.Iyy_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy*asec^2
   - name: Ixy_pixel
     '@id': '#object.Ixy_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy*asec^2
   - name: I_flag
     '@id': '#object.I_flag'
     datatype: boolean
     description: Flag for issues with Ixx_pixel, Iyy_pixel, and Ixy_pixel.
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: IxxPSF_pixel
     '@id': '#object.IxxPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunits: nmgy*asec^2
   - name: IyyPSF_pixel
     '@id': '#object.IyyPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunits: nmgy*asec^2
   - name: IxyPSF_pixel
     '@id': '#object.IxyPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunits: nmgy*asec^2
   - name: mag_g_cModel
     '@id': '#object.mag_g_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for g filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_i_cModel
     '@id': '#object.mag_i_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for i filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_r_cModel
     '@id': '#object.mag_r_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for r filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_u_cModel
     '@id': '#object.mag_u_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for u filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_y_cModel
     '@id': '#object.mag_y_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for y filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_z_cModel
     '@id': '#object.mag_z_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for z filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: magerr_g_cModel
     '@id': '#object.magerr_g_cModel'
     datatype: double
     description: Error on mag_g_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_i_cModel
@@ -6389,6 +8469,8 @@ tables:
     datatype: double
     description: Error on mag_i_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_r_cModel
@@ -6396,6 +8478,8 @@ tables:
     datatype: double
     description: Error on mag_r_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_u_cModel
@@ -6403,6 +8487,8 @@ tables:
     datatype: double
     description: Error on mag_u_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_y_cModel
@@ -6410,6 +8496,8 @@ tables:
     datatype: double
     description: Error on mag_y_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_z_cModel
@@ -6417,6 +8505,8 @@ tables:
     datatype: double
     description: Error on mag_z_cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: snr_g_cModel
@@ -6424,42 +8514,56 @@ tables:
     datatype: double
     description: Signal to noise ratio for magnitude for g filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: snr_i_cModel
     '@id': '#object.snr_i_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for i filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: snr_r_cModel
     '@id': '#object.snr_r_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for r filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: snr_u_cModel
     '@id': '#object.snr_u_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for u filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: snr_y_cModel
     '@id': '#object.snr_y_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for y filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: snr_z_cModel
     '@id': '#object.snr_z_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for z filter fitted by cModel
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     ivoa:ucd: stat.snr
   - name: psFlux_g
     '@id': '#object.psFlux_g'
     datatype: double
     description: Calibrated flux for Point Source model for g filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_i
@@ -6467,6 +8571,8 @@ tables:
     datatype: double
     description: Calibrated flux for Point Source model for i filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_r
@@ -6474,6 +8580,8 @@ tables:
     datatype: double
     description: Calibrated flux for Point Source model for r filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_u
@@ -6481,6 +8589,8 @@ tables:
     datatype: double
     description: Calibrated flux for Point Source model for u filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_y
@@ -6488,6 +8598,8 @@ tables:
     datatype: double
     description: Calibrated flux for Point Source model for y filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_z
@@ -6495,6 +8607,8 @@ tables:
     datatype: double
     description: Calibrated flux for Point Source model for z filter.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: phot.count
   - name: psFlux_flag_g
@@ -6502,36 +8616,50 @@ tables:
     datatype: boolean
     description: flag for issues with psFlux_g
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFlux_flag_i
     '@id': '#object.psFlux_flag_i'
     datatype: boolean
     description: flag for issues with psFlux_i
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFlux_flag_r
     '@id': '#object.psFlux_flag_r'
     datatype: boolean
     description: flag for issues with psFlux_r
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFlux_flag_u
     '@id': '#object.psFlux_flag_u'
     datatype: boolean
     description: flag for issues with psFlux_u
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFlux_flag_y
     '@id': '#object.psFlux_flag_y'
     datatype: boolean
     description: flag for issues with psFlux_y
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFlux_flag_z
     '@id': '#object.psFlux_flag_z'
     datatype: boolean
     description: flag for issues with psFlux_zs
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: psFluxErr_g
     '@id': '#object.psFluxErr_g'
     datatype: double
     description: Uncertainty of psFlux_g.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: psFluxErr_i
@@ -6539,6 +8667,8 @@ tables:
     datatype: double
     description: Uncertainty of psFlux_i.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: psFluxErr_r
@@ -6546,6 +8676,8 @@ tables:
     datatype: double
     description: Uncertainty of psFlux_r.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: psFluxErr_u
@@ -6553,6 +8685,8 @@ tables:
     datatype: double
     description: Uncertainty of psFlux_u.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: psFluxErr_y
@@ -6560,6 +8694,8 @@ tables:
     datatype: double
     description: Uncertainty of psFlux_y.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: psFluxErr_z
@@ -6567,6 +8703,8 @@ tables:
     datatype: double
     description: Uncertainty of psFlux_z.
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nmgy
     ivoa:ucd: stat.error;phot.count
   - name: mag_g
@@ -6574,42 +8712,56 @@ tables:
     datatype: double
     description: Magnitude for g filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_i
     '@id': '#object.mag_i'
     datatype: double
     description: Magnitude for i filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_r
     '@id': '#object.mag_r'
     datatype: double
     description: Magnitude for r filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_u
     '@id': '#object.mag_u'
     datatype: double
     description: Magnitude for u filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_y
     '@id': '#object.mag_y'
     datatype: double
     description: Magnitude for y filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: mag_z
     '@id': '#object.mag_z'
     datatype: double
     description: magnitude for z filter
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
   - name: magerr_g
     '@id': '#object.magerr_g'
     datatype: double
     description: Error on mag_g
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_i
@@ -6617,6 +8769,8 @@ tables:
     datatype: double
     description: Error on mag_i
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_r
@@ -6624,6 +8778,8 @@ tables:
     datatype: double
     description: Error on mag_r
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_u
@@ -6631,6 +8787,8 @@ tables:
     datatype: double
     description: Error on mag_u
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_y
@@ -6638,6 +8796,8 @@ tables:
     datatype: double
     description: Error on mag_y
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_z
@@ -6645,6 +8805,8 @@ tables:
     datatype: double
     description: Error on mag_z
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: I_flag_g
@@ -6652,376 +8814,512 @@ tables:
     datatype: boolean
     description: Flag for issues with second moments of source intensity, g band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: I_flag_i
     '@id': '#object.I_flag_i'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, i band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: I_flag_r
     '@id': '#object.I_flag_r'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, r band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: I_flag_u
     '@id': '#object.I_flag_u'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, u band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: I_flag_y
     '@id': '#object.I_flag_y'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, y band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: I_flag_z
     '@id': '#object.I_flag_z'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, z band
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: Ixx_pixel_g
     '@id': '#object.Ixx_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixx_pixel_i
     '@id': '#object.Ixx_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixx_pixel_r
     '@id': '#object.Ixx_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixx_pixel_u
     '@id': '#object.Ixx_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixx_pixel_y
     '@id': '#object.Ixx_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixx_pixel_z
     '@id': '#object.Ixx_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_g
     '@id': '#object.Iyy_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_i
     '@id': '#object.Iyy_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_r
     '@id': '#object.Iyy_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_u
     '@id': '#object.Iyy_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_y
     '@id': '#object.Iyy_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Iyy_pixel_z
     '@id': '#object.Iyy_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_g
     '@id': '#object.Ixy_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_i
     '@id': '#object.Ixy_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_r
     '@id': '#object.Ixy_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_u
     '@id': '#object.Ixy_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_y
     '@id': '#object.Ixy_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: Ixy_pixel_z
     '@id': '#object.Ixy_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_g
     '@id': '#object.IxxPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_i
     '@id': '#object.IxxPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_r
     '@id': '#object.IxxPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_u
     '@id': '#object.IxxPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_y
     '@id': '#object.IxxPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxxPSF_pixel_z
     '@id': '#object.IxxPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_g
     '@id': '#object.IyyPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_i
     '@id': '#object.IyyPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_r
     '@id': '#object.IyyPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_u
     '@id': '#object.IyyPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_y
     '@id': '#object.IyyPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IyyPSF_pixel_z
     '@id': '#object.IyyPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_g
     '@id': '#object.IxyPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_i
     '@id': '#object.IxyPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_r
     '@id': '#object.IxyPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_u
     '@id': '#object.IxyPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_y
     '@id': '#object.IxyPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: IxyPSF_pixel_z
     '@id': '#object.IxyPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec^2
   - name: good
     '@id': '#object.good'
     datatype: boolean
     description: True if the source has no flagged pixels
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: clean
     '@id': '#object.clean'
     datatype: boolean
     description: True if the source has no flagged pixels and is not deblended
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
   - name: cModelFlux_g
     '@id': '#object.cModelFlux_g'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_i
     '@id': '#object.cModelFlux_i'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_r
     '@id': '#object.cModelFlux_r'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_u
     '@id': '#object.cModelFlux_u'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_y
     '@id': '#object.cModelFlux_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_z
     '@id': '#object.cModelFlux_z'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFluxErr_g
     '@id': '#object.cModelFluxErr_g'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_i
     '@id': '#object.cModelFluxErr_i'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_r
     '@id': '#object.cModelFluxErr_r'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_u
     '@id': '#object.cModelFluxErr_u'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_y
     '@id': '#object.cModelFluxErr_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_z
     '@id': '#object.cModelFluxErr_z'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFlux_flag_g
     '@id': '#object.cModelFlux_flag_g'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_i
     '@id': '#object.cModelFlux_flag_i'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_r
     '@id': '#object.cModelFlux_flag_r'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_u
     '@id': '#object.cModelFlux_flag_u'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_y
     '@id': '#object.cModelFlux_flag_y'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_z
     '@id': '#object.cModelFlux_flag_z'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: Flag for issues with cModelFlux_flag_<band>
   - name: psf_fwhm_g
     '@id': '#object.psf_fwhm_g'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_i
     '@id': '#object.psf_fwhm_i'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_r
     '@id': '#object.psf_fwhm_r'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_u
     '@id': '#object.psf_fwhm_u'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_y
     '@id': '#object.psf_fwhm_y'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_z
     '@id': '#object.psf_fwhm_z'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
 - name: truth_match
   '@id': '#truth_match'
@@ -7033,17 +9331,23 @@ tables:
     datatype: char
     length: 20
     mysql:datatype: CHAR(20)
+    tap:column_index: 999
+    tap:principal: 0
     description: Unique object ID
   - name: host_galaxy
     '@id': '#truth_match.host_galaxy'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: ID of the host galaxy for a SN/AGN entry (-1 for other truth types)
   - name: ra
     '@id': '#truth_match.ra'
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: deg
     description: Right Ascension
     ivoa:ucd: pos.eq.ra
@@ -7052,6 +9356,8 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: deg
     description: Declination
     ivoa:ucd: pos.eq.dec
@@ -7059,130 +9365,176 @@ tables:
     '@id': '#truth_match.redshift'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     description: Redshift
   - name: is_variable
     '@id': '#truth_match.is_variable'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: 1 for a variable source
   - name: is_pointsource
     '@id': '#truth_match.is_pointsource'
     datatype: int
     mysql:datatype: INTEGER
+    tap:column_index: 999
+    tap:principal: 0
     description: 1 for a point source
   - name: flux_u
     '@id': '#truth_match.flux_u'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in u
   - name: flux_g
     '@id': '#truth_match.flux_g'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in g
   - name: flux_r
     '@id': '#truth_match.flux_r'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in r
   - name: flux_i
     '@id': '#truth_match.flux_i'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in i
   - name: flux_z
     '@id': '#truth_match.flux_z'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in z
   - name: flux_y
     '@id': '#truth_match.flux_y'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in y
   - name: flux_u_noMW
     '@id': '#truth_match.flux_u_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in u, without Milky Way extinction (i.e., dereddened)
   - name: flux_g_noMW
     '@id': '#truth_match.flux_g_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in g, without Milky Way extinction (i.e., dereddened)
   - name: flux_r_noMW
     '@id': '#truth_match.flux_r_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in r, without Milky Way extinction (i.e., dereddened)
   - name: flux_i_noMW
     '@id': '#truth_match.flux_i_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in i, without Milky Way extinction (i.e., dereddened)
   - name: flux_z_noMW
     '@id': '#truth_match.flux_z_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in z, without Milky Way extinction (i.e., dereddened)
   - name: flux_y_noMW
     '@id': '#truth_match.flux_y_noMW'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: nJy
     description: Static flux value in y, without Milky Way extinction (i.e., dereddened)
   - name: mag_r
     '@id': '#truth_match.mag_r'
     datatype: float
     mysql:datatype: FLOAT
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: mag
     description: Magnitude in r
   - name: tract
     '@id': '#truth_match.tract'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Tract ID in Sky Map
   - name: patch
     '@id': '#truth_match.patch'
     datatype: char
     length: 3
     mysql:datatype: CHAR(3)
+    tap:column_index: 999
+    tap:principal: 0
     description: Patch ID in Sky Map (as a string, x,y)
   - name: cosmodc2_hp
     '@id': '#truth_match.cosmodc2_hp'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Healpix ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: cosmodc2_id
     '@id': '#truth_match.cosmodc2_id'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: Galaxy ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: truth_type
     '@id': '#truth_match.truth_type'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: 1 for galaxies, 2 for stars, and 3 for SNe
   - name: match_objectId
     '@id': '#truth_match.match_objectId'
     datatype: long
     mysql:datatype: BIGINT
+    tap:column_index: 999
+    tap:principal: 0
     description: objectId of the matching object entry (-1 for unmatched truth entries)
   - name: match_sep
     '@id': '#truth_match.match_sep'
     datatype: double
     mysql:datatype: DOUBLE
+    tap:column_index: 999
+    tap:principal: 0
     fits:tunit: asec
     description: On-sky angular separation of this object-truth matching pair (-1
       for unmatched truth entries)
@@ -7190,16 +9542,22 @@ tables:
     '@id': '#truth_match.is_good_match'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if this object--truth matching pair satisfies all matching criteria
   - name: is_nearest_neighbor
     '@id': '#truth_match.is_nearest_neighbor'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True if this truth entry is the nearest neighbor of the object specified
       by match_objectId
   - name: is_unique_truth_entry
     '@id': '#truth_match.is_unique_truth_entry'
     datatype: boolean
     mysql:datatype: BOOLEAN
+    tap:column_index: 999
+    tap:principal: 0
     description: True for truth entries that appear for the first time in this truth
       table

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -13,7 +13,7 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
-    tap:column_index: 999
+    tap:column_index: 1
     tap:principal: 1
     description: Unique id.
   - name: coord_ra
@@ -21,7 +21,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 2
     tap:principal: 1
     description: RA-coordinate
     fits:tunit: ''
@@ -31,7 +31,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 3
     tap:principal: 1
     description: Decl-coordinate
     fits:tunit: ''
@@ -257,7 +257,7 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
-    tap:column_index: 999
+    tap:column_index: 1
     tap:principal: 1
     description: Unique id.
   - name: coord_ra
@@ -265,7 +265,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 2
     tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
@@ -275,7 +275,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 3
     tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
@@ -2207,7 +2207,7 @@ tables:
     datatype: long
     nullable: false
     mysql:datatype: BIGINT
-    tap:column_index: 999
+    tap:column_index: 1
     tap:principal: 1
     description: Unique id.
   - name: coord_ra
@@ -2215,7 +2215,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 2
     tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
@@ -2225,7 +2225,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 3
     tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
@@ -8241,7 +8241,7 @@ tables:
     nullable: false
     description: Unique id.
     mysql:datatype: BIGINT
-    tap:column_index: 999
+    tap:column_index: 1
     tap:principal: 1
     ivoa:ucd: meta.id;src
   - name: parentObjectId
@@ -8249,7 +8249,7 @@ tables:
     datatype: long
     description: Id of the parent object this object has been deblended from, if any.
     mysql:datatype: BIGINT
-    tap:column_index: 999
+    tap:column_index: 2
     tap:principal: 1
   - name: ra
     '@id': '#object.ra'
@@ -8257,7 +8257,7 @@ tables:
     nullable: false
     description: RA-coordinate of the center of the object for the Point Source model.
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 3
     tap:principal: 1
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
@@ -8268,7 +8268,7 @@ tables:
     description: Decl-coordinate of the center of the object for the Point Source
       model.
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 4
     tap:principal: 1
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
@@ -9331,7 +9331,7 @@ tables:
     datatype: char
     length: 20
     mysql:datatype: CHAR(20)
-    tap:column_index: 999
+    tap:column_index: 1
     tap:principal: 1
     description: Unique object ID
   - name: host_galaxy
@@ -9346,7 +9346,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 2
     tap:principal: 1
     fits:tunit: deg
     description: Right Ascension
@@ -9356,7 +9356,7 @@ tables:
     datatype: double
     nullable: false
     mysql:datatype: DOUBLE
-    tap:column_index: 999
+    tap:column_index: 3
     tap:principal: 1
     fits:tunit: deg
     description: Declination

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -14,7 +14,7 @@ tables:
     nullable: false
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Unique id.
   - name: coord_ra
     '@id': '#position.coord_ra'
@@ -22,7 +22,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: RA-coordinate
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -32,7 +32,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Decl-coordinate
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -42,7 +42,7 @@ tables:
     nullable: false
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: unique ID of parent source
     fits:tunit: ''
   - name: deblend_nChild
@@ -50,7 +50,7 @@ tables:
     datatype: int
     mysql:datatype: INTEGER
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Number of children this object has (defaults to 0)
     fits:tunit: ''
   - name: detect_isPrimary
@@ -58,7 +58,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: true if source has no children and is in the inner region of a coadd
       patch and is in the inner region of a coadd tract and is not "detected" in a
       pseudo-filter (see config.pseudoFilterList)
@@ -68,7 +68,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Milky Way dust extinction, E(B-V)
     fits:tunit: mag
   - name: detect_isPatchInner
@@ -258,7 +258,7 @@ tables:
     nullable: false
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Unique id.
   - name: coord_ra
     '@id': '#reference.coord_ra'
@@ -266,7 +266,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -276,7 +276,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -612,7 +612,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: base_ClassificationExtendedness_flag
@@ -831,7 +831,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: ext_shapeHSM_HsmSourceMoments_x
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_x'
@@ -1375,7 +1375,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Deblender thought this source looked like a PSF
     fits:tunit: ''
   - name: deblend_tooManyPeaks
@@ -1407,7 +1407,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Deblender skipped this source
     fits:tunit: ''
   - name: deblend_rampedTemplate
@@ -2075,7 +2075,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flag set if the final cmodel fit (or any previous fit) failed
     fits:tunit: ''
   - name: modelfit_CModel_flag_region_maxArea
@@ -2208,7 +2208,7 @@ tables:
     nullable: false
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Unique id.
   - name: coord_ra
     '@id': '#forced_photometry.coord_ra'
@@ -2216,7 +2216,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.ra
@@ -2226,7 +2226,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: position in ra/dec
     fits:tunit: ''
     ivoa:ucd: pos.eq.dec
@@ -2411,14 +2411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: g_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.g_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: g_base_ClassificationExtendedness_flag
@@ -2426,7 +2426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: g_modelfit_CModel_instFlux
@@ -2434,7 +2434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: g_modelfit_CModel_instFluxErr
@@ -2442,7 +2442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: g_modelfit_CModel_instFlux_inner
@@ -3411,14 +3411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: i_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.i_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: i_base_ClassificationExtendedness_flag
@@ -3426,7 +3426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: i_modelfit_CModel_instFlux
@@ -3434,7 +3434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: i_modelfit_CModel_instFluxErr
@@ -3442,7 +3442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: i_modelfit_CModel_instFlux_inner
@@ -4411,14 +4411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: r_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.r_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: r_base_ClassificationExtendedness_flag
@@ -4426,7 +4426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: r_modelfit_CModel_instFlux
@@ -4434,7 +4434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: r_modelfit_CModel_instFluxErr
@@ -4442,7 +4442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: r_modelfit_CModel_instFlux_inner
@@ -5411,14 +5411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: u_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.u_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: u_base_ClassificationExtendedness_flag
@@ -5426,7 +5426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: u_modelfit_CModel_instFlux
@@ -5434,7 +5434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: u_modelfit_CModel_instFluxErr
@@ -5442,7 +5442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: u_modelfit_CModel_instFlux_inner
@@ -6411,14 +6411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: y_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.y_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: y_base_ClassificationExtendedness_flag
@@ -6426,7 +6426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: y_modelfit_CModel_instFlux
@@ -6434,7 +6434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: y_modelfit_CModel_instFluxErr
@@ -6442,7 +6442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: y_modelfit_CModel_instFlux_inner
@@ -7411,14 +7411,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if the source has no flagged pixels.
   - name: z_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.z_base_ClassificationExtendedness_value'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
     fits:tunit: ''
   - name: z_base_ClassificationExtendedness_flag
@@ -7426,7 +7426,7 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Set to 1 for any fatal failure.
     fits:tunit: ''
   - name: z_modelfit_CModel_instFlux
@@ -7434,7 +7434,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux from the final cmodel fit
     fits:tunit: count
   - name: z_modelfit_CModel_instFluxErr
@@ -7442,7 +7442,7 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: flux uncertainty from the final cmodel fit
     fits:tunit: count
   - name: z_modelfit_CModel_instFlux_inner
@@ -8242,7 +8242,7 @@ tables:
     description: Unique id.
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: meta.id;src
   - name: parentObjectId
     '@id': '#object.parentObjectId'
@@ -8250,7 +8250,7 @@ tables:
     description: Id of the parent object this object has been deblended from, if any.
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: ra
     '@id': '#object.ra'
     datatype: double
@@ -8258,7 +8258,7 @@ tables:
     description: RA-coordinate of the center of the object for the Point Source model.
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: dec
@@ -8269,7 +8269,7 @@ tables:
       model.
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: tract
@@ -8278,14 +8278,14 @@ tables:
     description: tract ID
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: patch
     '@id': '#object.patch'
     datatype: char
     length: 3
     mysql:datatype: CHAR(3)
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: patch ID
   - name: x
     '@id': '#object.x'
@@ -8343,7 +8343,7 @@ tables:
     description: 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: blendedness
     '@id': '#object.blendedness'
     datatype: double
@@ -8351,7 +8351,7 @@ tables:
       (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766))
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: Ixx_pixel
     '@id': '#object.Ixx_pixel'
     datatype: double
@@ -8413,7 +8413,7 @@ tables:
     description: Composite model (cModel) magnitude for g filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: mag_i_cModel
     '@id': '#object.mag_i_cModel'
@@ -8421,7 +8421,7 @@ tables:
     description: Composite model (cModel) magnitude for i filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: mag_r_cModel
     '@id': '#object.mag_r_cModel'
@@ -8429,7 +8429,7 @@ tables:
     description: Composite model (cModel) magnitude for r filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: mag_u_cModel
     '@id': '#object.mag_u_cModel'
@@ -8437,7 +8437,7 @@ tables:
     description: Composite model (cModel) magnitude for u filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: mag_y_cModel
     '@id': '#object.mag_y_cModel'
@@ -8445,7 +8445,7 @@ tables:
     description: Composite model (cModel) magnitude for y filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: mag_z_cModel
     '@id': '#object.mag_z_cModel'
@@ -8453,7 +8453,7 @@ tables:
     description: Composite model (cModel) magnitude for z filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
   - name: magerr_g_cModel
     '@id': '#object.magerr_g_cModel'
@@ -8461,7 +8461,7 @@ tables:
     description: Error on mag_g_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_i_cModel
@@ -8470,7 +8470,7 @@ tables:
     description: Error on mag_i_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_r_cModel
@@ -8479,7 +8479,7 @@ tables:
     description: Error on mag_r_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_u_cModel
@@ -8488,7 +8488,7 @@ tables:
     description: Error on mag_u_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_y_cModel
@@ -8497,7 +8497,7 @@ tables:
     description: Error on mag_y_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: magerr_z_cModel
@@ -8506,7 +8506,7 @@ tables:
     description: Error on mag_z_cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     ivoa:ucd: stat.error
   - name: snr_g_cModel
@@ -8515,7 +8515,7 @@ tables:
     description: Signal to noise ratio for magnitude for g filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: snr_i_cModel
     '@id': '#object.snr_i_cModel'
@@ -8523,7 +8523,7 @@ tables:
     description: Signal to noise ratio for magnitude for i filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: snr_r_cModel
     '@id': '#object.snr_r_cModel'
@@ -8531,7 +8531,7 @@ tables:
     description: Signal to noise ratio for magnitude for r filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: snr_u_cModel
     '@id': '#object.snr_u_cModel'
@@ -8539,7 +8539,7 @@ tables:
     description: Signal to noise ratio for magnitude for u filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: snr_y_cModel
     '@id': '#object.snr_y_cModel'
@@ -8547,7 +8547,7 @@ tables:
     description: Signal to noise ratio for magnitude for y filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: snr_z_cModel
     '@id': '#object.snr_z_cModel'
@@ -8555,7 +8555,7 @@ tables:
     description: Signal to noise ratio for magnitude for z filter fitted by cModel
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     ivoa:ucd: stat.snr
   - name: psFlux_g
     '@id': '#object.psFlux_g'
@@ -9145,14 +9145,14 @@ tables:
     description: True if the source has no flagged pixels
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: clean
     '@id': '#object.clean'
     datatype: boolean
     description: True if the source has no flagged pixels and is not deblended
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
   - name: cModelFlux_g
     '@id': '#object.cModelFlux_g'
     datatype: double
@@ -9242,42 +9242,42 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_i
     '@id': '#object.cModelFlux_flag_i'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_r
     '@id': '#object.cModelFlux_flag_r'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_u
     '@id': '#object.cModelFlux_flag_u'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_y
     '@id': '#object.cModelFlux_flag_y'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_z
     '@id': '#object.cModelFlux_flag_z'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: psf_fwhm_g
     '@id': '#object.psf_fwhm_g'
@@ -9332,14 +9332,14 @@ tables:
     length: 20
     mysql:datatype: CHAR(20)
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Unique object ID
   - name: host_galaxy
     '@id': '#truth_match.host_galaxy'
     datatype: long
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: ID of the host galaxy for a SN/AGN entry (-1 for other truth types)
   - name: ra
     '@id': '#truth_match.ra'
@@ -9347,7 +9347,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: deg
     description: Right Ascension
     ivoa:ucd: pos.eq.ra
@@ -9357,7 +9357,7 @@ tables:
     nullable: false
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: deg
     description: Declination
     ivoa:ucd: pos.eq.dec
@@ -9366,28 +9366,28 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Redshift
   - name: is_variable
     '@id': '#truth_match.is_variable'
     datatype: int
     mysql:datatype: INTEGER
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: 1 for a variable source
   - name: is_pointsource
     '@id': '#truth_match.is_pointsource'
     datatype: int
     mysql:datatype: INTEGER
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: 1 for a point source
   - name: flux_u
     '@id': '#truth_match.flux_u'
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in u
   - name: flux_g
@@ -9395,7 +9395,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in g
   - name: flux_r
@@ -9403,7 +9403,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in r
   - name: flux_i
@@ -9411,7 +9411,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in i
   - name: flux_z
@@ -9419,7 +9419,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in z
   - name: flux_y
@@ -9427,7 +9427,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: nJy
     description: Static flux value in y
   - name: flux_u_noMW
@@ -9483,7 +9483,7 @@ tables:
     datatype: float
     mysql:datatype: FLOAT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: mag
     description: Magnitude in r
   - name: tract
@@ -9491,7 +9491,7 @@ tables:
     datatype: long
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Tract ID in Sky Map
   - name: patch
     '@id': '#truth_match.patch'
@@ -9499,7 +9499,7 @@ tables:
     length: 3
     mysql:datatype: CHAR(3)
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: Patch ID in Sky Map (as a string, x,y)
   - name: cosmodc2_hp
     '@id': '#truth_match.cosmodc2_hp'
@@ -9520,21 +9520,21 @@ tables:
     datatype: long
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: 1 for galaxies, 2 for stars, and 3 for SNe
   - name: match_objectId
     '@id': '#truth_match.match_objectId'
     datatype: long
     mysql:datatype: BIGINT
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: objectId of the matching object entry (-1 for unmatched truth entries)
   - name: match_sep
     '@id': '#truth_match.match_sep'
     datatype: double
     mysql:datatype: DOUBLE
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     fits:tunit: asec
     description: On-sky angular separation of this object-truth matching pair (-1
       for unmatched truth entries)
@@ -9543,14 +9543,14 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if this object--truth matching pair satisfies all matching criteria
   - name: is_nearest_neighbor
     '@id': '#truth_match.is_nearest_neighbor'
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True if this truth entry is the nearest neighbor of the object specified
       by match_objectId
   - name: is_unique_truth_entry
@@ -9558,6 +9558,6 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     tap:column_index: 999
-    tap:principal: 0
+    tap:principal: 1
     description: True for truth entries that appear for the first time in this truth
       table


### PR DESCRIPTION
Also assigned `column_index` values to selected columns (ID, ra, dec) to move them to the top in the Portal.