### PR TITLE
Minor cleanups for DP0.2 schema

### DIFF
--- a/browser/dp02.md
+++ b/browser/dp02.md
@@ -1,7 +1,9 @@
 ---
 layout: schema
-title: Data Preview 0.2 Schema (Preliminary)
+title: Data Preview 0.2 Schema
 schema: dp02_dc2
-sort-index: 11
+sort-index: 9
 ---
-Preliminary schema for Data Preview 0.2, including only catalog tables for now.
+Data Preview 0.2 contains the image and catalog products of the Rubin Science
+Pipelines v23 processing of DESC’s Data Challenge 2 simulation, which covered 300 square
+degrees of the wide-fast-deep LSST survey region over 5 years.

--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -1,6 +1,10 @@
 #!/bin/bash -ex
+#
+# NB: The order of files in the ./build statements controls the TAP_SCHEMA.schemas.schema_index
+# values that control the presentation order of schemas.  This is respected by the Portal Aspect.
+#
 ./build mock
 ./build stable ../yml/hsc.yaml ../yml/wise_01.yml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml
 ./build int ../yml/hsc.yaml ../yml/wise_01.yml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml
 ./build idfprod ../yml/dp01_dc2.yaml
-./build idfint ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
+./build idfint ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -1,17 +1,13 @@
 ---
 name: dp02_dc2_catalogs
 "@id": "#dp02_dc2_catalogs"
-description: Data Preview 0.2 contains the image and catalog products of the Rubin Science
-  Pipelines v23 processing of DESC’s Data Challenge 2 simulation, which covered 300 square
-  degrees of the wide-fast-deep LSST survey region over 5 years.
+description: "Data Preview 0.2 contains the image and catalog products of the Rubin Science
+  Pipelines v23 processing of the DESC Data Challenge 2 simulation, which covered 300 square
+  degrees of the wide-fast-deep LSST survey region over 5 years."
 tables:
 - name: Object
   "@id": "#Object"
-  description: The object table contains descriptions of the multi-epoch static astronomical
-    objects, in particular their astrophysical properties as derived from analysis
-    of the Sources that are associated with them. Note that fast moving objects are
-    kept in the MovingObject tables. Note that less-frequently used columns are stored
-    in a separate table called Object_Extra.
+  description: "Properties of the astronomical objects detected and measured on the deep coadded images."
   tap:table_index: 1
   columns:
   - name: objectId
@@ -5965,9 +5961,8 @@ tables:
     fits:tunit: deg
 - name: Source
   "@id": "#Source"
-  description: Table to store high signal-to-noise sources;. A source is
-    a measurement of Object's properties from a single image that contains its footprint
-    on the sky.
+  description: "Properties of detections on the single-epoch visit images, performed
+    independently of the Object detections on coadded images."
   tap:table_index: 2
   columns:
   - name: sourceId
@@ -6841,9 +6836,10 @@ tables:
     fits:tunit:
 - name: ForcedSource
   "@id": "#ForcedSource"
-  description: The forced source table contains forced-photometry source
-     measurement on an individual Exposure based on a Multifit shape model
-     derived from a deep detection.
+  description: "Forced-photometry measurements on individual single-epoch visit images and
+    difference images, based on and linked to the entries in the Object table. Point-source
+    PSF photometry is performed, based on coordinates from a reference band chosen for each
+    Object and reported in the Object.refBand column."
   tap:table_index: 3
   columns:
   - name: forcedSourceId
@@ -7085,7 +7081,9 @@ tables:
     fits:tunit: nanojansky
 - name: DiaObject
   "@id": "#DiaObject"
-  description: this is diaObjectTable_tract in the butler repo
+  description: "Properties of time-varying astronomical objects based on association
+    of data from one or more spatially-related DiaSource detections on individual
+    single-epoch difference images."
   tap:table_index: 4
   columns:
   - name: decl
@@ -7780,7 +7778,7 @@ tables:
     description:
 - name: DiaSource
   "@id": "#DiaSource"
-  description: this is diaSourceTable_tract in the butler repo
+  description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 5
   columns:
   - name: apFlux
@@ -8187,7 +8185,9 @@ tables:
     fits:tunit: pixel
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
-  description: this is forcedSourceOnDiaObjectTable_tract in the butler repo
+  description: "Point-source forced-photometry measurements on individual single-epoch
+    visit images and difference images, based on and linked to the entries in the
+    DiaObject table."
   tap:table_index: 6
   columns:
   - name: band
@@ -8486,7 +8486,8 @@ tables:
 #     description: objectId of object
 - name: Visit
   '@id': '#Visit'
-  description: Defines a single Visit.
+  description: "Metadata about the pointings of the DC2 simulated survey,
+    largely associated with the boresight of the entire focal plane."
   tap:table_index: 7
   columns:
   - name: visit
@@ -8589,7 +8590,8 @@ tables:
     mysql:datatype: TIMESTAMP
 - name: CcdVisit
   '@id': '#CcdVisit'
-  description: Defines a single detector of a visit
+  description: "Metadata about the 189 individual CCD images for each Visit in the
+    DC2 simulated survey."
   tap:table_index: 8
   columns:
   - name: ccdVisitId

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -1,6 +1,9 @@
 ---
 name: dp02_dc2_catalogs
 "@id": "#dp02_dc2_catalogs"
+description: Data Preview 0.2 contains the image and catalog products of the Rubin Science
+  Pipelines v23 processing of DESC’s Data Challenge 2 simulation, which covered 300 square
+  degrees of the wide-fast-deep LSST survey region over 5 years.
 tables:
 - name: Object
   "@id": "#Object"
@@ -9,6 +12,7 @@ tables:
     of the Sources that are associated with them. Note that fast moving objects are
     kept in the MovingObject tables. Note that less-frequently used columns are stored
     in a separate table called Object_Extra.
+  tap:table_index: 1
   columns:
   - name: objectId
     "@id": "#Object.objectId"
@@ -5959,13 +5963,12 @@ tables:
     description: Position in ra/dec. Measured on z-band.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-
-
 - name: Source
   "@id": "#Source"
   description: Table to store high signal-to-noise sources;. A source is
     a measurement of Object's properties from a single image that contains its footprint
     on the sky.
+  tap:table_index: 2
   columns:
   - name: sourceId
     "@id": "#Source.sourceId"
@@ -6841,6 +6844,7 @@ tables:
   description: The forced source table contains forced-photometry source
      measurement on an individual Exposure based on a Multifit shape model
      derived from a deep detection.
+  tap:table_index: 3
   columns:
   - name: forcedSourceId
     "@id": "#ForcedSource.forcedSourceId"
@@ -7082,6 +7086,7 @@ tables:
 - name: DiaObject
   "@id": "#DiaObject"
   description: this is diaObjectTable_tract in the butler repo
+  tap:table_index: 4
   columns:
   - name: decl
     "@id": "#DiaObject.decl"
@@ -7776,6 +7781,7 @@ tables:
 - name: DiaSource
   "@id": "#DiaSource"
   description: this is diaSourceTable_tract in the butler repo
+  tap:table_index: 5
   columns:
   - name: apFlux
     "@id": "#DiaSource.apFlux"
@@ -8182,6 +8188,7 @@ tables:
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
   description: this is forcedSourceOnDiaObjectTable_tract in the butler repo
+  tap:table_index: 6
   columns:
   - name: band
     "@id": "#ForcedSourceOnDiaObject.band"
@@ -8480,6 +8487,7 @@ tables:
 - name: Visit
   '@id': '#Visit'
   description: Defines a single Visit.
+  tap:table_index: 7
   columns:
   - name: visit
     '@id': '#Visit.visit'
@@ -8582,6 +8590,7 @@ tables:
 - name: CcdVisit
   '@id': '#CcdVisit'
   description: Defines a single detector of a visit
+  tap:table_index: 8
   columns:
   - name: ccdVisitId
     '@id': '#CcdVisit.ccdVisitId'
@@ -8764,4 +8773,3 @@ tables:
     description: Declination of lower right corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-


### PR DESCRIPTION
- Add schema description text to felis and browser blurb
- Remove "(preliminary)" from browser blurb
- Add tap table ordering indices
- Promote DP0.2 schema to top billing in browser