### PR TITLE
DM-35221: Mark single-character columns as variable-length strings in VOTable output

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -113,6 +113,7 @@ tables:
     description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
     mysql:datatype: CHAR(1)
     fits:tunit:
+    votable:arraysize: "*"
   - name: refExtendedness
     "@id": "#Object.refExtendedness"
     datatype: double
@@ -6802,6 +6803,7 @@ tables:
     description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
     mysql:datatype: CHAR(1)
     fits:tunit:
+    votable:arraysize: "*"
   - name: instrument
     "@id": "#Source.instrument"
     datatype: char
@@ -6896,6 +6898,7 @@ tables:
     mysql:datatype: CHAR(1)
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
+    votable:arraysize: "*"
   - name: ccdVisitId
     "@id": "#ForcedSource.ccdVisitId"
     datatype: long
@@ -8183,9 +8186,11 @@ tables:
   - name: band
     "@id": "#ForcedSourceOnDiaObject.band"
     datatype: char
+    length: 1
     mysql:datatype: CHAR(1)
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
+    votable:arraysize: "*"
   - name: ccdVisitId
     "@id": "#ForcedSourceOnDiaObject.ccdVisitId"
     datatype: long
@@ -8490,6 +8495,7 @@ tables:
     datatype: char
     length: 1
     description: ''
+    votable:arraysize: "*"
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -8564,6 +8570,7 @@ tables:
     datatype: char
     length: 1
     description: ''
+    votable:arraysize: "*"
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double

--- a/yml/dp02_dc2_preops-863.yaml
+++ b/yml/dp02_dc2_preops-863.yaml
@@ -114,6 +114,7 @@ tables:
     description:
     mysql:datatype: CHAR(1)
     fits:tunit:
+    votable:arraysize: "*"
   - name: refExtendedness
     "@id": "#Object.refExtendedness"
     datatype: double
@@ -6783,6 +6784,7 @@ tables:
     description: Name of the band used to take the exposure where this source was measured.
     mysql:datatype: CHAR(1)
     fits:tunit:
+    votable:arraysize: "*"
   - name: instrument
     "@id": "#Source.instrument"
     datatype: char
@@ -6868,6 +6870,7 @@ tables:
     length: 1
     mysql:datatype: CHAR(1)
     description:
+    votable:arraysize: "*"
   - name: ccdVisitId
     "@id": "#ForcedSource.ccdVisitId"
     datatype: long
@@ -7826,6 +7829,7 @@ tables:
     datatype: char
     mysql:datatype: CHAR(1)
     description:
+    votable:arraysize: "*"
   - name: forced_PsfFlux_flag
     "@id": "#DiaSource.forced_PsfFlux_flag"
     datatype: boolean
@@ -8060,6 +8064,7 @@ tables:
     datatype: char
     mysql:datatype: CHAR(1)
     description:
+    votable:arraysize: "*"
   - name: ccdVisitId
     "@id": "#ForcedSourceOnDiaObject.ccdVisitId"
     datatype: long
@@ -8254,6 +8259,7 @@ tables:
     datatype: char
     length: 1
     description: ''
+    votable:arraysize: "*"
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -8310,6 +8316,7 @@ tables:
     datatype: char
     length: 1
     description: ''
+    votable:arraysize: "*"
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double


### PR DESCRIPTION
Workaround for a Firefly bug but legitimate in its own right.