### PR TITLE
Update Python for build GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,12 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
 
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
       - name: Install dependencies
         id: depend
         run: pip install -r requirements.txt

--- a/tap-schema/set_schema_index
+++ b/tap-schema/set_schema_index
@@ -10,7 +10,7 @@ def set_schema_index(felis_files):
         click.echo(f"file {f}: index {idx}")
 
         with open(f) as orig_file:
-            felis_yaml = yaml.load(orig_file.read())
+            felis_yaml = yaml.safe_load(orig_file.read())
 
         felis_yaml["tap:schema_index"] = idx
 


### PR DESCRIPTION
As of earlier today, Felis requires Python 3.10.  Update version used in build GHA by adding actions/setup-python step.