### PR TITLE
Elide `MatchesTruth`,`MatchesObject` from DP0.2

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8402,81 +8402,81 @@ tables:
     mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
-- name: MatchesTruth
-  '@id': '#MatchesTruth'
-  description: Match information for truth_summary sources.
-  columns:
-  - name: index
-    '@id': '#MatchesTruth.index'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: Incrementing (implicit) row index
-  - name: match_candidate
-    '@id': '#MatchesTruth.match_candidate'
-    datatype: boolean
-    mysql:datatype: BOOLEAN
-    description: True for sources that were selected for matching
-  - name: match_row
-    '@id': '#MatchesTruth.match_row'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: Index of matched objectTable_tract table row, if any
-  - name: match_count
-    '@id': '#MatchesTruth.match_count'
-    datatype: int
-    mysql:datatype: INTEGER
-    description: Number of candidate object matches within match radius
-  - name: match_chisq
-    '@id': '#MatchesTruth.match_chisq'
-    datatype: double
-    mysql:datatype: double
-    description: The chi-squared value of the (best) match
-  - name: match_n_chisq_finite
-    '@id': '#MatchesTruth.match_n_chisq_finite'
-    datatype: int
-    mysql:datatype: INTEGER
-    description: The number of finite columns used to compute the match chisq
-  - name: id
-    '@id': '#MatchesTruth.id'
-    datatype: char
-    length: 16
-    mysql:datatype: CHAR(16)
-    description: id for truth_summary source.
-  - name: match_objectId
-    '@id': '#MatchesTruth.match_objectId'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: objectId of matched objectTable_tract object, if any
-- name: MatchesObject
-  '@id': '#MatchesObject'
-  description: Match information for objectTable_tract sources
-  columns:
-  - name: index
-    '@id': '#MatchesObject.index'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: Incrementing (implicit) row index
-  - name: match_candidate
-    '@id': '#MatchesObject.match_candidate'
-    datatype: boolean
-    mysql:datatype: BOOLEAN
-    description: True for sources that were selected for matching
-  - name: match_row
-    '@id': '#MatchesObject.match_row'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: Index of matched truth_summary table row, if any
-  - name: match_id
-    '@id': '#MatchesObject.match_id'
-    datatype: char
-    length: 16
-    mysql:datatype: CHAR(16)
-    description: id of matched truth_summary source, if any
-  - name: objectId
-    '@id': '#MatchesObject.objectId'
-    datatype: long
-    mysql:datatype: BIGINT
-    description: objectId of object
+# - name: MatchesTruth
+#   '@id': '#MatchesTruth'
+#   description: Match information for truth_summary sources.
+#   columns:
+#   - name: index
+#     '@id': '#MatchesTruth.index'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: Incrementing (implicit) row index
+#   - name: match_candidate
+#     '@id': '#MatchesTruth.match_candidate'
+#     datatype: boolean
+#     mysql:datatype: BOOLEAN
+#     description: True for sources that were selected for matching
+#   - name: match_row
+#     '@id': '#MatchesTruth.match_row'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: Index of matched objectTable_tract table row, if any
+#   - name: match_count
+#     '@id': '#MatchesTruth.match_count'
+#     datatype: int
+#     mysql:datatype: INTEGER
+#     description: Number of candidate object matches within match radius
+#   - name: match_chisq
+#     '@id': '#MatchesTruth.match_chisq'
+#     datatype: double
+#     mysql:datatype: double
+#     description: The chi-squared value of the (best) match
+#   - name: match_n_chisq_finite
+#     '@id': '#MatchesTruth.match_n_chisq_finite'
+#     datatype: int
+#     mysql:datatype: INTEGER
+#     description: The number of finite columns used to compute the match chisq
+#   - name: id
+#     '@id': '#MatchesTruth.id'
+#     datatype: char
+#     length: 16
+#     mysql:datatype: CHAR(16)
+#     description: id for truth_summary source.
+#   - name: match_objectId
+#     '@id': '#MatchesTruth.match_objectId'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: objectId of matched objectTable_tract object, if any
+# - name: MatchesObject
+#   '@id': '#MatchesObject'
+#   description: Match information for objectTable_tract sources
+#   columns:
+#   - name: index
+#     '@id': '#MatchesObject.index'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: Incrementing (implicit) row index
+#   - name: match_candidate
+#     '@id': '#MatchesObject.match_candidate'
+#     datatype: boolean
+#     mysql:datatype: BOOLEAN
+#     description: True for sources that were selected for matching
+#   - name: match_row
+#     '@id': '#MatchesObject.match_row'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: Index of matched truth_summary table row, if any
+#   - name: match_id
+#     '@id': '#MatchesObject.match_id'
+#     datatype: char
+#     length: 16
+#     mysql:datatype: CHAR(16)
+#     description: id of matched truth_summary source, if any
+#   - name: objectId
+#     '@id': '#MatchesObject.objectId'
+#     datatype: long
+#     mysql:datatype: BIGINT
+#     description: objectId of object
 - name: Visit
   '@id': '#Visit'
   description: Defines a single Visit.


### PR DESCRIPTION
Commenting out `MatchesTruth` and `MatchesObject` table descriptions, to reduce confusion since these will not be initially offered with DP0.2.  We will restore these descriptions once the table formats are finalized and tables are populated on the release servers.