### PR TITLE
DM-43748: Add missing length fields to a few columns

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8087,6 +8087,7 @@ tables:
   - name: filterName
     "@id": "#DiaSource.filterName"
     datatype: char
+    length: 1
     mysql:datatype: CHAR(1)
     description: Band used to take this observation
     fits:tunit:
@@ -9283,6 +9284,7 @@ tables:
   - name: id_truth_type
     '@id': '#MatchesTruth.id_truth_type'
     datatype: char
+    length: 18
     mysql:datatype: CHAR(18)
     tap:column_index: 2
     tap:principal: 1
@@ -9343,6 +9345,7 @@ tables:
   - name: id_truth_type
     '@id': '#TruthSummary.id_truth_type'
     datatype: char
+    length: 22
     mysql:datatype: CHAR(22)
     tap:column_index: 0
     tap:principal: 1

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -9260,6 +9260,7 @@ tables:
   - name: band
     "@id": "#DiaSource.band"
     datatype: char
+    length: 1
     mysql:datatype: CHAR(1)
     description: Band used to take this observation.
     fits:tunit:


### PR DESCRIPTION
A few columns in DP0.2 and imsim were missing the length field. There are MySQL type overrides that include the length but these are not propagated to Felis's internal type engine.

The DP0.2 lengths were copied from the `mysql:datatype` and verified against the values for the corresponding columns in the Qserv ingest files.

The imsim length was also taken from the `mysql:datatype` value.