### PR TITLE
Fix warning message in yaml linting

### DIFF
--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only do Docker builds of ticket branches and tagged releases.
-    #if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
This adds a space after a comment to fix a warning in the yaml linting that was appearing in the Github Workflow log.