### PR TITLE
DM-41921: Fix misspelled attribute names in schemas

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -2483,7 +2483,7 @@ tables:
   mysql:charset: latin1
 - name: DiaObjectLast
   "@id": "#DiaObjectLast"
-  deescription: Table with a subset of DiaObject columns used to store only the
+  description: Table with a subset of DiaObject columns used to store only the
     latest version of each object.
   columns:
   - name: diaObjectId

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -8390,7 +8390,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunits: nmgy*asec^2
+    fits:tunit: nmgy*asec^2
   - name: IyyPSF_pixel
     '@id': '#object.IyyPSF_pixel'
     datatype: double
@@ -8398,7 +8398,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunits: nmgy*asec^2
+    fits:tunit: nmgy*asec^2
   - name: IxyPSF_pixel
     '@id': '#object.IxyPSF_pixel'
     datatype: double
@@ -8406,7 +8406,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunits: nmgy*asec^2
+    fits:tunit: nmgy*asec^2
   - name: mag_g_cModel
     '@id': '#object.mag_g_cModel'
     datatype: double

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8695,7 +8695,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#Visit.band'
     datatype: char
@@ -8704,7 +8704,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -8748,7 +8748,7 @@ tables:
     datatype: double
     description: Airmass of the observed line of sight.
     mysql:datatype: FLOAT
-    fits.tunit:
+    fits:tunit:
   - name: expTime
     '@id': '#Visit.expTime'
     datatype: double
@@ -8769,7 +8769,7 @@ tables:
     description: Midpoint time for exposure at the fiducial center of the focal plane array in MJD.
       TAI, accurate to 10ms.
     mysql:datatype: DOUBLE
-    fits.tunit: d
+    fits:tunit: d
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
@@ -8805,7 +8805,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#CcdVisit.band'
     datatype: char
@@ -8814,7 +8814,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -5483,19 +5483,19 @@ tables:
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits.tunit:
+    fits:tunit:
   - name: iyyDebiasedPSF
     "@id": "#Source.iyyDebiasedPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits.tunit:
+    fits:tunit:
   - name: ixyDebiasedPSF
     "@id": "#Source.ixyDebiasedPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits.tunit:
+    fits:tunit:
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double
@@ -6151,7 +6151,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#Visit.band'
     datatype: char
@@ -6160,7 +6160,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -6208,7 +6208,7 @@ tables:
     datatype: double
     description: Airmass of the observed line of sight.
     mysql:datatype: FLOAT
-    fits.tunit:
+    fits:tunit:
   - name: expTime
     '@id': '#Visit.expTime'
     datatype: double
@@ -6229,7 +6229,7 @@ tables:
     description: Midpoint time of the visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
     mysql:datatype: DOUBLE
-    fits.tunit: d
+    fits:tunit: d
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
@@ -6264,7 +6264,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#CcdVisit.band'
     datatype: char
@@ -6273,7 +6273,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -8936,7 +8936,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#Visit.band'
     datatype: char
@@ -8945,7 +8945,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -8993,7 +8993,7 @@ tables:
     datatype: double
     description: Airmass of the observed line of sight.
     mysql:datatype: FLOAT
-    fits.tunit:
+    fits:tunit:
   - name: expTime
     '@id': '#Visit.expTime'
     datatype: double
@@ -9014,7 +9014,7 @@ tables:
     description: Midpoint time for visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
     mysql:datatype: DOUBLE
-    fits.tunit: d
+    fits:tunit: d
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
@@ -9049,7 +9049,7 @@ tables:
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
-    fits.tunit:
+    fits:tunit:
   - name: band
     '@id': '#CcdVisit.band'
     datatype: char
@@ -9058,7 +9058,7 @@ tables:
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
-    fits.tunit:
+    fits:tunit:
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double


### PR DESCRIPTION
This fixes some trivial misspellings in schema files found using Pydantic validation.
