### PR TITLE
DM-32769: Implement streak detection and masking in AP

### DIFF
--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -1128,6 +1128,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on g-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: g_pixelFlags_streak
+    "@id": "#Object.g_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on g-band.
+    fits:tunit:
+  - name: g_pixelFlags_streakCenter
+    "@id": "#Object.g_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on g-band.
+    fits:tunit:
   - name: g_psfFlux
     "@id": "#Object.g_psfFlux"
     datatype: double
@@ -2100,6 +2112,18 @@ tables:
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on i-band.
     mysql:datatype: BOOLEAN
+    fits:tunit:
+  - name: i_pixelFlags_streak
+    "@id": "#Object.i_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on i-band.
+    fits:tunit:
+  - name: i_pixelFlags_streakCenter
+    "@id": "#Object.i_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on i-band.
     fits:tunit:
   - name: i_psfFlux
     "@id": "#Object.i_psfFlux"
@@ -3074,6 +3098,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on r-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: r_pixelFlags_streak
+    "@id": "#Object.r_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on r-band.
+    fits:tunit:
+  - name: r_pixelFlags_streakCenter
+    "@id": "#Object.r_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on r-band.
+    fits:tunit:
   - name: r_psfFlux
     "@id": "#Object.r_psfFlux"
     datatype: double
@@ -4046,6 +4082,18 @@ tables:
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on y-band.
     mysql:datatype: BOOLEAN
+    fits:tunit:
+  - name: y_pixelFlags_streak
+    "@id": "#Object.y_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on y-band.
+    fits:tunit:
+  - name: y_pixelFlags_streakCenter
+    "@id": "#Object.y_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on y-band.
     fits:tunit:
   - name: y_psfFlux
     "@id": "#Object.y_psfFlux"
@@ -5020,6 +5068,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on z-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: z_pixelFlags_streak
+    "@id": "#Object.z_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on z-band.
+    fits:tunit:
+  - name: z_pixelFlags_streakCenter
+    "@id": "#Object.z_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on z-band.
+    fits:tunit:
   - name: z_psfFlux
     "@id": "#Object.z_psfFlux"
     datatype: double
@@ -5729,6 +5789,18 @@ tables:
     datatype: boolean
     description: Sources center is close to suspect pixels
     mysql:datatype: BOOLEAN
+    fits:tunit:
+  - name: pixelFlags_streak
+    "@id": "#Source.pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint.
+    fits:tunit:
+  - name: pixelFlags_streakCenter
+    "@id": "#Source.pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center.
     fits:tunit:
   - name: psfFlux_apCorr
     "@id": "#Source.psfFlux_apCorr"

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -1138,6 +1138,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on g-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: g_pixelFlags_streak
+    "@id": "#Object.g_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on g-band.
+    fits:tunit:
+  - name: g_pixelFlags_streakCenter
+    "@id": "#Object.g_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on g-band.
+    fits:tunit:
   - name: g_psfFlux
     "@id": "#Object.g_psfFlux"
     datatype: double
@@ -2115,6 +2127,18 @@ tables:
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on i-band.
     mysql:datatype: BOOLEAN
+    fits:tunit:
+  - name: i_pixelFlags_streak
+    "@id": "#Object.i_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on i-band.
+    fits:tunit:
+  - name: i_pixelFlags_streakCenter
+    "@id": "#Object.i_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on i-band.
     fits:tunit:
   - name: i_psfFlux
     "@id": "#Object.i_psfFlux"
@@ -3094,6 +3118,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on r-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: r_pixelFlags_streak
+    "@id": "#Object.r_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on r-band.
+    fits:tunit:
+  - name: r_pixelFlags_streakCenter
+    "@id": "#Object.r_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on r-band.
+    fits:tunit:
   - name: r_psfFlux
     "@id": "#Object.r_psfFlux"
     datatype: double
@@ -4071,6 +4107,18 @@ tables:
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on u-band.
     mysql:datatype: BOOLEAN
+    fits:tunit:
+  - name: u_pixelFlags_streak
+    "@id": "#Object.u_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on u-band.
+    fits:tunit:
+  - name: u_pixelFlags_streakCenter
+    "@id": "#Object.u_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on u-band.
     fits:tunit:
   - name: u_psfFlux
     "@id": "#Object.u_psfFlux"
@@ -5050,6 +5098,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on y-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: y_pixelFlags_streak
+    "@id": "#Object.y_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on y-band.
+    fits:tunit:
+  - name: y_pixelFlags_streakCenter
+    "@id": "#Object.y_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on y-band.
+    fits:tunit:
   - name: y_psfFlux
     "@id": "#Object.y_psfFlux"
     datatype: double
@@ -6028,6 +6088,18 @@ tables:
     description: Sources center is close to suspect pixels. Measured on z-band.
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: z_pixelFlags_streak
+    "@id": "#Object.z_pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint. Measured on z-band.
+    fits:tunit:
+  - name: z_pixelFlags_streakCenter
+    "@id": "#Object.z_pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center. Measured on z-band.
+    fits:tunit:
   - name: z_psfFlux
     "@id": "#Object.z_psfFlux"
     datatype: double
@@ -6750,6 +6822,18 @@ tables:
     description: Sources center is close to suspect pixels
     mysql:datatype: BOOLEAN
     fits:tunit:
+  - name: pixelFlags_streak
+    "@id": "#Source.pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint.
+    fits:tunit:
+  - name: pixelFlags_streakCenter
+    "@id": "#Source.pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center.
+    fits:tunit:
   - name: psfFlux_apCorr
     "@id": "#Source.psfFlux_apCorr"
     datatype: double
@@ -7282,6 +7366,18 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Sources footprint includes suspect pixels
+    fits:tunit:
+  - name: pixelFlags_streak
+    "@id": "#ForcedSource.pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint.
+    fits:tunit:
+  - name: pixelFlags_streakCenter
+    "@id": "#ForcedSource.pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center.
     fits:tunit:
   - name: psfDiffFluxErr
     "@id": "#ForcedSource.psfDiffFluxErr"
@@ -8317,6 +8413,18 @@ tables:
     mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels.
     fits:tunit:
+  - name: pixelFlags_streak
+    "@id": "#DiaSource.pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint.
+    fits:tunit:
+  - name: pixelFlags_streakCenter
+    "@id": "#DiaSource.pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center.
+    fits:tunit:
   - name: psfFlux
     "@id": "#DiaSource.psfFlux"
     datatype: double
@@ -8665,6 +8773,18 @@ tables:
     datatype: boolean
     mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels
+    fits:tunit:
+  - name: pixelFlags_streak
+    "@id": "#ForcedSourceOnDiaObject.pixelFlags_streak"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source footprint.
+    fits:tunit:
+  - name: pixelFlags_streakCenter
+    "@id": "#ForcedSourceOnDiaObject.pixelFlags_streakCenter"
+    datatype: boolean
+    mysql:datatype: BOOLEAN
+    description: Streak in the Source center.
     fits:tunit:
   - name: psfDiffFlux
     "@id": "#ForcedSourceOnDiaObject.psfDiffFlux"


### PR DESCRIPTION
This PR adds streak and streakCenter pixel flags to the hsc and imsim schemas so ci_hsc and ci_imsim are happy with the new flags existing.