### PR TITLE
DM-36082: Full annotation of ForcedSource: UCDs, column_index, principal

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -6866,32 +6866,45 @@ tables:
     mysql:datatype: BIGINT
     description: Unique ID of forced source. Primary Key.
     fits:tunit:
+    ivoa:ucd: meta.id;meta.main
+    tap:principal: 1
+    tap:column_index: 100
   - name: objectId
     "@id": "#ForcedSource.objectId"
     datatype: long
     mysql:datatype: BIGINT
     description: Unique Object ID. Primary Key of the Object Table
     fits:tunit:
+    ivoa:ucd: meta.id
+    tap:principal: 1
+    tap:column_index: 10
   - name: parentObjectId
     "@id": "#ForcedSource.parentObjectId"
     datatype: long
     mysql:datatype: BIGINT
     description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
     fits:tunit:
+    ivoa:ucd: meta.id.parent
+    tap:principal: 0
+    tap:column_index: 130
   - name: coord_ra
     "@id": "#ForcedSource.coord_ra"
     datatype: double
     mysql:datatype: DOUBLE
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
+    description: Fiducial ICRS Right Ascension of Object centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
+    tap:principal: 0
+    tap:column_index: 110
   - name: coord_dec
     "@id": "#ForcedSource.coord_dec"
     datatype: double
     mysql:datatype: DOUBLE
-    description: Fiducial ICRS Declination of centroid used for database indexing
+    description: Fiducial ICRS Declination of Object centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
+    tap:principal: 0
+    tap:column_index: 120
   - name: skymap
     "@id": "#ForcedSource.skymap"
     datatype: char
@@ -6899,18 +6912,26 @@ tables:
     mysql:datatype: CHAR(12)
     description: Name of skymap used for coadd projection
     fits:tunit:
+    tap:principal: 0
+    tap:column_index: 160
   - name: tract
     "@id": "#ForcedSource.tract"
     datatype: long
     mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
+    ivoa:ucd: meta.id
+    tap:principal: 0
+    tap:column_index: 140
   - name: patch
     "@id": "#ForcedSource.patch"
     datatype: long
     mysql:datatype: BIGINT
     description: Skymap patch ID
     fits:tunit:
+    ivoa:ucd: meta.id.part
+    tap:principal: 0
+    tap:column_index: 150
   - name: band
     "@id": "#ForcedSource.band"
     datatype: char
@@ -6919,186 +6940,279 @@ tables:
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
     votable:arraysize: "*"
+    ivoa:ucd: meta.id;instr.filter
+    tap:principal: 1
+    tap:column_index: 20
   - name: ccdVisitId
     "@id": "#ForcedSource.ccdVisitId"
     datatype: long
     mysql:datatype: BIGINT
-    description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
+    description: Unique ID of visit and detector for which forced photometry was performed. Primary Key of the CcdVisit Table.
     fits:tunit:
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+    tap:column_index: 90
   - name: detect_isPatchInner
     "@id": "#ForcedSource.detect_isPatchInner"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd patch
     fits:tunit:
+    ivoa:ucd: meta.code
+    tap:principal: 0
+    tap:column_index: 190
   - name: detect_isPrimary
     "@id": "#ForcedSource.detect_isPrimary"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
     fits:tunit:
+    ivoa:ucd: meta.code.qual
+    tap:principal: 1
+    tap:column_index: 170
   - name: detect_isTractInner
     "@id": "#ForcedSource.detect_isTractInner"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd tract
     fits:tunit:
+    ivoa:ucd: meta.code
+    tap:principal: 0
+    tap:column_index: 180
   - name: localBackground_instFluxErr
     "@id": "#ForcedSource.localBackground_instFluxErr"
     datatype: double
     mysql:datatype: DOUBLE
-    description: 1-sigma flux uncertainty
+    description: 1-sigma uncertainty on the background in an annulus around source
     fits:tunit: count
+    ivoa:ucd: phot.count;stat.error
+    tap:principal: 0
+    tap:column_index: 410
   - name: localBackground_instFlux
     "@id": "#ForcedSource.localBackground_instFlux"
     datatype: double
     mysql:datatype: DOUBLE
     description: Background in annulus around source
     fits:tunit: count
+    ivoa:ucd: phot.count
+    tap:principal: 0
+    tap:column_index: 400
   - name: localPhotoCalibErr
     "@id": "#ForcedSource.localPhotoCalibErr"
     datatype: double
     mysql:datatype: DOUBLE
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
+    ivoa:ucd: phot.calib;stat.error
+    tap:principal: 0
+    tap:column_index: 430
   - name: localPhotoCalib_flag
     "@id": "#ForcedSource.localPhotoCalib_flag"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
+    ivoa:ucd: meta.code.qual
+    tap:principal: 0
+    tap:column_index: 440
   - name: localPhotoCalib
     "@id": "#ForcedSource.localPhotoCalib"
     datatype: double
     mysql:datatype: DOUBLE
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
+    ivoa:ucd: phot.calib
+    tap:principal: 0
+    tap:column_index: 420
   - name: localWcs_CDMatrix_1_1
     "@id": "#ForcedSource.localWcs_CDMatrix_1_1"
     datatype: double
     mysql:datatype: DOUBLE
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
+    ivoa:ucd: pos.wcs.cdmatrix
+    tap:principal: 0
+    tap:column_index: 450
   - name: localWcs_CDMatrix_1_2
     "@id": "#ForcedSource.localWcs_CDMatrix_1_2"
     datatype: double
     mysql:datatype: DOUBLE
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
+    ivoa:ucd: pos.wcs.cdmatrix
+    tap:principal: 0
+    tap:column_index: 460
   - name: localWcs_CDMatrix_2_1
     "@id": "#ForcedSource.localWcs_CDMatrix_2_1"
     datatype: double
     mysql:datatype: DOUBLE
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
+    ivoa:ucd: pos.wcs.cdmatrix
+    tap:principal: 0
+    tap:column_index: 470
   - name: localWcs_CDMatrix_2_2
     "@id": "#ForcedSource.localWcs_CDMatrix_2_2"
     datatype: double
     mysql:datatype: DOUBLE
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
+    ivoa:ucd: pos.wcs.cdmatrix
+    tap:principal: 0
+    tap:column_index: 480
   - name: localWcs_flag
     "@id": "#ForcedSource.localWcs_flag"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
+    ivoa:ucd: meta.code.qual
+    tap:principal: 0
+    tap:column_index: 490
   - name: pixelFlags_bad
     "@id": "#ForcedSource.pixelFlags_bad"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 200
   - name: pixelFlags_crCenter
     "@id": "#ForcedSource.pixelFlags_crCenter"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 220
   - name: pixelFlags_cr
     "@id": "#ForcedSource.pixelFlags_cr"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 210
   - name: pixelFlags_edge
     "@id": "#ForcedSource.pixelFlags_edge"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 230
   - name: pixelFlags_interpolatedCenter
     "@id": "#ForcedSource.pixelFlags_interpolatedCenter"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 250
   - name: pixelFlags_interpolated
     "@id": "#ForcedSource.pixelFlags_interpolated"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 240
   - name: pixelFlags_saturatedCenter
     "@id": "#ForcedSource.pixelFlags_saturatedCenter"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 270
   - name: pixelFlags_saturated
     "@id": "#ForcedSource.pixelFlags_saturated"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 260
   - name: pixelFlags_suspectCenter
     "@id": "#ForcedSource.pixelFlags_suspectCenter"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 290
   - name: pixelFlags_suspect
     "@id": "#ForcedSource.pixelFlags_suspect"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Sources footprint includes suspect pixels
     fits:tunit:
+    ivoa:ucd: meta.code.qual;instr.pixel
+    tap:principal: 0
+    tap:column_index: 280
   - name: psfDiffFluxErr
     "@id": "#ForcedSource.psfDiffFluxErr"
     datatype: double
     mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
+    ivoa:ucd: phot.flux;stat.error
+    tap:principal: 1
+    tap:column_index: 70
   - name: psfDiffFlux_flag
     "@id": "#ForcedSource.psfDiffFlux_flag"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the image difference
     fits:tunit:
+    ivoa:ucd: meta.code.qual
+    tap:principal: 0
+    tap:column_index: 80
   - name: psfDiffFlux
     "@id": "#ForcedSource.psfDiffFlux"
     datatype: double
     mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
+    ivoa:ucd: phot.flux
+    tap:principal: 1
+    tap:column_index: 60
   - name: psfFluxErr
     "@id": "#ForcedSource.psfFluxErr"
     datatype: double
     mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
+    ivoa:ucd: phot.flux;stat.error
+    tap:principal: 1
+    tap:column_index: 40
   - name: psfFlux_flag
     "@id": "#ForcedSource.psfFlux_flag"
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
+    ivoa:ucd: meta.code.qual
+    tap:principal: 0
+    tap:column_index: 50
   - name: psfFlux
     "@id": "#ForcedSource.psfFlux"
     datatype: double
     mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
+    ivoa:ucd: phot.flux
+    tap:principal: 1
+    tap:column_index: 30
 - name: DiaObject
   "@id": "#DiaObject"
   description: "Properties of time-varying astronomical objects based on association
@@ -8233,7 +8347,7 @@ tables:
     "@id": "#ForcedSourceOnDiaObject.ccdVisitId"
     datatype: long
     mysql:datatype: BIGINT
-    description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
+    description: Unique ID of visit and detector for which forced photometry was performed. Primary Key of the CcdVisit Table.
     fits:tunit:
     ivoa:ucd: meta.id;obs.image
     tap:principal: 1


### PR DESCRIPTION
Follows recent annotation of ForcedSourceOnDiaObject at the time
of its restoration to DP0.2.

Clarify description of ccdVisitId for forced photometry tables.