### PR TITLE
DM-42404: Install felis with pip using its package name instead of the Github URL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
         # required dependencies for the tap-schema build.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+http://github.com/lsst/felis.git@main#egg=lsst-felis
+          pip install lsst-felis
         working-directory: ./tap-schema
 
       - name: Log in to Docker Hub

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+http://github.com/lsst/felis.git@main#egg=lsst-felis
+          pip install lsst-felis
 
       - name: Validate YAML files
         run: felis validate ./yml/*.yaml


### PR DESCRIPTION
Felis is now available on PyPI as "lsst-felis" so change to using this instead of the Github URL.