### PR TITLE
DM-35333: Minor fixes to schema browser

### DIFF
--- a/browser/_layouts/schema.html
+++ b/browser/_layouts/schema.html
@@ -18,7 +18,7 @@
             <li><a href="">{{ page.title }}</a></li>
             <ul>
               {%- for table in site.data[page.schema].tables %}
-              <li><a href="{{ table['@id'] }}">{{ table['@id'] | remove:'#' }}</a></li>
+              <li><a href="{{ table['@id'] }}">{{ table.name }}</a></li>
               {%- endfor %}
             </ul>
           </ul>

--- a/browser/_layouts/schema.html
+++ b/browser/_layouts/schema.html
@@ -43,7 +43,7 @@
               <tr id="{{ col['@id'] | remove:'#' }}">
                 <td class="column-name">{{ col.name }}</td>
                 <td>{{ col.datatype }}</td>
-                <td>{{ col['fits:tunit'] }}</td>
+                <td>{{ col['ivoa:unit'] | default: col['fits:tunit'] }}</td>
                 <td>
                     {{- col.description | escape }}
                     {%- if col['ivoa:ucd'] %} [{{col['ivoa:ucd']}}]{% endif -%}

--- a/browser/dp01.md
+++ b/browser/dp01.md
@@ -4,4 +4,5 @@ title: Data Preview 0.1 Schema
 schema: dp01_dc2
 sort-index: 10
 ---
-Data Preview 0.1 includes five tables based on the DESC's Data Challenge 2 simulation of 300 square degrees of the wide-fast-deep LSST survey region after 5 years. All tables contain objects detected in coadded images.
+{%- comment %} Below pulls blurb directly from the top-level "description:" element in the schema: {% endcomment -%}
+{{ site.data[page.schema].description }}

--- a/browser/dp02.md
+++ b/browser/dp02.md
@@ -4,6 +4,5 @@ title: Data Preview 0.2 Schema
 schema: dp02_dc2
 sort-index: 9
 ---
-Data Preview 0.2 contains the image and catalog products of the Rubin Science
-Pipelines v23 processing of DESC’s Data Challenge 2 simulation, which covered 300 square
-degrees of the wide-fast-deep LSST survey region over 5 years.
+{%- comment %} Below pulls blurb directly from the top-level "description:" element in the schema: {% endcomment -%}
+{{ site.data[page.schema].description }}


### PR DESCRIPTION
Make some minor tweaks to the schema browser, motivated by DP0.2:

- Render table names in navbar based on schema `name` attribute (not `id`)
- Render blurb text from top-level schema `description` attribute if present
- Render units first from `ivoa:unit`, if present, falling back to `fits:tunit`