### PR TITLE
Remove github pages CNAME for schema browser

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-dm.lsst.org


### PR DESCRIPTION
not desired, after all -- TLD is configured further up, as CNAME for lsst.github.io