### PR TITLE
DM-41063: Update docstring for DiaSource.ext_trailedSources_Naive_flag_edge

### DIFF
--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -8036,7 +8036,7 @@ tables:
   - name: trail_flag_edge
     "@id": "#DiaSource.trail_flag_edge"
     datatype: boolean
-    description: This flag is set if a trailed source extends onto or past edge pixels.
+    description: This flag is set if a trailed source contains edge pixels.
     fits:tunit:
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"


### PR DESCRIPTION
The docstring for `DiaSource.ext_trailedSources_Naive_flag_edge` has been updated to reflect that it only indicates whether or not a trailed source's endpoints contain edge pixels. Other flags pertaining to trailed sources will not be persisted at this time and are only used for filtering purposes in `filterDiaSourceCatalog.py` in `ap_association`.