### PR TITLE
DM-42993: Replace usage of "^" for exponentiation in unit definitions with "**"

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -84,7 +84,7 @@ tables:
     datatype: float
     description: Covariance between ra and dec.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: radecMjdTai
     "@id": "#DiaObject.radecMjdTai"
     datatype: double
@@ -139,21 +139,21 @@ tables:
     datatype: float
     description: Covariance of pmRa and pmDec.
     mysql:datatype: FLOAT
-    fits:tunit: "mas^2/yr^2"
+    fits:tunit: "mas**2/yr**2"
     ivoa:ucd: stat.covariance;pos.eq
   - name: pmRa_parallax_Cov
     "@id": "#DiaObject.pmRa_parallax_Cov"
     datatype: float
     description: Covariance of pmRa and parallax.
     mysql:datatype: FLOAT
-    fits:tunit: mas^2/yr
+    fits:tunit: mas**2/yr
     ivoa:ucd: stat.covariance
   - name: pmDec_parallax_Cov
     "@id": "#DiaObject.pmDec_parallax_Cov"
     datatype: float
     description: Covariance of pmDec and parallax.
     mysql:datatype: FLOAT
-    fits:tunit: mas^2/yr
+    fits:tunit: mas**2/yr
     ivoa:ucd: stat.covariance
   - name: pmParallaxLnL
     "@id": "#DiaObject.pmParallaxLnL"
@@ -1323,7 +1323,7 @@ tables:
     description: H-G12 covariance (u band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
@@ -1367,7 +1367,7 @@ tables:
     description: H-G12 covariance (g band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
@@ -1411,7 +1411,7 @@ tables:
     description: H-G12 covariance (r band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
@@ -1455,7 +1455,7 @@ tables:
     description: H-G12 covariance (i band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
@@ -1499,7 +1499,7 @@ tables:
     description: H-G12 covariance (z band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
@@ -1543,7 +1543,7 @@ tables:
     description: H-G12 covariance (y band).
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
@@ -1673,7 +1673,7 @@ tables:
     datatype: float
     description: Covariance between ra and dec.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: x
     "@id": "#DiaSource.x"
@@ -1710,7 +1710,7 @@ tables:
     datatype: float
     description: Covariance between x and y.
     mysql:datatype: FLOAT
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
     ivoa:ucd: stat.covariance
   - name: apFlux
     "@id": "#DiaSource.apFlux"
@@ -1794,7 +1794,7 @@ tables:
     datatype: float
     description: Covariance between psfRa and psfDec.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: psfLnL
     "@id": "#DiaSource.psfLnL"
@@ -2186,88 +2186,88 @@ tables:
     datatype: float
     description: Estimated sky background at the position (centroid) of the object.
     mysql:datatype: FLOAT
-    fits:tunit: nJy/arcsec^2
+    fits:tunit: nJy/arcsec**2
   - name: fpBkgdErr
     "@id": "#DiaSource.fpBkgdErr"
     datatype: float
     description: Estimated uncertainty of fpBkgd.
     mysql:datatype: FLOAT
-    fits:tunit: nJy/arcsec^2
+    fits:tunit: nJy/arcsec**2
   - name: ixx
     "@id": "#DiaSource.ixx"
     datatype: float
     description: Adaptive second moment of the source intensity.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: ixxErr
     "@id": "#DiaSource.ixxErr"
     datatype: float
     description: Uncertainty of ixx.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
     ivoa:ucd: stat.error
   - name: iyy
     "@id": "#DiaSource.iyy"
     datatype: float
     description: Adaptive second moment of the source intensity.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: iyyErr
     "@id": "#DiaSource.iyyErr"
     datatype: float
     description: Uncertainty of iyy.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
     ivoa:ucd: stat.error
   - name: ixy
     "@id": "#DiaSource.ixy"
     datatype: float
     description: Adaptive second moment of the source intensity.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: ixyErr
     "@id": "#DiaSource.ixyErr"
     datatype: float
     description: Uncertainty of ixy.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
     ivoa:ucd: stat.error
   - name: ixx_iyy_Cov
     "@id": "#DiaSource.ixx_iyy_Cov"
     datatype: float
     description: Covariance of ixx and iyy.
     mysql:datatype: FLOAT
-    fits:tunit: nJy^2*arcsec^4
+    fits:tunit: nJy**2*arcsec**4
   - name: ixx_ixy_Cov
     "@id": "#DiaSource.ixx_ixy_Cov"
     datatype: float
     description: Covariance of ixx and ixy.
     mysql:datatype: FLOAT
-    fits:tunit: nJy^2*arcsec^4
+    fits:tunit: nJy**2*arcsec**4
   - name: iyy_ixy_Cov
     "@id": "#DiaSource.iyy_ixy_Cov"
     datatype: float
     description: Covariance of iyy and ixy.
     mysql:datatype: FLOAT
-    fits:tunit: nJy^2*arcsec^4
+    fits:tunit: nJy**2*arcsec**4
   - name: ixxPSF
     "@id": "#DiaSource.ixxPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: iyyPSF
     "@id": "#DiaSource.iyyPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: ixyPSF
     "@id": "#DiaSource.ixyPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
     mysql:datatype: FLOAT
-    fits:tunit: nJy*arcsec^2
+    fits:tunit: nJy*arcsec**2
   - name: extendedness
     "@id": "#DiaSource.extendedness"
     datatype: float
@@ -2534,7 +2534,7 @@ tables:
     "@id": "#DiaObjectLast.ra_dec_Cov"
     datatype: float
     description: Covariance between ra and dec.
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: radecMjdTai
     "@id": "#DiaObjectLast.radecMjdTai"
     datatype: double
@@ -2583,19 +2583,19 @@ tables:
     datatype: float
     description: Covariance of pmRa and pmDec.
     ivoa:ucd: stat.covariance;pos.eq
-    fits:tunit: mas^2/yr^2
+    fits:tunit: mas**2/yr**2
   - name: pmRa_parallax_Cov
     "@id": "#DiaObjectLast.pmRa_parallax_Cov"
     datatype: float
     description: Covariance of pmRa and parallax.
     ivoa:ucd: stat.covariance
-    fits:tunit: mas^2/yr
+    fits:tunit: mas**2/yr
   - name: pmDec_parallax_Cov
     "@id": "#DiaObjectLast.pmDec_parallax_Cov"
     datatype: float
     description: Covariance of pmDec and parallax.
     ivoa:ucd: stat.covariance
-    fits:tunit: mas^2/yr
+    fits:tunit: mas**2/yr
   primaryKey: "#DiaObjectLast.diaObjectId"
 - name: MPCORB
   "@id": "#MPCORB"
@@ -3002,7 +3002,7 @@ tables:
     datatype: float
     description: Predicted R.A./Dec covariance
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -501,7 +501,7 @@ tables:
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_raw_child_yy
     '@id': '#reference.base_Blendedness_raw_child_yy'
     datatype: double
@@ -510,7 +510,7 @@ tables:
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_raw_child_xy
     '@id': '#reference.base_Blendedness_raw_child_xy'
     datatype: double
@@ -519,7 +519,7 @@ tables:
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_raw_parent_xx
     '@id': '#reference.base_Blendedness_raw_parent_xx'
     datatype: double
@@ -528,7 +528,7 @@ tables:
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_raw_parent_yy
     '@id': '#reference.base_Blendedness_raw_parent_yy'
     datatype: double
@@ -537,7 +537,7 @@ tables:
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_raw_parent_xy
     '@id': '#reference.base_Blendedness_raw_parent_xy'
     datatype: double
@@ -546,7 +546,7 @@ tables:
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the "raw" pixel values.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_child_xx
     '@id': '#reference.base_Blendedness_abs_child_xx'
     datatype: double
@@ -556,7 +556,7 @@ tables:
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_child_yy
     '@id': '#reference.base_Blendedness_abs_child_yy'
     datatype: double
@@ -566,7 +566,7 @@ tables:
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_child_xy
     '@id': '#reference.base_Blendedness_abs_child_xy'
     datatype: double
@@ -576,7 +576,7 @@ tables:
     description: Shape of the child, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_parent_xx
     '@id': '#reference.base_Blendedness_abs_parent_xx'
     datatype: double
@@ -586,7 +586,7 @@ tables:
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_parent_yy
     '@id': '#reference.base_Blendedness_abs_parent_yy'
     datatype: double
@@ -596,7 +596,7 @@ tables:
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_Blendedness_abs_parent_xy
     '@id': '#reference.base_Blendedness_abs_parent_xy'
     datatype: double
@@ -606,7 +606,7 @@ tables:
     description: Shape of the parent, measured with a Gaussian weight matched to the
       child.  Operates on the absolute value of the pixels to try to obtain a "de-noised"
       value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_ClassificationExtendedness_value
     '@id': '#reference.base_ClassificationExtendedness_value'
     datatype: double
@@ -856,7 +856,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_yy'
     datatype: double
@@ -864,7 +864,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_xy'
     datatype: double
@@ -872,7 +872,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMoments_flag
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag'
     datatype: boolean
@@ -936,7 +936,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmPsfMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_yy'
     datatype: double
@@ -944,7 +944,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmPsfMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_xy'
     datatype: double
@@ -952,7 +952,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmShapeRegauss_e1
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_e1'
     datatype: double
@@ -1008,7 +1008,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMomentsRound_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_yy'
     datatype: double
@@ -1016,7 +1016,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMomentsRound_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_xy'
     datatype: double
@@ -1024,7 +1024,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ext_shapeHSM_HsmSourceMomentsRound_Flux
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_Flux'
     datatype: double
@@ -1168,7 +1168,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_yy
     '@id': '#reference.base_SdssShape_yy'
     datatype: double
@@ -1176,7 +1176,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_xy
     '@id': '#reference.base_SdssShape_xy'
     datatype: double
@@ -1184,7 +1184,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_xxErr
     '@id': '#reference.base_SdssShape_xxErr'
     datatype: double
@@ -1192,7 +1192,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_yyErr
     '@id': '#reference.base_SdssShape_yyErr'
     datatype: double
@@ -1200,7 +1200,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_xyErr
     '@id': '#reference.base_SdssShape_xyErr'
     datatype: double
@@ -1208,7 +1208,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_x
     '@id': '#reference.base_SdssShape_x'
     datatype: double
@@ -1248,7 +1248,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_psf_yy
     '@id': '#reference.base_SdssShape_psf_yy'
     datatype: double
@@ -1256,7 +1256,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_psf_xy
     '@id': '#reference.base_SdssShape_psf_xy'
     datatype: double
@@ -1264,7 +1264,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: base_SdssShape_instFlux_xx_Cov
     '@id': '#reference.base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -1272,7 +1272,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: base_SdssShape_instFlux_yy_Cov
     '@id': '#reference.base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -1280,7 +1280,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: base_SdssShape_instFlux_xy_Cov
     '@id': '#reference.base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -1288,7 +1288,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: base_SdssShape_flag
     '@id': '#reference.base_SdssShape_flag'
     datatype: boolean
@@ -1475,7 +1475,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_initial_ellipse_yy
     '@id': '#reference.modelfit_CModel_initial_ellipse_yy'
     datatype: double
@@ -1483,7 +1483,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_initial_ellipse_xy
     '@id': '#reference.modelfit_CModel_initial_ellipse_xy'
     datatype: double
@@ -1491,7 +1491,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_initial_objective
     '@id': '#reference.modelfit_CModel_initial_objective'
     datatype: double
@@ -1587,7 +1587,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_exp_ellipse_yy
     '@id': '#reference.modelfit_CModel_exp_ellipse_yy'
     datatype: double
@@ -1595,7 +1595,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_exp_ellipse_xy
     '@id': '#reference.modelfit_CModel_exp_ellipse_xy'
     datatype: double
@@ -1603,7 +1603,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_exp_objective
     '@id': '#reference.modelfit_CModel_exp_objective'
     datatype: double
@@ -1699,7 +1699,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_dev_ellipse_yy
     '@id': '#reference.modelfit_CModel_dev_ellipse_yy'
     datatype: double
@@ -1707,7 +1707,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_dev_ellipse_xy
     '@id': '#reference.modelfit_CModel_dev_ellipse_xy'
     datatype: double
@@ -1715,7 +1715,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_dev_objective
     '@id': '#reference.modelfit_CModel_dev_objective'
     datatype: double
@@ -1827,7 +1827,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_ellipse_yy
     '@id': '#reference.modelfit_CModel_ellipse_yy'
     datatype: double
@@ -1835,7 +1835,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_ellipse_xy
     '@id': '#reference.modelfit_CModel_ellipse_xy'
     datatype: double
@@ -1843,7 +1843,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_initial_ellipse_xx
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xx'
     datatype: double
@@ -1852,7 +1852,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_initial_ellipse_yy
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_yy'
     datatype: double
@@ -1861,7 +1861,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_initial_ellipse_xy
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xy'
     datatype: double
@@ -1870,7 +1870,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
       applying bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_final_ellipse_xx
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xx'
     datatype: double
@@ -1879,7 +1879,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_final_ellipse_yy
     '@id': '#reference.modelfit_CModel_region_final_ellipse_yy'
     datatype: double
@@ -1888,7 +1888,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_region_final_ellipse_xy
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xy'
     datatype: double
@@ -1897,7 +1897,7 @@ tables:
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
       bad pixel mask)
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: modelfit_CModel_exp_apCorr
     '@id': '#reference.modelfit_CModel_exp_apCorr'
     datatype: double
@@ -2637,7 +2637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_yy
     '@id': '#forced_photometry.g_base_SdssShape_yy'
     datatype: double
@@ -2645,7 +2645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_xy
     '@id': '#forced_photometry.g_base_SdssShape_xy'
     datatype: double
@@ -2653,7 +2653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_xxErr
     '@id': '#forced_photometry.g_base_SdssShape_xxErr'
     datatype: double
@@ -2661,7 +2661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_yyErr
     '@id': '#forced_photometry.g_base_SdssShape_yyErr'
     datatype: double
@@ -2669,7 +2669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_xyErr
     '@id': '#forced_photometry.g_base_SdssShape_xyErr'
     datatype: double
@@ -2677,7 +2677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_x
     '@id': '#forced_photometry.g_base_SdssShape_x'
     datatype: double
@@ -2717,7 +2717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_psf_yy
     '@id': '#forced_photometry.g_base_SdssShape_psf_yy'
     datatype: double
@@ -2725,7 +2725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_psf_xy
     '@id': '#forced_photometry.g_base_SdssShape_psf_xy'
     datatype: double
@@ -2733,7 +2733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -2741,7 +2741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: g_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -2749,7 +2749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: g_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -2757,7 +2757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: g_base_SdssShape_flag
     '@id': '#forced_photometry.g_base_SdssShape_flag'
     datatype: boolean
@@ -3637,7 +3637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_yy
     '@id': '#forced_photometry.i_base_SdssShape_yy'
     datatype: double
@@ -3645,7 +3645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_xy
     '@id': '#forced_photometry.i_base_SdssShape_xy'
     datatype: double
@@ -3653,7 +3653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_xxErr
     '@id': '#forced_photometry.i_base_SdssShape_xxErr'
     datatype: double
@@ -3661,7 +3661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_yyErr
     '@id': '#forced_photometry.i_base_SdssShape_yyErr'
     datatype: double
@@ -3669,7 +3669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_xyErr
     '@id': '#forced_photometry.i_base_SdssShape_xyErr'
     datatype: double
@@ -3677,7 +3677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_x
     '@id': '#forced_photometry.i_base_SdssShape_x'
     datatype: double
@@ -3717,7 +3717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_psf_yy
     '@id': '#forced_photometry.i_base_SdssShape_psf_yy'
     datatype: double
@@ -3725,7 +3725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_psf_xy
     '@id': '#forced_photometry.i_base_SdssShape_psf_xy'
     datatype: double
@@ -3733,7 +3733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -3741,7 +3741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: i_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -3749,7 +3749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: i_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -3757,7 +3757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: i_base_SdssShape_flag
     '@id': '#forced_photometry.i_base_SdssShape_flag'
     datatype: boolean
@@ -4637,7 +4637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_yy
     '@id': '#forced_photometry.r_base_SdssShape_yy'
     datatype: double
@@ -4645,7 +4645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_xy
     '@id': '#forced_photometry.r_base_SdssShape_xy'
     datatype: double
@@ -4653,7 +4653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_xxErr
     '@id': '#forced_photometry.r_base_SdssShape_xxErr'
     datatype: double
@@ -4661,7 +4661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_yyErr
     '@id': '#forced_photometry.r_base_SdssShape_yyErr'
     datatype: double
@@ -4669,7 +4669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_xyErr
     '@id': '#forced_photometry.r_base_SdssShape_xyErr'
     datatype: double
@@ -4677,7 +4677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_x
     '@id': '#forced_photometry.r_base_SdssShape_x'
     datatype: double
@@ -4717,7 +4717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_psf_yy
     '@id': '#forced_photometry.r_base_SdssShape_psf_yy'
     datatype: double
@@ -4725,7 +4725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_psf_xy
     '@id': '#forced_photometry.r_base_SdssShape_psf_xy'
     datatype: double
@@ -4733,7 +4733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -4741,7 +4741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: r_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -4749,7 +4749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: r_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -4757,7 +4757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: r_base_SdssShape_flag
     '@id': '#forced_photometry.r_base_SdssShape_flag'
     datatype: boolean
@@ -5637,7 +5637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_yy
     '@id': '#forced_photometry.u_base_SdssShape_yy'
     datatype: double
@@ -5645,7 +5645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_xy
     '@id': '#forced_photometry.u_base_SdssShape_xy'
     datatype: double
@@ -5653,7 +5653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_xxErr
     '@id': '#forced_photometry.u_base_SdssShape_xxErr'
     datatype: double
@@ -5661,7 +5661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_yyErr
     '@id': '#forced_photometry.u_base_SdssShape_yyErr'
     datatype: double
@@ -5669,7 +5669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_xyErr
     '@id': '#forced_photometry.u_base_SdssShape_xyErr'
     datatype: double
@@ -5677,7 +5677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_x
     '@id': '#forced_photometry.u_base_SdssShape_x'
     datatype: double
@@ -5717,7 +5717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_psf_yy
     '@id': '#forced_photometry.u_base_SdssShape_psf_yy'
     datatype: double
@@ -5725,7 +5725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_psf_xy
     '@id': '#forced_photometry.u_base_SdssShape_psf_xy'
     datatype: double
@@ -5733,7 +5733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -5741,7 +5741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: u_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -5749,7 +5749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: u_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -5757,7 +5757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: u_base_SdssShape_flag
     '@id': '#forced_photometry.u_base_SdssShape_flag'
     datatype: boolean
@@ -6637,7 +6637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_yy
     '@id': '#forced_photometry.y_base_SdssShape_yy'
     datatype: double
@@ -6645,7 +6645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_xy
     '@id': '#forced_photometry.y_base_SdssShape_xy'
     datatype: double
@@ -6653,7 +6653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_xxErr
     '@id': '#forced_photometry.y_base_SdssShape_xxErr'
     datatype: double
@@ -6661,7 +6661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_yyErr
     '@id': '#forced_photometry.y_base_SdssShape_yyErr'
     datatype: double
@@ -6669,7 +6669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_xyErr
     '@id': '#forced_photometry.y_base_SdssShape_xyErr'
     datatype: double
@@ -6677,7 +6677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_x
     '@id': '#forced_photometry.y_base_SdssShape_x'
     datatype: double
@@ -6717,7 +6717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_psf_yy
     '@id': '#forced_photometry.y_base_SdssShape_psf_yy'
     datatype: double
@@ -6725,7 +6725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_psf_xy
     '@id': '#forced_photometry.y_base_SdssShape_psf_xy'
     datatype: double
@@ -6733,7 +6733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -6741,7 +6741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: y_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -6749,7 +6749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: y_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -6757,7 +6757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: y_base_SdssShape_flag
     '@id': '#forced_photometry.y_base_SdssShape_flag'
     datatype: boolean
@@ -7637,7 +7637,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_yy
     '@id': '#forced_photometry.z_base_SdssShape_yy'
     datatype: double
@@ -7645,7 +7645,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_xy
     '@id': '#forced_photometry.z_base_SdssShape_xy'
     datatype: double
@@ -7653,7 +7653,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_xxErr
     '@id': '#forced_photometry.z_base_SdssShape_xxErr'
     datatype: double
@@ -7661,7 +7661,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_yyErr
     '@id': '#forced_photometry.z_base_SdssShape_yyErr'
     datatype: double
@@ -7669,7 +7669,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_xyErr
     '@id': '#forced_photometry.z_base_SdssShape_xyErr'
     datatype: double
@@ -7677,7 +7677,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_x
     '@id': '#forced_photometry.z_base_SdssShape_x'
     datatype: double
@@ -7717,7 +7717,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_psf_yy
     '@id': '#forced_photometry.z_base_SdssShape_psf_yy'
     datatype: double
@@ -7725,7 +7725,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_psf_xy
     '@id': '#forced_photometry.z_base_SdssShape_psf_xy'
     datatype: double
@@ -7733,7 +7733,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xx_Cov'
     datatype: double
@@ -7741,7 +7741,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: z_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_yy_Cov'
     datatype: double
@@ -7749,7 +7749,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: z_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xy_Cov'
     datatype: double
@@ -7757,7 +7757,7 @@ tables:
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
-    fits:tunit: count*pixel^2
+    fits:tunit: count*pixel**2
   - name: z_base_SdssShape_flag
     '@id': '#forced_photometry.z_base_SdssShape_flag'
     datatype: boolean
@@ -8359,7 +8359,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: Iyy_pixel
     '@id': '#object.Iyy_pixel'
     datatype: double
@@ -8367,7 +8367,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: Ixy_pixel
     '@id': '#object.Ixy_pixel'
     datatype: double
@@ -8375,7 +8375,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: I_flag
     '@id': '#object.I_flag'
     datatype: boolean
@@ -8390,7 +8390,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: IyyPSF_pixel
     '@id': '#object.IyyPSF_pixel'
     datatype: double
@@ -8398,7 +8398,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: IxyPSF_pixel
     '@id': '#object.IxyPSF_pixel'
     datatype: double
@@ -8406,7 +8406,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: nmgy*arcsec^2
+    fits:tunit: nmgy*arcsec**2
   - name: mag_g_cModel
     '@id': '#object.mag_g_cModel'
     datatype: double
@@ -8858,7 +8858,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixx_pixel_i
     '@id': '#object.Ixx_pixel_i'
     datatype: double
@@ -8866,7 +8866,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixx_pixel_r
     '@id': '#object.Ixx_pixel_r'
     datatype: double
@@ -8874,7 +8874,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixx_pixel_u
     '@id': '#object.Ixx_pixel_u'
     datatype: double
@@ -8882,7 +8882,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixx_pixel_y
     '@id': '#object.Ixx_pixel_y'
     datatype: double
@@ -8890,7 +8890,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixx_pixel_z
     '@id': '#object.Ixx_pixel_z'
     datatype: double
@@ -8898,7 +8898,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_g
     '@id': '#object.Iyy_pixel_g'
     datatype: double
@@ -8906,7 +8906,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_i
     '@id': '#object.Iyy_pixel_i'
     datatype: double
@@ -8914,7 +8914,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_r
     '@id': '#object.Iyy_pixel_r'
     datatype: double
@@ -8922,7 +8922,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_u
     '@id': '#object.Iyy_pixel_u'
     datatype: double
@@ -8930,7 +8930,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_y
     '@id': '#object.Iyy_pixel_y'
     datatype: double
@@ -8938,7 +8938,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Iyy_pixel_z
     '@id': '#object.Iyy_pixel_z'
     datatype: double
@@ -8946,7 +8946,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_g
     '@id': '#object.Ixy_pixel_g'
     datatype: double
@@ -8954,7 +8954,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_i
     '@id': '#object.Ixy_pixel_i'
     datatype: double
@@ -8962,7 +8962,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_r
     '@id': '#object.Ixy_pixel_r'
     datatype: double
@@ -8970,7 +8970,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_u
     '@id': '#object.Ixy_pixel_u'
     datatype: double
@@ -8978,7 +8978,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_y
     '@id': '#object.Ixy_pixel_y'
     datatype: double
@@ -8986,7 +8986,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: Ixy_pixel_z
     '@id': '#object.Ixy_pixel_z'
     datatype: double
@@ -8994,7 +8994,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_g
     '@id': '#object.IxxPSF_pixel_g'
     datatype: double
@@ -9002,7 +9002,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_i
     '@id': '#object.IxxPSF_pixel_i'
     datatype: double
@@ -9010,7 +9010,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_r
     '@id': '#object.IxxPSF_pixel_r'
     datatype: double
@@ -9018,7 +9018,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_u
     '@id': '#object.IxxPSF_pixel_u'
     datatype: double
@@ -9026,7 +9026,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_y
     '@id': '#object.IxxPSF_pixel_y'
     datatype: double
@@ -9034,7 +9034,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxxPSF_pixel_z
     '@id': '#object.IxxPSF_pixel_z'
     datatype: double
@@ -9042,7 +9042,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_g
     '@id': '#object.IyyPSF_pixel_g'
     datatype: double
@@ -9050,7 +9050,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_i
     '@id': '#object.IyyPSF_pixel_i'
     datatype: double
@@ -9058,7 +9058,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_r
     '@id': '#object.IyyPSF_pixel_r'
     datatype: double
@@ -9066,7 +9066,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_u
     '@id': '#object.IyyPSF_pixel_u'
     datatype: double
@@ -9074,7 +9074,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_y
     '@id': '#object.IyyPSF_pixel_y'
     datatype: double
@@ -9082,7 +9082,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IyyPSF_pixel_z
     '@id': '#object.IyyPSF_pixel_z'
     datatype: double
@@ -9090,7 +9090,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_g
     '@id': '#object.IxyPSF_pixel_g'
     datatype: double
@@ -9098,7 +9098,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_i
     '@id': '#object.IxyPSF_pixel_i'
     datatype: double
@@ -9106,7 +9106,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_r
     '@id': '#object.IxyPSF_pixel_r'
     datatype: double
@@ -9114,7 +9114,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_u
     '@id': '#object.IxyPSF_pixel_u'
     datatype: double
@@ -9122,7 +9122,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_y
     '@id': '#object.IxyPSF_pixel_y'
     datatype: double
@@ -9130,7 +9130,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: IxyPSF_pixel_z
     '@id': '#object.IxyPSF_pixel_z'
     datatype: double
@@ -9138,7 +9138,7 @@ tables:
     mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: good
     '@id': '#object.good'
     datatype: boolean

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -142,19 +142,19 @@ tables:
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
     datatype: boolean
@@ -396,13 +396,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
@@ -432,13 +432,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
@@ -643,7 +643,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_gaap0p5Flux
     "@id": "#Object.g_gaap0p5Flux"
     datatype: double
@@ -841,7 +841,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
     datatype: boolean
@@ -871,73 +871,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_kronFlux
     "@id": "#Object.g_kronFlux"
     datatype: double
@@ -1358,13 +1358,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
@@ -1394,13 +1394,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
@@ -1605,7 +1605,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_gaap0p5Flux
     "@id": "#Object.i_gaap0p5Flux"
     datatype: double
@@ -1803,7 +1803,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
     datatype: boolean
@@ -1833,73 +1833,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_kronFlux
     "@id": "#Object.i_kronFlux"
     datatype: double
@@ -2320,13 +2320,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
@@ -2356,13 +2356,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
@@ -2567,7 +2567,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_gaap0p5Flux
     "@id": "#Object.r_gaap0p5Flux"
     datatype: double
@@ -2765,7 +2765,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
     datatype: boolean
@@ -2795,73 +2795,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_kronFlux
     "@id": "#Object.r_kronFlux"
     datatype: double
@@ -3282,13 +3282,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdE2
     "@id": "#Object.u_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdFluxB
     "@id": "#Object.u_bdFluxB"
     datatype: double
@@ -3318,13 +3318,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdReD
     "@id": "#Object.u_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_blendedness
     "@id": "#Object.u_blendedness"
     datatype: double
@@ -3529,7 +3529,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_gaap0p5Flux
     "@id": "#Object.u_gaap0p5Flux"
     datatype: double
@@ -3727,7 +3727,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_i_flag
     "@id": "#Object.u_i_flag"
     datatype: boolean
@@ -3757,73 +3757,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxDebiasedPSF
     "@id": "#Object.u_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxPSF
     "@id": "#Object.u_ixxPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxRound
     "@id": "#Object.u_ixxRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixy
     "@id": "#Object.u_ixy"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyDebiasedPSF
     "@id": "#Object.u_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyPSF
     "@id": "#Object.u_ixyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyRound
     "@id": "#Object.u_ixyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyy
     "@id": "#Object.u_iyy"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyDebiasedPSF
     "@id": "#Object.u_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyPSF
     "@id": "#Object.u_iyyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyRound
     "@id": "#Object.u_iyyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_kronFlux
     "@id": "#Object.u_kronFlux"
     datatype: double
@@ -4244,13 +4244,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
@@ -4280,13 +4280,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
@@ -4491,7 +4491,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_gaap0p5Flux
     "@id": "#Object.y_gaap0p5Flux"
     datatype: double
@@ -4689,7 +4689,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
     datatype: boolean
@@ -4719,73 +4719,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_kronFlux
     "@id": "#Object.y_kronFlux"
     datatype: double
@@ -5206,13 +5206,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
@@ -5242,13 +5242,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
@@ -5453,7 +5453,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_gaap0p5Flux
     "@id": "#Object.z_gaap0p5Flux"
     datatype: double
@@ -5651,7 +5651,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
     datatype: boolean
@@ -5681,73 +5681,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_kronFlux
     "@id": "#Object.z_kronFlux"
     datatype: double
@@ -6259,37 +6259,37 @@ tables:
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double

--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -103,7 +103,7 @@ tables:
     description: H-G12 covariance (u band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
@@ -147,7 +147,7 @@ tables:
     description: H-G12 covariance (g band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
@@ -191,7 +191,7 @@ tables:
     description: H-G12 covariance (r band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
@@ -235,7 +235,7 @@ tables:
     description: H-G12 covariance (i band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
@@ -279,7 +279,7 @@ tables:
     description: H-G12 covariance (z band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
@@ -323,7 +323,7 @@ tables:
     description: H-G12 covariance (y band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
@@ -445,7 +445,7 @@ tables:
     datatype: float
     description: Covariance between ra and dec.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: snr
     "@id": "#DiaSource.snr"
@@ -619,7 +619,7 @@ tables:
     datatype: float
     description: Predicted R.A./Dec covariance
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -103,7 +103,7 @@ tables:
     description: H-G12 covariance (u band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
@@ -147,7 +147,7 @@ tables:
     description: H-G12 covariance (g band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
@@ -191,7 +191,7 @@ tables:
     description: H-G12 covariance (r band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
@@ -235,7 +235,7 @@ tables:
     description: H-G12 covariance (i band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
@@ -279,7 +279,7 @@ tables:
     description: H-G12 covariance (z band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
@@ -323,7 +323,7 @@ tables:
     description: H-G12 covariance (y band)
     mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
-    fits:tunit: mag^2
+    fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
@@ -445,7 +445,7 @@ tables:
     datatype: float
     description: Covariance between ra and dec.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: snr
     "@id": "#DiaSource.snr"
@@ -610,7 +610,7 @@ tables:
     datatype: float
     description: Predicted R.A./Dec covariance
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -45,7 +45,7 @@ tables:
     datatype: float
     description: Covariance between fiducial ICRS Right Ascension and Declination of centroid.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: deblend_nChild
     "@id": "#Object.deblend_nChild"
     datatype: int
@@ -232,19 +232,19 @@ tables:
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
     datatype: boolean
@@ -478,13 +478,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
@@ -514,13 +514,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
@@ -749,7 +749,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_gaap0p7FluxErr
     "@id": "#Object.g_gaap0p7FluxErr"
     datatype: double
@@ -929,7 +929,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
     datatype: boolean
@@ -959,73 +959,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_hsm_moments_30
     "@id": "#Object.g_hsm_moments_30"
     datatype: double
@@ -1397,7 +1397,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on g-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: g_deblend_dataCoverage
     "@id": "#Object.g_deblend_dataCoverage"
     datatype: float
@@ -1613,13 +1613,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
@@ -1649,13 +1649,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
@@ -1884,7 +1884,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_gaap0p7FluxErr
     "@id": "#Object.i_gaap0p7FluxErr"
     datatype: double
@@ -2064,7 +2064,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
     datatype: boolean
@@ -2094,73 +2094,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_hsm_moments_30
     "@id": "#Object.i_hsm_moments_30"
     datatype: double
@@ -2532,7 +2532,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on i-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: i_deblend_dataCoverage
     "@id": "#Object.i_deblend_dataCoverage"
     datatype: float
@@ -2748,13 +2748,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
@@ -2784,13 +2784,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
@@ -3019,7 +3019,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_gaap0p7FluxErr
     "@id": "#Object.r_gaap0p7FluxErr"
     datatype: double
@@ -3199,7 +3199,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
     datatype: boolean
@@ -3229,73 +3229,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_hsm_moments_30
     "@id": "#Object.r_hsm_moments_30"
     datatype: double
@@ -3667,7 +3667,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on r-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: r_deblend_dataCoverage
     "@id": "#Object.r_deblend_dataCoverage"
     datatype: float
@@ -3883,13 +3883,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
@@ -3919,13 +3919,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
@@ -4154,7 +4154,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_gaap0p7FluxErr
     "@id": "#Object.y_gaap0p7FluxErr"
     datatype: double
@@ -4334,7 +4334,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
     datatype: boolean
@@ -4364,73 +4364,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_hsm_moments_30
     "@id": "#Object.y_hsm_moments_30"
     datatype: double
@@ -4802,7 +4802,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on y-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: y_deblend_dataCoverage
     "@id": "#Object.y_deblend_dataCoverage"
     datatype: float
@@ -5018,13 +5018,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
@@ -5054,13 +5054,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
@@ -5289,7 +5289,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_gaap0p7FluxErr
     "@id": "#Object.z_gaap0p7FluxErr"
     datatype: double
@@ -5469,7 +5469,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
     datatype: boolean
@@ -5499,73 +5499,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_hsm_moments_30
     "@id": "#Object.z_hsm_moments_30"
     datatype: double
@@ -5937,7 +5937,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on z-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: z_deblend_dataCoverage
     "@id": "#Object.z_deblend_dataCoverage"
     datatype: float
@@ -6059,7 +6059,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
   - name: calibFlux
     "@id": "#Source.calibFlux"
     datatype: double
@@ -6263,37 +6263,37 @@ tables:
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixxDebiasedPSF
     "@id": "#Source.ixxDebiasedPSF"
     datatype: double

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -52,7 +52,7 @@ tables:
     datatype: float
     description: Covariance between fiducial ICRS Right Ascension and Declination of centroid
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec;meta.main
   - name: deblend_nChild
     "@id": "#Object.deblend_nChild"
@@ -240,19 +240,19 @@ tables:
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
     datatype: boolean
@@ -486,13 +486,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
@@ -522,13 +522,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
@@ -759,7 +759,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_gaap0p7Flux
     "@id": "#Object.g_gaap0p7Flux"
     datatype: double
@@ -939,7 +939,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
     datatype: boolean
@@ -969,73 +969,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: g_hsm_moments_30
     "@id": "#Object.g_hsm_moments_30"
     datatype: double
@@ -1409,7 +1409,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on g-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: g_deblend_dataCoverage
     "@id": "#Object.g_deblend_dataCoverage"
@@ -1626,13 +1626,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
@@ -1662,13 +1662,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
@@ -1899,7 +1899,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_gaap0p7Flux
     "@id": "#Object.i_gaap0p7Flux"
     datatype: double
@@ -2079,7 +2079,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
     datatype: boolean
@@ -2109,73 +2109,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: i_hsm_moments_30
     "@id": "#Object.i_hsm_moments_30"
     datatype: double
@@ -2549,7 +2549,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on i-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: i_deblend_dataCoverage
     "@id": "#Object.i_deblend_dataCoverage"
@@ -2766,13 +2766,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
@@ -2802,13 +2802,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
@@ -3039,7 +3039,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_gaap0p7Flux
     "@id": "#Object.r_gaap0p7Flux"
     datatype: double
@@ -3219,7 +3219,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
     datatype: boolean
@@ -3249,73 +3249,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: r_hsm_moments_30
     "@id": "#Object.r_hsm_moments_30"
     datatype: double
@@ -3689,7 +3689,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on r-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: r_deblend_dataCoverage
     "@id": "#Object.r_deblend_dataCoverage"
@@ -3906,13 +3906,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdE2
     "@id": "#Object.u_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdFluxB
     "@id": "#Object.u_bdFluxB"
     datatype: double
@@ -3942,13 +3942,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_bdReD
     "@id": "#Object.u_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_blendedness
     "@id": "#Object.u_blendedness"
     datatype: double
@@ -4179,7 +4179,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_gaap0p7Flux
     "@id": "#Object.u_gaap0p7Flux"
     datatype: double
@@ -4359,7 +4359,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_i_flag
     "@id": "#Object.u_i_flag"
     datatype: boolean
@@ -4389,73 +4389,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxDebiasedPSF
     "@id": "#Object.u_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxPSF
     "@id": "#Object.u_ixxPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixxRound
     "@id": "#Object.u_ixxRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixy
     "@id": "#Object.u_ixy"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyDebiasedPSF
     "@id": "#Object.u_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyPSF
     "@id": "#Object.u_ixyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_ixyRound
     "@id": "#Object.u_ixyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyy
     "@id": "#Object.u_iyy"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyDebiasedPSF
     "@id": "#Object.u_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyPSF
     "@id": "#Object.u_iyyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_iyyRound
     "@id": "#Object.u_iyyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: u_hsm_moments_30
     "@id": "#Object.u_hsm_moments_30"
     datatype: double
@@ -4829,7 +4829,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on u-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: u_deblend_dataCoverage
     "@id": "#Object.u_deblend_dataCoverage"
@@ -5046,13 +5046,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
@@ -5082,13 +5082,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
@@ -5319,7 +5319,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_gaap0p7Flux
     "@id": "#Object.y_gaap0p7Flux"
     datatype: double
@@ -5499,7 +5499,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
     datatype: boolean
@@ -5529,73 +5529,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: y_hsm_moments_30
     "@id": "#Object.y_hsm_moments_30"
     datatype: double
@@ -5969,7 +5969,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on y-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: y_deblend_dataCoverage
     "@id": "#Object.y_deblend_dataCoverage"
@@ -6186,13 +6186,13 @@ tables:
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
@@ -6222,13 +6222,13 @@ tables:
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
@@ -6459,7 +6459,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_gaap0p7Flux
     "@id": "#Object.z_gaap0p7Flux"
     datatype: double
@@ -6639,7 +6639,7 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
     datatype: boolean
@@ -6669,73 +6669,73 @@ tables:
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: z_hsm_moments_30
     "@id": "#Object.z_hsm_moments_30"
     datatype: double
@@ -7109,7 +7109,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination, measured on z-band.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: z_deblend_dataCoverage
     "@id": "#Object.z_deblend_dataCoverage"
@@ -7233,7 +7233,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: decl
     "@id": "#Source.decl"
@@ -7445,55 +7445,55 @@ tables:
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixxDebiasedPSF
     "@id": "#Source.ixxDebiasedPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: iyyDebiasedPSF
     "@id": "#Source.iyyDebiasedPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: ixyDebiasedPSF
     "@id": "#Source.ixyDebiasedPSF"
     datatype: double
     description: HSM moments
     mysql:datatype: DOUBLE
-    fits:tunit: pixel^2
+    fits:tunit: pixel**2
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double
@@ -9275,37 +9275,37 @@ tables:
     datatype: double
     mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: ixxPSF
     "@id": "#DiaSource.ixxPSF"
     datatype: double
     mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: ixy
     "@id": "#DiaSource.ixy"
     datatype: double
     mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: ixyPSF
     "@id": "#DiaSource.ixyPSF"
     datatype: double
     mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: iyy
     "@id": "#DiaSource.iyy"
     datatype: double
     mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: iyyPSF
     "@id": "#DiaSource.iyyPSF"
     datatype: double
     mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
-    fits:tunit: arcsec^2
+    fits:tunit: arcsec**2
   - name: midpointMjdTai
     "@id": "#DiaSource.midpointMjdTai"
     datatype: double
@@ -9476,7 +9476,7 @@ tables:
     datatype: float
     description: Covariance between right ascension and declination.
     mysql:datatype: FLOAT
-    fits:tunit: deg^2
+    fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: shape_flag
     "@id": "#DiaSource.shape_flag"


### PR DESCRIPTION
This follows the IVOA standard for exponentiation defined here:

https://ivoa.net/documents/VOUnits/20231104/PR-VOUnits-1.1-20231104.html

Table 7 in "2.9  Mathematical expressions containing symbols" indicates that `**` should be used for "Raised to the power expr."