### PR TITLE
Change mysql datatype from double to DOUBLE to fix db creation error

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -9056,7 +9056,7 @@ tables:
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: double
+    mysql:datatype: DOUBLE
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -8741,7 +8741,7 @@ tables:
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: double
+    mysql:datatype: DOUBLE
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'


### PR DESCRIPTION
This type needs to be uppercase or creating the database fails.

(I didn't create a Jira ticket for this.)