### PR TITLE
DM-33942: Remove visit_system from the schema

### DIFF
--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -5921,12 +5921,6 @@ tables:
     length: 5
     mysql:datatype: CHAR(5)
     fits:tunit:
-  - name: visit_system
-    "@id": "#Source.visit_system"
-    datatype: long
-    description:
-    mysql:datatype: BIGINT
-    fits:tunit:
   - name: visit
     "@id": "#Source.visit"
     datatype: long

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -6882,12 +6882,6 @@ tables:
     length: 5
     mysql:datatype: CHAR(5)
     fits:tunit:
-  - name: visit_system
-    "@id": "#Source.visit_system"
-    datatype: long
-    description:
-    mysql:datatype: BIGINT
-    fits:tunit:
   - name: visit
     "@id": "#Source.visit"
     datatype: long


### PR DESCRIPTION
With the butler schema change the visit_system is no longer part of the visit dataId.