### PR TITLE
DM-36077: (part 2) Add an internal standardID as a workaround

### DIFF
--- a/datalink/dp02_object_to_fs_timeseries.xml
+++ b/datalink/dp02_object_to_fs_timeseries.xml
@@ -40,5 +40,6 @@
         </PARAM>
       </GROUP>
       <PARAM name="accessURL" datatype="char" arraysize="*" value="$baseUrl$/api/datalink/timeseries"/>
+      <PARAM name="standardID" datatype="char" arraysize="*" value="lsst://api.data.lsst.cloud/datalink/timeseries#v0.1"/>
     </RESOURCE>
 </VOTABLE>


### PR DESCRIPTION
Because of a bug in Firefly 2022.2.2, service descriptors without a `standardID` trigger an exception.  To work around this, we include a temporary, internal `standardID` for the timeseries service.  It is not yet clear whether this is a good
idea to do in the long term.  DataLink 1.0 suggests that this is not OK, but realistically a standardID without the `ivo:` prefix seems like a good hint that it should be ignored.

I will return to this question in the future.