### PR TITLE
DM-41251: Add foreign key constraint from ForcedSource to Object

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -7213,6 +7213,15 @@ tables:
     ivoa:ucd: phot.flux
     tap:principal: 1
     tap:column_index: 30
+  constraints:
+  - name: FK_forcedSourceId_objectId
+    "@type": "ForeignKey"
+    "@id": "#FK_forcedSourceId_objectId"
+    description: Foreign key from ForcedSource to Object
+    columns:
+    - "#ForcedSource.forcedSourceId"
+    referencedColumns:
+    - "#Object.objectId"
 - name: DiaObject
   "@id": "#DiaObject"
   description: "Properties of time-varying astronomical objects based on association

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -7214,12 +7214,12 @@ tables:
     tap:principal: 1
     tap:column_index: 30
   constraints:
-  - name: FK_forcedSourceId_objectId
+  - name: Obj_FS
     "@type": "ForeignKey"
-    "@id": "#FK_forcedSourceId_objectId"
-    description: Foreign key from ForcedSource to Object
+    "@id": "#FK_ForcedSource_objectId_Object_objectId"
+    description: Link Objects to associated ForcedSources
     columns:
-    - "#ForcedSource.forcedSourceId"
+    - "#ForcedSource.objectId"
     referencedColumns:
     - "#Object.objectId"
 - name: DiaObject


### PR DESCRIPTION
This demonstrates working foreign key constraints in felis that are loaded into the TAP_SCHEMA table.

I checked that the `felis load-tap` command results in the correct data for the constraint being loaded into the TAP_SCHEMA database in MySQL.