### PR TITLE
DM-43009: Annotate DP0.2 Visit and CcdVisit with principal, column indices, and UCDs

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8743,6 +8743,7 @@ tables:
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
     fits:tunit:
+    ivoa:ucd: meta.id;instr.filter
     tap:principal: 0
     tap:column_index: 11
   - name: band
@@ -8754,6 +8755,7 @@ tables:
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
     fits:tunit:
+    ivoa:ucd: meta.id;instr.bandpass
     tap:principal: 1
     tap:column_index: 10
   - name: ra
@@ -8780,6 +8782,7 @@ tables:
     description: Sky rotation angle.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    ivoa:ucd: pos.posAng
     tap:principal: 1
     tap:column_index: 4
   - name: azimuth
@@ -8788,6 +8791,7 @@ tables:
     description: Azimuth of focal plane center at the middle of the exposure.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    ivoa:ucd: pos.az.azi
     tap:principal: 0
     tap:column_index: 14
   - name: altitude
@@ -8796,6 +8800,7 @@ tables:
     description: Altitude of focal plane center at the middle of the exposure.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    ivoa:ucd: pos.az.alt
     tap:principal: 0
     tap:column_index: 13
   - name: zenithDistance
@@ -8804,6 +8809,7 @@ tables:
     description: Zenith distance at the middle of the exposure.
     mysql:datatype: FLOAT
     fits:tunit: deg
+    ivoa:ucd: pos.az.zd
     tap:principal: 0
     tap:column_index: 15
   - name: airmass
@@ -8812,6 +8818,7 @@ tables:
     description: Airmass of the observed line of sight.
     mysql:datatype: FLOAT
     fits:tunit:
+    ivoa:ucd: obs.airMass
     tap:principal: 1
     tap:column_index: 12
   - name: expTime
@@ -8831,6 +8838,7 @@ tables:
     description: Midpoint time for exposure at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
     fits:tunit:
+    ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 0
     tap:column_index: 6
   - name: expMidptMJD
@@ -8850,6 +8858,7 @@ tables:
     mysql:datatype: DATETIME(6)
     description: Start time of the exposure at the fiducial center of the focal plane array,
       TAI, accurate to 10ms.
+    ivoa:ucd: time.start;obs.exposure
     tap:principal: 0
     tap:column_index: 8
   - name: obsStartMJD
@@ -8903,7 +8912,7 @@ tables:
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
     fits:tunit:
-    ivoa:ucd: meta.id;instr.filter
+    ivoa:ucd: meta.id;instr.bandpass
     tap:principal: 1
     tap:column_index: 13
   - name: ra
@@ -8930,6 +8939,7 @@ tables:
     description: Zenith distance at observation mid-point.
     mysql:datatype: FLOAT
     fits:tunit: deg
+    ivoa:ucd: pos.az.zd
     tap:principal: 1
     tap:column_index: 20
   - name: zeroPoint
@@ -8938,6 +8948,7 @@ tables:
     description: Zero-point for the Ccd, estimated at Ccd center.
     mysql:datatype: FLOAT
     fits:tunit: mag
+    ivoa:ucd: arith.zp;instr.calib
     tap:principal: 0
     tap:column_index: 17
   - name: psfSigma
@@ -8946,6 +8957,7 @@ tables:
     description: PSF model second-moments determinant radius (center of chip)
     mysql:datatype: FLOAT
     fits:tunit: pixel
+    ivoa:ucd: stat.stdev;instr.det.psf
     tap:principal: 0
     tap:column_index: 16
   - name: skyBg
@@ -8954,6 +8966,7 @@ tables:
     description: Average sky background.
     mysql:datatype: FLOAT
     fits:tunit: DN
+    ivoa:ucd: instr.skyLevel
     tap:principal: 0
     tap:column_index: 18
   - name: skyNoise
@@ -8962,6 +8975,7 @@ tables:
     description: RMS noise of the sky background.
     mysql:datatype: FLOAT
     fits:tunit: DN
+    ivoa:ucd: stat.rms;instr.skyLevel
     tap:principal: 0
     tap:column_index: 19
   - name: detector
@@ -8969,6 +8983,7 @@ tables:
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
     mysql:datatype: BIGINT
+    ivoa:ucd: meta.id.part;instr.det
     tap:principal: 1
     tap:column_index: 3
   - name: seeing
@@ -8977,6 +8992,7 @@ tables:
     description: Mean measured FWHM of the PSF.
     mysql:datatype: FLOAT
     fits:tunit: arcsec
+    ivoa:ucd: instr.obsty.seeing
     tap:principal: 1
     tap:column_index: 15
   - name: skyRotation
@@ -8985,6 +9001,7 @@ tables:
     description: Sky rotation angle.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    ivoa:ucd: pos.posAng
     tap:principal: 0
     tap:column_index: 6
   - name: expMidpt
@@ -8993,6 +9010,7 @@ tables:
     length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint for exposure. TAI, accurate to 10ms.
+    ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 0
     tap:column_index: 8
   - name: expMidptMJD
@@ -9019,6 +9037,7 @@ tables:
     length: 6
     mysql:datatype: DATETIME(6)
     description: Start of the exposure, TAI, accurate to 10ms.
+    ivoa:ucd: time.start;obs.exposure
     tap:principal: 0
     tap:column_index: 10
   - name: obsStartMJD
@@ -9036,6 +9055,7 @@ tables:
     description: Average dark current accumulation time, accurate to 10ms.
     mysql:datatype: DOUBLE
     fits:tunit: s
+    ivoa:ucd: time.duration;obs.calib.dark
     tap:principal: 0
     tap:column_index: 12
   - name: xSize
@@ -9044,6 +9064,7 @@ tables:
     description: Number of columns in the image.
     mysql:datatype: INTEGER
     fits:tunit: pixel
+    ivoa:ucd: meta.number;instr.det
     tap:principal: 0
     tap:column_index: 21
   - name: ySize
@@ -9054,13 +9075,14 @@ tables:
     fits:tunit: pixel
     tap:principal: 0
     tap:column_index: 22
+    ivoa:ucd: meta.number;instr.det
   - name: llcra
     '@id': '#CcdVisit.llcra'
     datatype: double
     description: RA of lower left corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 23
   - name: llcdec
@@ -9069,7 +9091,7 @@ tables:
     description: Declination of lower left corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 24
   - name: ulcra
@@ -9078,7 +9100,7 @@ tables:
     description: RA of upper left corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 25
   - name: ulcdec
@@ -9087,7 +9109,7 @@ tables:
     description: Declination of upper left corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 26
   - name: urcra
@@ -9096,7 +9118,7 @@ tables:
     description: RA of upper right corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 27
   - name: urcdec
@@ -9105,7 +9127,7 @@ tables:
     description: Declination of upper right corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 28
   - name: lrcra
@@ -9114,7 +9136,7 @@ tables:
     description: RA of lower right corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 29
   - name: lrcdec
@@ -9123,7 +9145,7 @@ tables:
     description: Declination of lower right corner.
     mysql:datatype: DOUBLE
     fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
     tap:column_index: 30
   constraints:

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8733,6 +8733,8 @@ tables:
     description: Unique identifier.
     mysql:datatype: INTEGER
     ivoa:ucd: meta.id;obs;meta.main
+    tap:principal: 1
+    tap:column_index: 1
   - name: physical_filter
     '@id': '#Visit.physical_filter'
     datatype: char
@@ -8741,6 +8743,8 @@ tables:
     votable:arraysize: "*"
     mysql:datatype: CHAR(32)
     fits:tunit:
+    tap:principal: 0
+    tap:column_index: 11
   - name: band
     '@id': '#Visit.band'
     datatype: char
@@ -8750,6 +8754,8 @@ tables:
     votable:arraysize: "*"
     mysql:datatype: CHAR(1)
     fits:tunit:
+    tap:principal: 1
+    tap:column_index: 10
   - name: ra
     '@id': '#Visit.ra'
     datatype: double
@@ -8757,6 +8763,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
+    tap:principal: 1
+    tap:column_index: 2
   - name: decl
     '@id': '#Visit.decl'
     datatype: double
@@ -8764,36 +8772,48 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
+    tap:principal: 1
+    tap:column_index: 3
   - name: skyRotation
     '@id': '#Visit.skyRotation'
     datatype: double
     description: Sky rotation angle.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    tap:principal: 1
+    tap:column_index: 4
   - name: azimuth
     '@id': '#Visit.azimuth'
     datatype: double
     description: Azimuth of focal plane center at the middle of the exposure.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    tap:principal: 0
+    tap:column_index: 14
   - name: altitude
     '@id': '#Visit.altitude'
     datatype: double
     description: Altitude of focal plane center at the middle of the exposure.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    tap:principal: 0
+    tap:column_index: 13
   - name: zenithDistance
     '@id': '#Visit.zenithDistance'
     datatype: double
     description: Zenith distance at the middle of the exposure.
     mysql:datatype: FLOAT
     fits:tunit: deg
+    tap:principal: 0
+    tap:column_index: 15
   - name: airmass
     '@id': '#Visit.airmass'
     datatype: double
     description: Airmass of the observed line of sight.
     mysql:datatype: FLOAT
     fits:tunit:
+    tap:principal: 1
+    tap:column_index: 12
   - name: expTime
     '@id': '#Visit.expTime'
     datatype: double
@@ -8801,6 +8821,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: s
     ivoa:ucd: time.duration;obs.exposure
+    tap:principal: 1
+    tap:column_index: 9
   - name: expMidpt
     '@id': '#Visit.expMidpt'
     datatype: timestamp
@@ -8809,6 +8831,8 @@ tables:
     description: Midpoint time for exposure at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
     fits:tunit:
+    tap:principal: 0
+    tap:column_index: 6
   - name: expMidptMJD
     '@id': '#Visit.expMidptMJD'
     datatype: double
@@ -8817,6 +8841,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch;obs.exposure
+    tap:principal: 1
+    tap:column_index: 5
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
@@ -8824,6 +8850,8 @@ tables:
     mysql:datatype: DATETIME(6)
     description: Start time of the exposure at the fiducial center of the focal plane array,
       TAI, accurate to 10ms.
+    tap:principal: 0
+    tap:column_index: 8
   - name: obsStartMJD
     '@id': '#Visit.obsStartMJD'
     datatype: double
@@ -8831,6 +8859,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.start;obs.exposure
+    tap:principal: 0
+    tap:column_index: 7
 - name: CcdVisit
   '@id': '#CcdVisit'
   description: "Metadata about the 189 individual CCD images for each Visit in the
@@ -8843,12 +8873,16 @@ tables:
     description: Primary key (unique identifier).
     mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image;meta.main
+    tap:principal: 1
+    tap:column_index: 1
   - name: visitId
     '@id': '#CcdVisit.visitId'
     datatype: long
     description: Reference to the corresponding entry in the Visit table.
     mysql:datatype: INTEGER
     ivoa:ucd: meta.id.parent;obs
+    tap:principal: 1
+    tap:column_index: 2
   - name: physical_filter
     '@id': '#CcdVisit.physical_filter'
     datatype: char
@@ -8858,6 +8892,8 @@ tables:
     mysql:datatype: CHAR(32)
     fits:tunit:
     ivoa:ucd: meta.id;instr.filter
+    tap:principal: 0
+    tap:column_index: 14
   - name: band
     '@id': '#CcdVisit.band'
     datatype: char
@@ -8868,6 +8904,8 @@ tables:
     mysql:datatype: CHAR(1)
     fits:tunit:
     ivoa:ucd: meta.id;instr.filter
+    tap:principal: 1
+    tap:column_index: 13
   - name: ra
     '@id': '#CcdVisit.ra'
     datatype: double
@@ -8875,6 +8913,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
+    tap:principal: 1
+    tap:column_index: 4
   - name: decl
     '@id': '#CcdVisit.decl'
     datatype: double
@@ -8882,59 +8922,79 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
+    tap:principal: 1
+    tap:column_index: 5
   - name: zenithDistance
     '@id': '#CcdVisit.zenithDistance'
     datatype: float
     description: Zenith distance at observation mid-point.
     mysql:datatype: FLOAT
     fits:tunit: deg
+    tap:principal: 1
+    tap:column_index: 20
   - name: zeroPoint
     '@id': '#CcdVisit.zeroPoint'
     datatype: float
     description: Zero-point for the Ccd, estimated at Ccd center.
     mysql:datatype: FLOAT
     fits:tunit: mag
+    tap:principal: 0
+    tap:column_index: 17
   - name: psfSigma
     '@id': '#CcdVisit.psfSigma'
     datatype: float
     description: PSF model second-moments determinant radius (center of chip)
     mysql:datatype: FLOAT
     fits:tunit: pixel
+    tap:principal: 0
+    tap:column_index: 16
   - name: skyBg
     '@id': '#CcdVisit.skyBg'
     datatype: float
     description: Average sky background.
     mysql:datatype: FLOAT
     fits:tunit: DN
+    tap:principal: 0
+    tap:column_index: 18
   - name: skyNoise
     '@id': '#CcdVisit.skyNoise'
     datatype: float
     description: RMS noise of the sky background.
     mysql:datatype: FLOAT
     fits:tunit: DN
+    tap:principal: 0
+    tap:column_index: 19
   - name: detector
     '@id': '#CcdVisit.detector'
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
     mysql:datatype: BIGINT
+    tap:principal: 1
+    tap:column_index: 3
   - name: seeing
     '@id': '#CcdVisit.seeing'
     datatype: double
     description: Mean measured FWHM of the PSF.
     mysql:datatype: FLOAT
     fits:tunit: arcsec
+    tap:principal: 1
+    tap:column_index: 15
   - name: skyRotation
     '@id': '#CcdVisit.skyRotation'
     datatype: double
     description: Sky rotation angle.
     mysql:datatype: DOUBLE
     fits:tunit: deg
+    tap:principal: 0
+    tap:column_index: 6
   - name: expMidpt
     '@id': '#CcdVisit.expMidpt'
     datatype: timestamp
     length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint for exposure. TAI, accurate to 10ms.
+    tap:principal: 0
+    tap:column_index: 8
   - name: expMidptMJD
     '@id': '#CcdVisit.expMidptMJD'
     datatype: double
@@ -8942,6 +9002,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch;obs.exposure
+    tap:principal: 1
+    tap:column_index: 7
   - name: expTime
     '@id': '#CcdVisit.expTime'
     datatype: double
@@ -8949,12 +9011,16 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: s
     ivoa:ucd: time.duration;obs.exposure
+    tap:principal: 1
+    tap:column_index: 11
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
     datatype: timestamp
     length: 6
     mysql:datatype: DATETIME(6)
     description: Start of the exposure, TAI, accurate to 10ms.
+    tap:principal: 0
+    tap:column_index: 10
   - name: obsStartMJD
     '@id': '#CcdVisit.obsStartMJD'
     datatype: double
@@ -8962,24 +9028,32 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.start;obs.exposure
+    tap:principal: 0
+    tap:column_index: 9
   - name: darkTime
     '@id': '#CcdVisit.darkTime'
     datatype: double
     description: Average dark current accumulation time, accurate to 10ms.
     mysql:datatype: DOUBLE
     fits:tunit: s
+    tap:principal: 0
+    tap:column_index: 12
   - name: xSize
     '@id': '#CcdVisit.xSize'
     datatype: long
     description: Number of columns in the image.
     mysql:datatype: INTEGER
     fits:tunit: pixel
+    tap:principal: 0
+    tap:column_index: 21
   - name: ySize
     '@id': '#CcdVisit.ySize'
     datatype: long
     description: Number of rows in the image.
     mysql:datatype: INTEGER
     fits:tunit: pixel
+    tap:principal: 0
+    tap:column_index: 22
   - name: llcra
     '@id': '#CcdVisit.llcra'
     datatype: double
@@ -8987,6 +9061,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
+    tap:principal: 0
+    tap:column_index: 23
   - name: llcdec
     '@id': '#CcdVisit.llcdec'
     datatype: double
@@ -8994,6 +9070,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
+    tap:principal: 0
+    tap:column_index: 24
   - name: ulcra
     '@id': '#CcdVisit.ulcra'
     datatype: double
@@ -9001,6 +9079,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
+    tap:principal: 0
+    tap:column_index: 25
   - name: ulcdec
     '@id': '#CcdVisit.ulcdec'
     datatype: double
@@ -9008,6 +9088,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
+    tap:principal: 0
+    tap:column_index: 26
   - name: urcra
     '@id': '#CcdVisit.urcra'
     datatype: double
@@ -9015,6 +9097,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
+    tap:principal: 0
+    tap:column_index: 27
   - name: urcdec
     '@id': '#CcdVisit.urcdec'
     datatype: double
@@ -9022,6 +9106,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
+    tap:principal: 0
+    tap:column_index: 28
   - name: lrcra
     '@id': '#CcdVisit.lrcra'
     datatype: double
@@ -9029,6 +9115,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
+    tap:principal: 0
+    tap:column_index: 29
   - name: lrcdec
     '@id': '#CcdVisit.lrcdec'
     datatype: double
@@ -9036,6 +9124,8 @@ tables:
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
+    tap:principal: 0
+    tap:column_index: 30
   constraints:
   - name: Visit_CcdV
     "@type": "ForeignKey"


### PR DESCRIPTION
The principal and column index annotations were determined in a pair programming session with @gpdf.

UCD assignments were based on a combination of discussion with @gpdf, comparison to other schemas, and the descriptions of valid words from the [UCD 1.5 list](https://ivoa.net/documents/UCD1+/20230125/EN-UCDlist-1.5-20230125.pdf).