### PR TITLE
[DM-35254] Add generation of column lists for datalinker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,4 +44,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: datalink/datalink-snippets.zip
+          files: |
+            datalink/datalink-columns.zip
+            datalink/datalink-snippets.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site
 Gemfile
 Gemfile.lock
+datalink/columns-principal.yaml
+datalink/*.zip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Science Data Model Schemas
 ==========================
 
@@ -36,6 +35,29 @@ The schemas in this repository serve several different purposes:
    produced by the observatory's science pipelines. These files are used to
    generate the TAP_SCHEMA records that are required for serving the catalogs
    via the IVOA Table Access Protocol (TAP).
- 
 
+Release assets
+--------------
 
+Each release of `sdm_schemas` includes the following additional release
+assets, generated automatically via GitHub Actions when a new tag is created.
+   
+ * `datalink-columns.zip` contains a set of YAML files with a restricted
+   subset of the Felis schema. Currently, they identify the principal and
+   minimal columns for a subset of the tables defined by the schema in
+   this repository. Principal columns are those for which the `principal`
+   flag is set in the TAP schema, and have the meaning defined in the
+   [IVOA TAP
+   specification](https://www.ivoa.net/documents/TAP/20190927/REC-TAP-1.1.html#tth_sEc4.3).
+   Minimal columns are still experimental and in flux. These files are
+   intended for use with the
+   [datalinker](https://github.com/lsst-sqre/datalinker) service of a
+   Rubin Science Platform depoyment.
+
+ * `datalink-snippets.zip` contains a JSON manifest and a set of XML files
+   that define VOTables following the IVOA DataLink specification. This
+   release asset is intended for use with the TAP service of a Rubin
+   Science Platform deployment and is used to add DataLink records to the
+   responses from a TAP query. Those DataLink records, in turn, provide
+   links to operations that a client may wish to perform on those results,
+   such as closely-related TAP queries.

--- a/datalink/build
+++ b/datalink/build
@@ -1,3 +1,12 @@
 #!/bin/bash -ex
 
-zip datalink-snippets.zip *
+# Build a collection of configuration files for datalinker that specify the
+# principal and minimal columns for tables.  This temporarily only does
+# tap:principal and we hand-maintain a columns-minimal.yaml file until we can
+# include a new key in the Felis input files.
+python build_column_lists.py ../yml/*.yml ../yml/*.yaml \
+       > columns-principal.yaml
+zip datalink-columns.zip columns-*.yaml
+
+# Build a collection of the datalink snippets.
+zip datalink-snippets.zip *.json *.xml

--- a/datalink/build
+++ b/datalink/build
@@ -4,7 +4,7 @@
 # principal and minimal columns for tables.  This temporarily only does
 # tap:principal and we hand-maintain a columns-minimal.yaml file until we can
 # include a new key in the Felis input files.
-python build_column_lists.py ../yml/*.yml ../yml/*.yaml \
+python build_datalink_metadata.py ../yml/*.yml ../yml/*.yaml \
        > columns-principal.yaml
 zip datalink-columns.zip columns-*.yaml
 

--- a/datalink/build_column_lists.py
+++ b/datalink/build_column_lists.py
@@ -1,0 +1,102 @@
+"""From the Felis source files, build YAML of principal column names."""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Any, List
+
+import yaml
+
+
+def filter_columns(table: Dict[str, Any], filter_key: str) -> List[str]:
+    """Find the principal columns for a table.
+
+    This respects the TAP v1.1 convention for ordering of columns.  All
+    columns without ``tap:column_index`` set will be sorted after all those
+    with it set, in the order in which they appeared in the Felis file.
+
+    Parameters
+    ----------
+    table : Dict[`str`, Any]
+        Felis definition of a table.
+    filter_key : `str`
+        Felis key to use to find columns of interest.  For example, use
+        ``tap:principal`` to find principal columns.
+
+    Returns
+    -------
+    columns : List[`str`]
+        List of filtered columns in sorted order.
+    """
+    principal = []
+    unknown_column_index = 100000000
+    for column in table["columns"]:
+        if column.get(filter_key):
+            column_index = column.get("tap:column_index", unknown_column_index)
+            unknown_column_index += 1
+            principal.append((column["name"], column_index))
+    return [c[0] for c in sorted(principal, key=lambda c: c[1])]
+
+
+def build_columns(
+    felis: Dict[str, Any], column_properties: List[str]
+) -> Dict[str, Dict[str, List[str]]]:
+    """Find the list of tables with a particular Felis property.
+
+    Parameters
+    ----------
+    felis : Dict[`str`, Any]
+        The parsed Felis YAML.
+    column_properties : `str`
+        The column properties to search for.
+    """
+    schema = felis["name"]
+    output: Dict[str, Dict[str, List[str]]] = defaultdict(dict)
+    for table in felis["tables"]:
+        name = table["name"]
+        full_name = f"{schema}.{name}"
+        for column_property in column_properties:
+            columns = filter_columns(table, column_property)
+            output[full_name][column_property] = columns
+    return output
+
+
+def process_files(files: List[Path]) -> None:
+    """Process a set of Felis input files and print output to standard out.
+
+    Parameters
+    ----------
+    files : List[`pathlib.Path`]
+        List of input files.
+
+    Output
+    ------
+    The YAML version of the output format will look like this:
+
+    .. code-block:: yaml
+
+       tables:
+         dp02_dc2_catalogs.ForcedSourceOnDiaObject:
+           tap:principal:
+             - band
+             - ccdVisitId
+    """
+    tables = {}
+    for input_file in files:
+        with input_file.open("r") as fh:
+            felis = yaml.safe_load(fh)
+        tables.update(build_columns(felis, ["tap:principal"]))
+
+    # Dump the result to standard output.
+    print(yaml.dump({"tables": tables}))
+
+
+def main() -> None:
+    """Entry point."""
+    process_files([Path(f) for f in sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    main()

--- a/datalink/build_datalink_metadata.py
+++ b/datalink/build_datalink_metadata.py
@@ -1,4 +1,9 @@
-"""From the Felis source files, build YAML of principal column names."""
+"""From the Felis source files, build YAML metadata used by DataLink.
+
+Currently, this only determines principal column names.  In the future, once
+a new key has been added to Felis, it will include other column lists, and
+possibly additional metadata.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +16,7 @@ import yaml
 
 
 def filter_columns(table: Dict[str, Any], filter_key: str) -> List[str]:
-    """Find the principal columns for a table.
+    """Find the columns for a table with a given key.
 
     This respects the TAP v1.1 convention for ordering of columns.  All
     columns without ``tap:column_index`` set will be sorted after all those
@@ -94,7 +99,7 @@ def process_files(files: List[Path]) -> None:
 
 
 def main() -> None:
-    """Entry point."""
+    """Script entry point."""
     process_files([Path(f) for f in sys.argv[1:]])
 
 

--- a/datalink/columns-minimal.yaml
+++ b/datalink/columns-minimal.yaml
@@ -1,0 +1,47 @@
+tables:
+  dp01_dc2_catalogs.forced_photometry:
+    lsst:minimal: []
+  dp01_dc2_catalogs.object:
+    lsst:minimal: []
+  dp01_dc2_catalogs.position:
+    lsst:minimal: []
+  dp01_dc2_catalogs.reference:
+    lsst:minimal: []
+  dp01_dc2_catalogs.truth_match:
+    lsst:minimal: []
+  dp02_dc2_catalogs.CcdVisit:
+    lsst:minimal: []
+  dp02_dc2_catalogs.CoaddPatches:
+    lsst:minimal: []
+  dp02_dc2_catalogs.DiaObject:
+    lsst:minimal: []
+  dp02_dc2_catalogs.DiaSource:
+    lsst:minimal: []
+  dp02_dc2_catalogs.ForcedSource:
+    lsst:minimal: []
+  dp02_dc2_catalogs.ForcedSourceOnDiaObject:
+    lsst:minimal: []
+  dp02_dc2_catalogs.Object:
+    lsst:minimal: []
+  dp02_dc2_catalogs.Source:
+    lsst:minimal: []
+  dp02_dc2_catalogs.Visit:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.CcdVisit:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.DiaObject:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.DiaSource:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.ForcedSource:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.ForcedSourceOnDiaObject:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.Object:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.Source:
+    lsst:minimal: []
+  dp02_test_PREOPS863_00.Visit:
+    lsst:minimal: []
+  ivoa.ObsCore:
+    lsst:minimal: []

--- a/datalink/columns-minimal.yaml
+++ b/datalink/columns-minimal.yaml
@@ -1,3 +1,9 @@
+# Currently, there is no Felis key to mark columns as part of the "minimal"
+# set, and the definition of the "minimal" set is still in flux and a subject
+# of active experimentation.  For now, maintain it here as a separate file.
+# In the future, this is expected to be included in the output from
+# build_datalink_metadata.py, run during the build.
+
 tables:
   dp01_dc2_catalogs.forced_photometry:
     lsst:minimal: []


### PR DESCRIPTION
To support datalinker endpoints that return selected lists of
columns from tables, we want to communicate to datalinker the
list of columns with specific Felis tags in various tables.

Add a Python script that generates a YAML file of columns tagged
with tap:principal, and create a zip file as a release artifact
that can be downloaded by datalinker when it starts.

Add a placeholder columns-minimal.yaml file that will be maintained
by hand for now.