### PR TITLE
DM-32666: Add gaussianFlux to Source Table

### DIFF
--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -5306,6 +5306,18 @@ tables:
     description:
     mysql:datatype: DOUBLE
     fits.tunit:
+  - name: gaussianFlux
+    "@id": "#Source.gaussianFlux"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
+  - name: gaussianFluxErr
+    "@id": "#Source.gaussianFluxErr"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
@@ -5590,6 +5602,12 @@ tables:
     fits.tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
+    datatype: boolean
+    description:
+    mysql:datatype: BOOLEAN
+    fits.tunit:
+  - name: gaussianFlux_flag
+    "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description:
     mysql:datatype: BOOLEAN

--- a/yml/hsc_gen2.yaml
+++ b/yml/hsc_gen2.yaml
@@ -5298,6 +5298,18 @@ tables:
     description:
     mysql:datatype: DOUBLE
     fits.tunit:
+  - name: gaussianFlux
+    "@id": "#Source.gaussianFlux"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
+  - name: gaussianFluxErr
+    "@id": "#Source.gaussianFluxErr"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
@@ -5582,6 +5594,12 @@ tables:
     fits.tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
+    datatype: boolean
+    description:
+    mysql:datatype: BOOLEAN
+    fits.tunit:
+  - name: gaussianFlux_flag
+    "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description:
     mysql:datatype: BOOLEAN

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -6267,6 +6267,18 @@ tables:
     description:
     mysql:datatype: DOUBLE
     fits.tunit:
+  - name: gaussianFlux
+    "@id": "#Source.gaussianFlux"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
+  - name: gaussianFluxErr
+    "@id": "#Source.gaussianFluxErr"
+    datatype: double
+    description:
+    mysql:datatype: DOUBLE
+    fits.tunit:
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
@@ -6551,6 +6563,12 @@ tables:
     fits.tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
+    datatype: boolean
+    description:
+    mysql:datatype: BOOLEAN
+    fits.tunit:
+  - name: gaussianFlux_flag
+    "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description:
     mysql:datatype: BOOLEAN


### PR DESCRIPTION
The single frame extendedness column is used for QA.
Therefore, the fluxes from which it is computed
(gaussian and psf) will also be used for QA. If a column is
needed for QA then it will also be needed during analysis.