### PR TITLE
Remove extraneous whitespace from a few description fields

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -1990,7 +1990,7 @@ tables:
   - name: dipoleRa
     "@id": "#DiaSource.dipoleRa"
     datatype: double
-    description: " Right ascension coordinate of centroid for dipole model."
+    description: "Right ascension coordinate of centroid for dipole model."
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
@@ -2004,7 +2004,7 @@ tables:
   - name: dipoleDec
     "@id": "#DiaSource.dipoleDec"
     datatype: double
-    description: " Declination coordinate of centroid for dipole model."
+    description: "Declination coordinate of centroid for dipole model."
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec

--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -1,10 +1,9 @@
 ---
 name: dp03_catalogs_10yr
 "@id": "#dp03_catalogs_10yr"
-description: >
-  Data Preview 0.3 (ten-year version): Contains the catalog products of a Solar System Science
+description: "Data Preview 0.3 (ten-year version): Contains the catalog products of a Solar System Science
   Collaboration simulation of the results of SSO analysis of the wide-fast-deep data
-  from the full LSST ten-year dataset.
+  from the full LSST ten-year dataset."
 tables:
 - name: SSObject
   "@id": "#SSObject"
@@ -429,7 +428,7 @@ tables:
   - name: dec
     "@id": "#DiaSource.dec"
     datatype: double
-    description: " Dec-coordinate of the center of this diaSource."
+    description: "Dec-coordinate of the center of this diaSource."
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -1,10 +1,9 @@
 ---
 name: dp03_catalogs_1yr
 "@id": "#dp03_catalogs_1yr"
-description: >
-  Data Preview 0.3 (one-year version): Contains the catalog products of a Solar System Science
+description: "Data Preview 0.3 (one-year version): Contains the catalog products of a Solar System Science
   Collaboration simulation of the results of SSO analysis of the wide-fast-deep data,
-  based on analyzing only the first year of LSST observations.
+  based on analyzing only the first year of LSST observations."
 tables:
 - name: SSObject
   "@id": "#SSObject"
@@ -429,7 +428,7 @@ tables:
   - name: dec
     "@id": "#DiaSource.dec"
     datatype: double
-    description: " Dec-coordinate of the center of this diaSource."
+    description: "Dec-coordinate of the center of this diaSource."
     mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec


### PR DESCRIPTION
Remove erroneous prepending spaces from a few column descriptions.

Fix a few schema descriptions that were using an unnecessary prepending `>` character that was adding an unwanted newline. Those descriptions can just be double-quoted instead.