### PR TITLE
Add missing length values for several DP0.2 columns

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8087,6 +8087,7 @@ tables:
   - name: filterName
     "@id": "#DiaSource.filterName"
     datatype: char
+    length: 1
     mysql:datatype: CHAR(1)
     description: Band used to take this observation
     fits:tunit:
@@ -9283,6 +9284,7 @@ tables:
   - name: id_truth_type
     '@id': '#MatchesTruth.id_truth_type'
     datatype: char
+    length: 18
     mysql:datatype: CHAR(18)
     tap:column_index: 2
     tap:principal: 1
@@ -9343,6 +9345,7 @@ tables:
   - name: id_truth_type
     '@id': '#TruthSummary.id_truth_type'
     datatype: char
+    length: 22
     mysql:datatype: CHAR(22)
     tap:column_index: 0
     tap:principal: 1

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -9260,6 +9260,7 @@ tables:
   - name: band
     "@id": "#DiaSource.band"
     datatype: char
+    length: 1
     mysql:datatype: CHAR(1)
     description: Band used to take this observation.
     fits:tunit:


### PR DESCRIPTION
These length values were copied from the Qserv v12 ingest files. There is a mysql override for these lines, but Felis still requires a `length` field due to how its type system works.