### PR TITLE
DM-42069: Fix to override the band_column for DiaSource time series query

### DIFF
--- a/datalink/dp02_diaobject_to_dias_timeseries.xml
+++ b/datalink/dp02_diaobject_to_dias_timeseries.xml
@@ -12,6 +12,9 @@
         <PARAM name="table" datatype="char" arraysize="*" value="dp02_dc2_catalogs.DiaSource">
           <DESCRIPTION>Table containing time series data</DESCRIPTION>
         </PARAM>
+        <PARAM name="band_column" datatype="char" arraysize="*" value="filterName">
+            <DESCRIPTION>Name of the filter band in time series table</DESCRIPTION>
+        </PARAM>
         <PARAM name="id_column" datatype="char" arraysize="*" value="diaObjectId">
           <DESCRIPTION>Foreign key in time series table</DESCRIPTION>
         </PARAM>


### PR DESCRIPTION
In DiaSource, the band_column is not named 'band' as in the other three source-like tables; it is called 'filterName'. This is a temporary patch for DP0.2. The column names will be made consistent in the next major revision of the DRP data model.