### PR TITLE
DM-32731: schema browser fixes

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+dm.lsst.org

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,9 @@ data_dir: ./yml
 layouts_dir: ./browser/_layouts
 exclude:
   - Gemfile
+  - /datalink
   - /tap-schema
+  - /ups
   - /yml
 readme_index:
   remove_originals: true

--- a/tap-schema/requirements.txt
+++ b/tap-schema/requirements.txt
@@ -1,3 +1,3 @@
 click
 pyyaml
-git+git://github.com/lsst-dm/felis.git@master#egg=felis
+git+git://github.com/lsst-dm/felis.git@main#egg=felis


### PR DESCRIPTION
* Add CNAME file now required to publish github pages (schema browser) from custom domain (dm.lsst.org).
* Add config directors to have browser skip the ups/ and datalink/ subdirectories.