### PR TITLE
Remove NCSA tap_schema container builds

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -4,8 +4,6 @@
 # values that control the presentation order of schemas.  This is respected by the Portal Aspect.
 #
 ./build mock
-./build stable ../yml/hsc.yaml ../yml/wise_01.yml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml
-./build int ../yml/hsc.yaml ../yml/wise_01.yml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml
 ./build idfprod ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml
 ./build idfint ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml
 ./build idfdev ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp02_dc2_preops-863.yaml


### PR DESCRIPTION
No reason to keep building these now, right?