### PR TITLE
DM-39309: Split DP0.3/SSO/Postgres away from DP0.2/Qserv

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -4,8 +4,9 @@
 # values that control the presentation order of schemas.  This is respected by the Portal Aspect.
 #
 ./build mock
-./build idfprod ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp03.yaml
-./build idfint ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp03.yaml
-./build idfdev ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml ../yml/dp03.yaml
+./build idfprod ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml
+./build idfint ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml
+./build idfdev ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/dp01_dc2.yaml
+./build idfsso ../yml/dp03.yaml
 ./build usdf-dev ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml ../yml/oga_live_obscore.yaml
 ./build usdf-prod ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml

--- a/yml/dp03.yaml
+++ b/yml/dp03.yaml
@@ -1,7 +1,9 @@
 ---
 name: dp03_catalogs
 "@id": "#dp03_catalogs"
-description: Data Preview 0.3 schema, focusing on Solar System products.
+description: "Data Preview 0.3 contains the catalog products of a Solar System Science
+  Collaboration simulation of the results of SSO analysis of the wide-fast-deep data
+  from the LSST ten-year dataset."
 tables:
 - name: SSObject
   "@id": "#SSObject"

--- a/yml/dp03.yaml
+++ b/yml/dp03.yaml
@@ -1,9 +1,10 @@
 ---
 name: dp03_catalogs
 "@id": "#dp03_catalogs"
-description: "Data Preview 0.3 contains the catalog products of a Solar System Science
+description: >
+  Data Preview 0.3 contains the catalog products of a Solar System Science
   Collaboration simulation of the results of SSO analysis of the wide-fast-deep data
-  from the LSST ten-year dataset."
+  from the LSST ten-year dataset.
 tables:
 - name: SSObject
   "@id": "#SSObject"


### PR DESCRIPTION
Split DP0.3/SSO/Postgres away from DP0.2/Qserv in TAP_SCHEMA builds, as these are on entirely distinct database servers.

Refine DP0.3 schema description to be stylistically a bit more like DP0.2.