### PR TITLE
Match name of dp02 preview slice to Qserv

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -1,5 +1,5 @@
 ---
-name: dp02_dc2_catalogs
+name: dp02_test_PREOPS863_00
 "@id": dp02_dc2_catalogs
 description: Preliminary schema for Data Preview 0.2, including only catalog tables for now
 tables:


### PR DESCRIPTION
Unfortunately, database name in back-end Qserv for the DP02 preview test slice is not the desired "harmonious" name for DP02 catalogs in tap_schema, and I am not aware that these names can be set independently.  Setting to the name as ingested for now.  We will correct this on the next test ingest.