### PR TITLE
DM-43348: Remove UCDs for Visit.expMidpt and Visit.expMidpt in DP0.2 schema

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8838,7 +8838,6 @@ tables:
     description: Midpoint time for exposure at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
     fits:tunit:
-    ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 0
     tap:column_index: 6
   - name: expMidptMJD
@@ -9010,7 +9009,6 @@ tables:
     length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint for exposure. TAI, accurate to 10ms.
-    ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 0
     tap:column_index: 8
   - name: expMidptMJD


### PR DESCRIPTION
There is a known bug in the Science Portal which occurs when a column has a `time.epoch` UCD and a null unit string. This represents a temporary fix until that issue is resolved in Firefly.