### PR TITLE
[DM-40764] Set access_url to xtype clob

### DIFF
--- a/yml/dp02_obscore.yaml
+++ b/yml/dp02_obscore.yaml
@@ -128,6 +128,7 @@ tables:
     ivoa:unit:
     datatype: char
     votable:arraysize: "*"
+    votable:xtype: clob
   - name: access_format
     "@id": "ObsCore.access_format"
     description: Content format of the dataset

--- a/yml/oga_live_obscore.yaml
+++ b/yml/oga_live_obscore.yaml
@@ -116,6 +116,7 @@ tables:
     ivoa:unit:
     datatype: char
     votable:arraysize: "*"
+    votable:xtype: clob
   - name: access_format
     "@id": "ObsCore.access_format"
     description: Content format of the dataset


### PR DESCRIPTION
So there's this special datatype called clob.  You can look up the full reference here:

https://www.ivoa.net/documents/ADQL/20180112/PR-ADQL-2.1-20180112.html

Section 3.4.2

So it's just like a character type or a unicode type, but the special part with a clob is that the value is generated by the server, not just stored in a database.  This is a bit complicated but it makes sense after thinking about it for a minute.  Since the TAP service is going to be making changes to the access_url column stored in the database, it means you can't use an ADQL query through the TAP service on that column.  This is because the ADQL (SQL) query is run before the TAP server modifies the return / generates the field, then any kind of restrictions (like a LIKE) will be 'ignored'.  So by setting to this type, it should prevent queries that filter on the column, but not blocking returning that column.

clob is the type of the access_url since the TAP server will be changing the value to put the correct hostname in the URL.  That means nobody can say access_url like '%data-int.lsst.cloud%'

When a field is this type, then additional code paths are exercised in the TAP service Formatter code, where we change the host in the URL we return (but keep the path).