### PR TITLE
DM-41355: Fix mysql datatype errors in SDM schemas

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -9074,7 +9074,7 @@ tables:
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: double
+    mysql:datatype: DOUBLE
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -8861,7 +8861,7 @@ tables:
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: double
+    mysql:datatype: DOUBLE
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'


### PR DESCRIPTION
This replaces a few usages of "double" with "DOUBLE" that were causing DDL generation errors.