### PR TITLE
DM-42935: Configure Felis logging to only print errors in tap-schema workflow

### DIFF
--- a/tap-schema/build
+++ b/tap-schema/build
@@ -10,7 +10,7 @@ shift
 # copied into the docker image.
 for file in $@
 do
-    felis load-tap --dry-run --engine-url=postgresql+psycopg2:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
+    felis --log-level ERROR load-tap  --dry-run --engine-url=postgresql:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
 done
 
 # Build and push docker images


### PR DESCRIPTION
Since all print outs from the Felis command are being redirected to a file which is supposed to contain only the DDL, log messages need to be suppressed unless they represent errors.