### PR TITLE
DM-42781: Put the different time spans of the DP0.3 schema descriptions up front

### DIFF
--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -2,9 +2,9 @@
 name: dp03_catalogs_10yr
 "@id": "#dp03_catalogs_10yr"
 description: >
-  Data Preview 0.3 contains the catalog products of a Solar System Science
+  Data Preview 0.3 (ten-year version): Contains the catalog products of a Solar System Science
   Collaboration simulation of the results of SSO analysis of the wide-fast-deep data
-  from the LSST ten-year dataset.
+  from the full LSST ten-year dataset.
 tables:
 - name: SSObject
   "@id": "#SSObject"

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -2,9 +2,9 @@
 name: dp03_catalogs_1yr
 "@id": "#dp03_catalogs_1yr"
 description: >
-  Data Preview 0.3 contains the catalog products of a Solar System Science
-  Collaboration simulation of the results of SSO analysis of the wide-fast-deep data.
-  This set of tables is from analyzing only the first year of LSST observations.
+  Data Preview 0.3 (one-year version): Contains the catalog products of a Solar System Science
+  Collaboration simulation of the results of SSO analysis of the wide-fast-deep data,
+  based on analyzing only the first year of LSST observations.
 tables:
 - name: SSObject
   "@id": "#SSObject"


### PR DESCRIPTION
This change was made on a branch in August 2023 and lost in the shuffle.