### PR TITLE
DM-43716: Remove all redundant mysql:datatype type overrides for Felis numerics

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -33,7 +33,6 @@ tables:
     datatype: long
     nullable: false
     description: Unique identifier of this DiaObject.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: validityStart
     "@id": "#DiaObject.validityStart"
@@ -54,14 +53,12 @@ tables:
     datatype: double
     nullable: false
     description: Right ascension coordinate of the position of the object at time radecMjdTai.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: raErr
     "@id": "#DiaObject.raErr"
     datatype: float
     description: Uncertainty of ra.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: dec
@@ -69,90 +66,77 @@ tables:
     datatype: double
     nullable: false
     description: Declination coordinate of the position of the object at time radecMjdTai.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: decErr
     "@id": "#DiaObject.decErr"
     datatype: float
     description: Uncertainty of dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: ra_dec_Cov
     "@id": "#DiaObject.ra_dec_Cov"
     datatype: float
     description: Covariance between ra and dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: radecMjdTai
     "@id": "#DiaObject.radecMjdTai"
     datatype: double
     description: Time at which the object was at a position ra/dec, expressed
       as Modified Julian Date, International Atomic Time.
-    mysql:datatype: DOUBLE
     ivoa:ucd: time.epoch
   - name: pmRa
     "@id": "#DiaObject.pmRa"
     datatype: float
     description: Proper motion in right ascension.
-    mysql:datatype: FLOAT
     fits:tunit: mas/yr
     ivoa:ucd: pos.pm
   - name: pmRaErr
     "@id": "#DiaObject.pmRaErr"
     datatype: float
     description: Uncertainty of pmRa.
-    mysql:datatype: FLOAT
     fits:tunit: mas/yr
     ivoa:ucd: stat.error;pos.pm
   - name: pmDec
     "@id": "#DiaObject.pmDec"
     datatype: float
     description: Proper motion of declination.
-    mysql:datatype: FLOAT
     fits:tunit: mas/yr
     ivoa:ucd: pos.pm
   - name: pmDecErr
     "@id": "#DiaObject.pmDecErr"
     datatype: float
     description: Uncertainty of pmDec.
-    mysql:datatype: FLOAT
     fits:tunit: mas/yr
     ivoa:ucd: stat.error;pos.pm
   - name: parallax
     "@id": "#DiaObject.parallax"
     datatype: float
     description: Parallax.
-    mysql:datatype: FLOAT
     fits:tunit: mas
     ivoa:ucd: pos.parallax
   - name: parallaxErr
     "@id": "#DiaObject.parallaxErr"
     datatype: float
     description: Uncertainty of parallax.
-    mysql:datatype: FLOAT
     fits:tunit: mas
     ivoa:ucd: stat.error;pos.parallax
   - name: pmRa_pmDec_Cov
     "@id": "#DiaObject.pmRa_pmDec_Cov"
     datatype: float
     description: Covariance of pmRa and pmDec.
-    mysql:datatype: FLOAT
     fits:tunit: "mas**2/yr**2"
     ivoa:ucd: stat.covariance;pos.eq
   - name: pmRa_parallax_Cov
     "@id": "#DiaObject.pmRa_parallax_Cov"
     datatype: float
     description: Covariance of pmRa and parallax.
-    mysql:datatype: FLOAT
     fits:tunit: mas**2/yr
     ivoa:ucd: stat.covariance
   - name: pmDec_parallax_Cov
     "@id": "#DiaObject.pmDec_parallax_Cov"
     datatype: float
     description: Covariance of pmDec and parallax.
-    mysql:datatype: FLOAT
     fits:tunit: mas**2/yr
     ivoa:ucd: stat.covariance
   - name: pmParallaxLnL
@@ -160,335 +144,284 @@ tables:
     datatype: float
     description: Natural log of the likelihood of the linear proper motion parallax
       fit.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.likelihood
   - name: pmParallaxChi2
     "@id": "#DiaObject.pmParallaxChi2"
     datatype: float
     description: Chi^2 static of the model fit.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: pmParallaxNdata
     "@id": "#DiaObject.pmParallaxNdata"
     datatype: int
     description: The number of data points used to fit the model.
-    mysql:datatype: INTEGER
   - name: u_psfFluxMean
     "@id": "#DiaObject.u_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for u filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: u_psfFluxMeanErr
     "@id": "#DiaObject.u_psfFluxMeanErr"
     datatype: float
     description: Standard error of u_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: u_psfFluxSigma
     "@id": "#DiaObject.u_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of u_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: u_psfFluxChi2
     "@id": "#DiaObject.u_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of u_psfFlux around u_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: u_psfFluxNdata
     "@id": "#DiaObject.u_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute u_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: u_fpFluxMean
     "@id": "#DiaObject.u_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for u filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: u_fpFluxMeanErr
     "@id": "#DiaObject.u_fpFluxMeanErr"
     datatype: float
     description: Standard error of u_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: u_fpFluxSigma
     "@id": "#DiaObject.u_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of u_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: g_psfFluxMean
     "@id": "#DiaObject.g_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for g filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: g_psfFluxMeanErr
     "@id": "#DiaObject.g_psfFluxMeanErr"
     datatype: float
     description: Standard error of g_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: g_psfFluxSigma
     "@id": "#DiaObject.g_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of g_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: g_psfFluxChi2
     "@id": "#DiaObject.g_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of g_psfFlux around g_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: g_psfFluxNdata
     "@id": "#DiaObject.g_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute g_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: g_fpFluxMean
     "@id": "#DiaObject.g_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for g filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: g_fpFluxMeanErr
     "@id": "#DiaObject.g_fpFluxMeanErr"
     datatype: float
     description: Standard error of g_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: g_fpFluxSigma
     "@id": "#DiaObject.g_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of g_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: r_psfFluxMean
     "@id": "#DiaObject.r_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for r filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: r_psfFluxMeanErr
     "@id": "#DiaObject.r_psfFluxMeanErr"
     datatype: float
     description: Standard error of r_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: r_psfFluxSigma
     "@id": "#DiaObject.r_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of r_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: r_psfFluxChi2
     "@id": "#DiaObject.r_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of r_psfFlux around r_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: r_psfFluxNdata
     "@id": "#DiaObject.r_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute r_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: r_fpFluxMean
     "@id": "#DiaObject.r_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for r filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: r_fpFluxMeanErr
     "@id": "#DiaObject.r_fpFluxMeanErr"
     datatype: float
     description: Standard error of r_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: r_fpFluxSigma
     "@id": "#DiaObject.r_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of r_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: i_psfFluxMean
     "@id": "#DiaObject.i_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for i filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: i_psfFluxMeanErr
     "@id": "#DiaObject.i_psfFluxMeanErr"
     datatype: float
     description: Standard error of i_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: i_psfFluxSigma
     "@id": "#DiaObject.i_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of i_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: i_psfFluxChi2
     "@id": "#DiaObject.i_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of i_psfFlux around i_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: i_psfFluxNdata
     "@id": "#DiaObject.i_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute i_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: i_fpFluxMean
     "@id": "#DiaObject.i_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for i filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: i_fpFluxMeanErr
     "@id": "#DiaObject.i_fpFluxMeanErr"
     datatype: float
     description: Standard error of i_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: i_fpFluxSigma
     "@id": "#DiaObject.i_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of i_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: z_psfFluxMean
     "@id": "#DiaObject.z_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for z filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: z_psfFluxMeanErr
     "@id": "#DiaObject.z_psfFluxMeanErr"
     datatype: float
     description: Standard error of z_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: z_psfFluxSigma
     "@id": "#DiaObject.z_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of z_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: z_psfFluxChi2
     "@id": "#DiaObject.z_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of z_psfFlux around z_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: z_psfFluxNdata
     "@id": "#DiaObject.z_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute z_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: z_fpFluxMean
     "@id": "#DiaObject.z_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for z filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: z_fpFluxMeanErr
     "@id": "#DiaObject.z_fpFluxMeanErr"
     datatype: float
     description: Standard error of z_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: z_fpFluxSigma
     "@id": "#DiaObject.z_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of z_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: y_psfFluxMean
     "@id": "#DiaObject.y_psfFluxMean"
     datatype: float
     description: Weighted mean point-source model magnitude for y filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: y_psfFluxMeanErr
     "@id": "#DiaObject.y_psfFluxMeanErr"
     datatype: float
     description: Standard error of y_psfFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: y_psfFluxSigma
     "@id": "#DiaObject.y_psfFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of y_psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: y_psfFluxChi2
     "@id": "#DiaObject.y_psfFluxChi2"
     datatype: float
     description: Chi^2 statistic for the scatter of y_psfFlux around y_psfFluxMean.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: y_psfFluxNdata
     "@id": "#DiaObject.y_psfFluxNdata"
     datatype: int
     description: The number of data points used to compute y_psfFluxChi2.
-    mysql:datatype: INTEGER
   - name: y_fpFluxMean
     "@id": "#DiaObject.y_fpFluxMean"
     datatype: float
     description: Weighted mean forced photometry flux for y filter.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: y_fpFluxMeanErr
     "@id": "#DiaObject.y_fpFluxMeanErr"
     datatype: float
     description: Standard error of y_fpFluxMean.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: y_fpFluxSigma
     "@id": "#DiaObject.y_fpFluxSigma"
     datatype: float
     description: Standard deviation of the distribution of y_fpFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.stdev
   - name: u_lcPeriodic
@@ -579,89 +512,74 @@ tables:
     "@id": "#DiaObject.nearbyObj1"
     datatype: long
     description: Id of the closest nearby object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyObj1Dist
     "@id": "#DiaObject.nearbyObj1Dist"
     datatype: float
     description: Distance to nearbyObj1.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: nearbyObj1LnP
     "@id": "#DiaObject.nearbyObj1LnP"
     datatype: float
     description: Natural log of the probability that the observed diaObject is the
       same as the nearbyObj1.
-    mysql:datatype: FLOAT
   - name: nearbyObj2
     "@id": "#DiaObject.nearbyObj2"
     datatype: long
     description: Id of the second-closest nearby object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyObj2Dist
     "@id": "#DiaObject.nearbyObj2Dist"
     datatype: float
     description: Distance to nearbyObj2.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: nearbyObj2LnP
     "@id": "#DiaObject.nearbyObj2LnP"
     datatype: float
     description: Natural log of the probability that the observed diaObject is the
       same as the nearbyObj2.
-    mysql:datatype: FLOAT
   - name: nearbyObj3
     "@id": "#DiaObject.nearbyObj3"
     datatype: long
     description: Id of the third-closest nearby object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyObj3Dist
     "@id": "#DiaObject.nearbyObj3Dist"
     datatype: float
     description: Distance to nearbyObj3.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: nearbyObj3LnP
     "@id": "#DiaObject.nearbyObj3LnP"
     datatype: float
     description: Natural log of the probability that the observed diaObject is the
       same as the nearbyObj3.
-    mysql:datatype: FLOAT
   - name: nearbyExtObj1
     "@id": "#DiaObject.nearbyExtObj1"
     datatype: long
     description: Id of the closest extended DR Object by second moment-based separation.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyExtObj1Sep
     "@id": "#DiaObject.nearbyExtObj1Sep"
     datatype: float
     description: Second moment-based separation of nearbyExtObj1 (unitless).
-    mysql:datatype: FLOAT
   - name: nearbyExtObj2
     "@id": "#DiaObject.nearbyExtObj2"
     datatype: long
     description: Id of the second closest extended DR Object by second moment-based separation.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyExtObj2Sep
     "@id": "#DiaObject.nearbyExtObj2Sep"
     datatype: float
     description: Second moment-based separation of nearbyExtObj2 (unitless).
-    mysql:datatype: FLOAT
   - name: nearbyExtObj3
     "@id": "#DiaObject.nearbyExtObj3"
     datatype: long
     description: Id of the third closest extended DR Object by second moment-based separation.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nearbyExtObj3Sep
     "@id": "#DiaObject.nearbyExtObj3Sep"
     datatype: float
     description: Second moment-based separation of nearbyExtObj3 (unitless).
-    mysql:datatype: FLOAT
   - name: nearbyLowzGal
     "@id": "#DiaObject.nearbyLowzGal"
     datatype: string
@@ -673,7 +591,6 @@ tables:
     datatype: float
     fits:tunit: arcsec
     description: Separation distance of nearbyLowzGal.
-    mysql:datatype: FLOAT
   - name: u_scienceFluxMean
     "@id": "#DiaObject.u_scienceFluxMean"
     datatype: float
@@ -1195,7 +1112,6 @@ tables:
     nullable: false
     value: "0"
     description: Flags, bitwise OR tbd.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
   - name: lastNonForcedSource
     "@id": "#DiaObject.lastNonForcedSource"
@@ -1233,7 +1149,6 @@ tables:
     nullable: false
     autoincrement: false
     description: Unique identifier.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: discoverySubmissionDate
     "@id": "#SSObject.discoverySubmissionDate"
@@ -1241,26 +1156,22 @@ tables:
     description: The date the LSST first linked and submitted the discovery observations
       to the MPC. May be NULL if not an LSST discovery. The date format will follow
       general LSST conventions (MJD TAI, at the moment).
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: firstObservationDate
     "@id": "#SSObject.firstObservationDate"
     datatype: double
     description: The time of the first LSST observation of this object (could be precovered)
       as Modified Julian Date, International Atomic Time.
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: arc
     "@id": "#SSObject.arc"
     datatype: float
     description: Arc of LSST observations.
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: numObs
     "@id": "#SSObject.numObs"
     datatype: int
     description: Number of LSST observations of this object.
-    mysql:datatype: INTEGER
   - name: lcPeriodic
     "@id": "#SSObject.lcPeriodic"
     datatype: binary
@@ -1272,312 +1183,262 @@ tables:
     "@id": "#SSObject.MOID"
     datatype: float
     description: Minimum orbit intersection distance to Earth.
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: MOIDTrueAnomaly
     "@id": "#SSObject.MOIDTrueAnomaly"
     datatype: float
     description: True anomaly of the MOID point.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDEclipticLongitude
     "@id": "#SSObject.MOIDEclipticLongitude"
     datatype: float
     description: Ecliptic longitude of the MOID point.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDDeltaV
     "@id": "#SSObject.MOIDDeltaV"
     datatype: float
     description: DeltaV at the MOID point.
-    mysql:datatype: FLOAT
     fits:tunit: km/s
   - name: u_H
     "@id": "#SSObject.u_H"
     datatype: float
     description: Best fit absolute magnitude (u band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_G12
     "@id": "#SSObject.u_G12"
     datatype: float
     description: Best fit G12 slope parameter (u band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_HErr
     "@id": "#SSObject.u_HErr"
     datatype: float
     description: Uncertainty of H (u band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_G12Err
     "@id": "#SSObject.u_G12Err"
     datatype: float
     description: Uncertainty of G12 (u band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_H_u_G12_Cov
     "@id": "#SSObject.u_H_u_G12_Cov"
     datatype: float
     description: H-G12 covariance (u band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (u band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: u_Ndata
     "@id": "#SSObject.u_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (u band).
-    mysql:datatype: INTEGER
   - name: g_H
     "@id": "#SSObject.g_H"
     datatype: float
     description: Best fit absolute magnitude (g band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_G12
     "@id": "#SSObject.g_G12"
     datatype: float
     description: Best fit G12 slope parameter (g band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_HErr
     "@id": "#SSObject.g_HErr"
     datatype: float
     description: Uncertainty of H (g band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_G12Err
     "@id": "#SSObject.g_G12Err"
     datatype: float
     description: Uncertainty of G12 (g band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_H_g_G12_Cov
     "@id": "#SSObject.g_H_g_G12_Cov"
     datatype: float
     description: H-G12 covariance (g band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (g band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: g_Ndata
     "@id": "#SSObject.g_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (g band).
-    mysql:datatype: INTEGER
   - name: r_H
     "@id": "#SSObject.r_H"
     datatype: float
     description: Best fit absolute magnitude (r band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_G12
     "@id": "#SSObject.r_G12"
     datatype: float
     description: Best fit G12 slope parameter (r band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_HErr
     "@id": "#SSObject.r_HErr"
     datatype: float
     description: Uncertainty of H (r band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_G12Err
     "@id": "#SSObject.r_G12Err"
     datatype: float
     description: Uncertainty of G12 (r band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_H_r_G12_Cov
     "@id": "#SSObject.r_H_r_G12_Cov"
     datatype: float
     description: H-G12 covariance (r band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (r band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: r_Ndata
     "@id": "#SSObject.r_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (r band).
-    mysql:datatype: INTEGER
   - name: i_H
     "@id": "#SSObject.i_H"
     datatype: float
     description: Best fit absolute magnitude (i band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_G12
     "@id": "#SSObject.i_G12"
     datatype: float
     description: Best fit G12 slope parameter (i band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_HErr
     "@id": "#SSObject.i_HErr"
     datatype: float
     description: Uncertainty of H (i band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_G12Err
     "@id": "#SSObject.i_G12Err"
     datatype: float
     description: Uncertainty of G12 (i band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_H_i_G12_Cov
     "@id": "#SSObject.i_H_i_G12_Cov"
     datatype: float
     description: H-G12 covariance (i band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (i band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: i_Ndata
     "@id": "#SSObject.i_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (i band).
-    mysql:datatype: INTEGER
   - name: z_H
     "@id": "#SSObject.z_H"
     datatype: float
     description: Best fit absolute magnitude (z band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_G12
     "@id": "#SSObject.z_G12"
     datatype: float
     description: Best fit G12 slope parameter (z band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_HErr
     "@id": "#SSObject.z_HErr"
     datatype: float
     description: Uncertainty of H (z band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_G12Err
     "@id": "#SSObject.z_G12Err"
     datatype: float
     description: Uncertainty of G12 (z band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_H_z_G12_Cov
     "@id": "#SSObject.z_H_z_G12_Cov"
     datatype: float
     description: H-G12 covariance (z band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (z band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: z_Ndata
     "@id": "#SSObject.z_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (z band).
-    mysql:datatype: INTEGER
   - name: y_H
     "@id": "#SSObject.y_H"
     datatype: float
     description: Best fit absolute magnitude (y band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_G12
     "@id": "#SSObject.y_G12"
     datatype: float
     description: Best fit G12 slope parameter (y band).
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_HErr
     "@id": "#SSObject.y_HErr"
     datatype: float
     description: Uncertainty of H (y band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_G12Err
     "@id": "#SSObject.y_G12Err"
     datatype: float
     description: Uncertainty of G12 (y band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_H_y_G12_Cov
     "@id": "#SSObject.y_H_y_G12_Cov"
     datatype: float
     description: H-G12 covariance (y band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (y band).
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: y_Ndata
     "@id": "#SSObject.y_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (y band).
-    mysql:datatype: INTEGER
   - name: maxExtendedness
     "@id": "#SSObject.maxExtendedness"
     datatype: float
     description: maximum `extendedness` value from the DIASource.
-    mysql:datatype: FLOAT
   - name: minExtendedness
     "@id": "#SSObject.minExtendedness"
     datatype: float
     description: minimum `extendedness` value from the DIASource.
-    mysql:datatype: FLOAT
   - name: medianExtendedness
     "@id": "#SSObject.medianExtendedness"
     datatype: float
     description: median `extendedness` value from the DIASource.
-    mysql:datatype: FLOAT
   - name: flags
     "@id": "#SSObject.flags"
     datatype: long
     nullable: false
     description: Flags, bitwise OR tbd.
     value: "0"
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
 - name: DiaSource
   "@id": "#DiaSource"
@@ -1590,14 +1451,12 @@ tables:
     nullable: false
     autoincrement: false
     description: Unique identifier of this DiaSource.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: ccdVisitId
     "@id": "#DiaSource.ccdVisitId"
     datatype: long
     nullable: false
     description: Id of the ccdVisit where this diaSource was measured.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: diaObjectId
     "@id": "#DiaSource.diaObjectId"
@@ -1606,7 +1465,6 @@ tables:
     description: Id of the diaObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: ssObjectId
     "@id": "#DiaSource.ssObjectId"
@@ -1615,14 +1473,12 @@ tables:
     description: Id of the ssObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: parentDiaSourceId
     "@id": "#DiaSource.parentDiaSourceId"
     datatype: long
     description: Id of the parent diaSource this diaSource has been deblended from,
       if any.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
@@ -1637,7 +1493,6 @@ tables:
     nullable: false
     description: Effective mid-visit time for this diaSource, expressed as Modified
       Julian Date, International Atomic Time.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch
   - name: ra
@@ -1645,14 +1500,12 @@ tables:
     datatype: double
     nullable: false
     description: Right ascension coordinate of the center of this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: raErr
     "@id": "#DiaSource.raErr"
     datatype: float
     description: Uncertainty of ra.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: dec
@@ -1660,21 +1513,18 @@ tables:
     datatype: double
     nullable: false
     description: Declination coordinate of the center of this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: decErr
     "@id": "#DiaSource.decErr"
     datatype: float
     description: Uncertainty of dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: ra_dec_Cov
     "@id": "#DiaSource.ra_dec_Cov"
     datatype: float
     description: Covariance between ra and dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: x
@@ -1682,14 +1532,12 @@ tables:
     datatype: float
     nullable: false
     description: x position computed by a centroiding algorithm.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: pos.cartesian.x
   - name: xErr
     "@id": "#DiaSource.xErr"
     datatype: float
     description: Uncertainty of x.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: stat.error;pos.cartesian.x
   - name: y
@@ -1697,35 +1545,30 @@ tables:
     datatype: float
     nullable: false
     description: y position computed by a centroiding algorithm.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: pos.cartesian.y
   - name: yErr
     "@id": "#DiaSource.yErr"
     datatype: float
     description: Uncertainty of y.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: stat.error;pos.cartesian.y
   - name: x_y_Cov
     "@id": "#DiaSource.x_y_Cov"
     datatype: float
     description: Covariance between x and y.
-    mysql:datatype: FLOAT
     fits:tunit: pixel**2
     ivoa:ucd: stat.covariance
   - name: apFlux
     "@id": "#DiaSource.apFlux"
     datatype: float
     description: Flux in a 12 pixel radius aperture on the difference image.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: apFluxErr
     "@id": "#DiaSource.apFluxErr"
     datatype: float
     description: Estimated uncertainty of apFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.count
   - name: snr
@@ -1733,69 +1576,59 @@ tables:
     datatype: float
     description: The signal-to-noise ratio at which this source was detected in the
       difference image.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.snr
   - name: psfFlux
     "@id": "#DiaSource.psfFlux"
     datatype: float
     description: Flux for Point Source model. Note this actually measures
       the flux difference between the template and the visit image.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: psfFluxErr
     "@id": "#DiaSource.psfFluxErr"
     datatype: float
     description: Uncertainty of psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: psfRa
     "@id": "#DiaSource.psfRa"
     datatype: double
     description: Right ascension coordinate of centroid for point source model.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: psfRaErr
     "@id": "#DiaSource.psfRaErr"
     datatype: float
     description: Uncertainty of psfRa.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: psfDec
     "@id": "#DiaSource.psfDec"
     datatype: double
     description: Declination coordinate of centroid for point source model.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: psfDecErr
     "@id": "#DiaSource.psfDecErr"
     datatype: float
     description: Uncertainty of psfDec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: psfFlux_psfRa_Cov
     "@id": "#DiaSource.psfFlux_psfRa_Cov"
     datatype: float
     description: Covariance between psfFlux and psfRa.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.deg
     ivoa:ucd: stat.covariance
   - name: psfFlux_psfDec_Cov
     "@id": "#DiaSource.psfFlux_psfDec_Cov"
     datatype: float
     description: Covariance between psfFlux and psfDec.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.deg
     ivoa:ucd: stat.covariance
   - name: psfRa_psfDec_Cov
     "@id": "#DiaSource.psfRa_psfDec_Cov"
     datatype: float
     description: Covariance between psfRa and psfDec.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: psfLnL
@@ -1803,176 +1636,148 @@ tables:
     datatype: float
     description: Natural log likelihood of the observed data given the point source
       model.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.likelihood
   - name: psfChi2
     "@id": "#DiaSource.psfChi2"
     datatype: float
     description: Chi^2 statistic of the point source model fit.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: psfNdata
     "@id": "#DiaSource.psfNdata"
     datatype: int
     description: The number of data points (pixels) used to fit the point source model.
-    mysql:datatype: INTEGER
   - name: trailFlux
     "@id": "#DiaSource.trailFlux"
     datatype: float
     description: Flux for a trailed source model. Note this actually measures
       the flux difference between the template and the visit image.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: trailFluxErr
     "@id": "#DiaSource.trailFluxErr"
     datatype: float
     description: Uncertainty of trailFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: trailRa
     "@id": "#DiaSource.trailRa"
     datatype: double
     description: Right ascension coordinate of centroid for trailed source model.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: trailRaErr
     "@id": "#DiaSource.trailRaErr"
     datatype: float
     description: Uncertainty of trailRa.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: trailDec
     "@id": "#DiaSource.trailDec"
     datatype: double
     description: Declination coordinate of centroid for trailed source model.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: trailDecErr
     "@id": "#DiaSource.trailDecErr"
     datatype: float
     description: Uncertainty of trailDec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: trailLength
     "@id": "#DiaSource.trailLength"
     datatype: float
     description: Maximum likelihood fit of trail length.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: trailLengthErr
     "@id": "#DiaSource.trailLengthErr"
     datatype: float
     description: Uncertainty of trailLength.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: trailAngle
     "@id": "#DiaSource.trailAngle"
     datatype: float
     description: Maximum likelihood fit of the angle between the meridian through
       the centroid and the trail direction (bearing).
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: trailAngleErr
     "@id": "#DiaSource.trailAngleErr"
     datatype: float
     description: Uncertainty of trailAngle.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: trailFlux_trailRa_Cov
     "@id": "#DiaSource.trailFlux_trailRa_Cov"
     datatype: float
     description: Covariance of trailFlux and trailRa.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailFlux_trailDec_Cov
     "@id": "#DiaSource.trailFlux_trailDec_Cov"
     datatype: float
     description: Covariance of trailFlux and trailDec.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailFlux_trailLength_Cov
     "@id": "#DiaSource.trailFlux_trailLength_Cov"
     datatype: float
     description: Covariance of trailFlux and trailLength
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailFlux_trailAngle_Cov
     "@id": "#DiaSource.trailFlux_trailAngle_Cov"
     datatype: float
     description: Covariance of trailFlux and trailAngle
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailRa_trailDec_Cov
     "@id": "#DiaSource.trailRa_trailDec_Cov"
     datatype: float
     description: Covariance of trailRa and trailDec.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailRa_trailLength_Cov
     "@id": "#DiaSource.trailRa_trailLength_Cov"
     datatype: float
     description: Covariance of trailRa and trailLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailRa_trailAngle_Cov
     "@id": "#DiaSource.trailRa_trailAngle_Cov"
     datatype: float
     description: Covariance of trailRa and trailAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailDec_trailLength_Cov
     "@id": "#DiaSource.trailDec_trailLength_Cov"
     datatype: float
     description: Covariance of trailDec and trailLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailDec_trailAngle_Cov
     "@id": "#DiaSource.trailDec_trailAngle_Cov"
     datatype: float
     description: Covariance of trailDec and trailAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailLength_trailAngle_Cov
     "@id": "#DiaSource.trailLength_trailAngle_Cov"
     datatype: float
     description: Covariance of trailLength and trailAngle
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: trailLnL
     "@id": "#DiaSource.trailLnL"
     datatype: float
     description: Natural log likelihood of the observed data given the trailed source
       model.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.likelihood
   - name: trailChi2
     "@id": "#DiaSource.trailChi2"
     datatype: float
     description: Chi^2 statistic of the trailed source model fit.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: trailNdata
     "@id": "#DiaSource.trailNdata"
     datatype: int
     value: "0"
     description: The number of data points (pixels) used to fit the trailed source model.
-    mysql:datatype: INTEGER
   - name: dipoleMeanFlux
     "@id": "#DiaSource.dipoleMeanFlux"
     datatype: float
     description: Maximum likelihood value for the mean absolute flux of the two lobes
       for a dipole model.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: dipoleMeanFluxErr
     "@id": "#DiaSource.dipoleMeanFluxErr"
     datatype: float
     description: Uncertainty of dipoleMeanFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: dipoleFluxDiff
@@ -1980,55 +1785,47 @@ tables:
     datatype: float
     description: Maximum likelihood value for the difference of absolute fluxes of
       the two lobes for a dipole model.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: dipoleFluxDiffErr
     "@id": "#DiaSource.dipoleFluxDiffErr"
     datatype: float
     description: Uncertainty of dipoleFluxDiff.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error
   - name: dipoleRa
     "@id": "#DiaSource.dipoleRa"
     datatype: double
     description: "Right ascension coordinate of centroid for dipole model."
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: dipoleRaErr
     "@id": "#DiaSource.dipoleRaErr"
     datatype: float
     description: Uncertainty of dipoleRa.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: dipoleDec
     "@id": "#DiaSource.dipoleDec"
     datatype: double
     description: "Declination coordinate of centroid for dipole model."
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: dipoleDecErr
     "@id": "#DiaSource.dipoleDecErr"
     datatype: float
     description: Uncertainty of dipoleDec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: dipoleLength
     "@id": "#DiaSource.dipoleLength"
     datatype: float
     description: Maximum likelihood value for the lobe separation in dipole model.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
     ivoa:ucd: pos.angDistance
   - name: dipoleLengthErr
     "@id": "#DiaSource.dipoleLengthErr"
     datatype: float
     description: Uncertainty of dipoleLength.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
     ivoa:ucd: stat.error;pos.angDistance
   - name: dipoleAngle
@@ -2036,137 +1833,115 @@ tables:
     datatype: float
     description: Maximum likelihood fit of the angle between the meridian through
       the centroid and the dipole direction (bearing, from negative to positive lobe).
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: pos.posAng
   - name: dipoleAngleErr
     "@id": "#DiaSource.dipoleAngleErr"
     datatype: float
     description: Uncertainty of dipoleAngle.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.posAng
   - name: dipoleMeanFlux_dipoleFluxDiff_Cov
     "@id": "#DiaSource.dipoleMeanFlux_dipoleFluxDiff_Cov"
     datatype: float
     description: Covariance of dipoleMeanFlux and dipoleFluxDiff.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleMeanFlux_dipoleRa_Cov
     "@id": "#DiaSource.dipoleMeanFlux_dipoleRa_Cov"
     datatype: float
     description: Covariance of dipoleMeanFlux and dipoleRa.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleMeanFlux_dipoleDec_Cov
     "@id": "#DiaSource.dipoleMeanFlux_dipoleDec_Cov"
     datatype: float
     description: Covariance of dipoleMeanFlux and dipoleDec.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleMeanFlux_dipoleLength_Cov
     "@id": "#DiaSource.dipoleMeanFlux_dipoleLength_Cov"
     datatype: float
     description: Covariance of dipoleMeanFlux and dipoleLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleMeanFlux_dipoleAngle_Cov
     "@id": "#DiaSource.dipoleMeanFlux_dipoleAngle_Cov"
     datatype: float
     description: Covariance of dipoleMeanFlux and dipoleAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleFluxDiff_dipoleRa_Cov
     "@id": "#DiaSource.dipoleFluxDiff_dipoleRa_Cov"
     datatype: float
     description: Covariance of dipoleFluxDiff and dipoleRa.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleFluxDiff_dipoleDec_Cov
     "@id": "#DiaSource.dipoleFluxDiff_dipoleDec_Cov"
     datatype: float
     description: Covariance of dipoleFluxDiff and dipoleDec.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleFluxDiff_dipoleLength_Cov
     "@id": "#DiaSource.dipoleFluxDiff_dipoleLength_Cov"
     datatype: float
     description: Covariance of dipoleFluxDiff and dipoleLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleFluxDiff_dipoleAngle_Cov
     "@id": "#DiaSource.dipoleFluxDiff_dipoleAngle_Cov"
     datatype: float
     description: Covariance of dipoleFluxDiff and dipoleAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleRa_dipoleDec_Cov
     "@id": "#DiaSource.dipoleRa_dipoleDec_Cov"
     datatype: float
     description: Covariance of dipoleRa and dipoleDec.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleRa_dipoleLength_Cov
     "@id": "#DiaSource.dipoleRa_dipoleLength_Cov"
     datatype: float
     description: Covariance of dipoleRa and dipoleLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleRa_dipoleAngle_Cov
     "@id": "#DiaSource.dipoleRa_dipoleAngle_Cov"
     datatype: float
     description: Covariance of dipoleRa and dipoleAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleDec_dipoleLength_Cov
     "@id": "#DiaSource.dipoleDec_dipoleLength_Cov"
     datatype: float
     description: Covariance of dipoleDec and dipoleLength.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleDec_dipoleAngle_Cov
     "@id": "#DiaSource.dipoleDec_dipoleAngle_Cov"
     datatype: float
     description: Covariance of dipoleDec and dipoleAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleLength_dipoleAngle_Cov
     "@id": "#DiaSource.dipoleLength_dipoleAngle_Cov"
     datatype: float
     description: Covariance of dipoleLength and dipoleAngle.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
   - name: dipoleLnL
     "@id": "#DiaSource.dipoleLnL"
     datatype: float
     description: Natural log likelihood of the observed data given the dipole source
       model.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.likelihood
   - name: dipoleChi2
     "@id": "#DiaSource.dipoleChi2"
     datatype: float
     description: Chi^2 statistic of the model fit.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: dipoleNdata
     "@id": "#DiaSource.dipoleNdata"
     datatype: int
     description: The number of data points (pixels) used to fit the model.
-    mysql:datatype: INTEGER
   - name: scienceFlux
     "@id": "#DiaSource.scienceFlux"
     datatype: float
     description: Forced photometry flux for a point source model measured on the visit image
       centered at DiaSource position.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: scienceFluxErr
     "@id": "#DiaSource.scienceFluxErr"
     datatype: float
     description: Estimated uncertainty of scienceFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.count
   - name: snapDiffFlux
@@ -2174,101 +1949,85 @@ tables:
     datatype: float
     description: Calibrated flux for Point Source model centered on radec but measured
       on the difference of snaps comprising this visit.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
   - name: snapDiffFluxErr
     "@id": "#DiaSource.snapDiffFluxErr"
     datatype: float
     description: Estimated uncertainty of snapDiffFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.count
   - name: fpBkgd
     "@id": "#DiaSource.fpBkgd"
     datatype: float
     description: Estimated sky background at the position (centroid) of the object.
-    mysql:datatype: FLOAT
     fits:tunit: nJy/arcsec**2
   - name: fpBkgdErr
     "@id": "#DiaSource.fpBkgdErr"
     datatype: float
     description: Estimated uncertainty of fpBkgd.
-    mysql:datatype: FLOAT
     fits:tunit: nJy/arcsec**2
   - name: ixx
     "@id": "#DiaSource.ixx"
     datatype: float
     description: Adaptive second moment of the source intensity.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: ixxErr
     "@id": "#DiaSource.ixxErr"
     datatype: float
     description: Uncertainty of ixx.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
     ivoa:ucd: stat.error
   - name: iyy
     "@id": "#DiaSource.iyy"
     datatype: float
     description: Adaptive second moment of the source intensity.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: iyyErr
     "@id": "#DiaSource.iyyErr"
     datatype: float
     description: Uncertainty of iyy.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
     ivoa:ucd: stat.error
   - name: ixy
     "@id": "#DiaSource.ixy"
     datatype: float
     description: Adaptive second moment of the source intensity.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: ixyErr
     "@id": "#DiaSource.ixyErr"
     datatype: float
     description: Uncertainty of ixy.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
     ivoa:ucd: stat.error
   - name: ixx_iyy_Cov
     "@id": "#DiaSource.ixx_iyy_Cov"
     datatype: float
     description: Covariance of ixx and iyy.
-    mysql:datatype: FLOAT
     fits:tunit: nJy**2.arcsec**4
   - name: ixx_ixy_Cov
     "@id": "#DiaSource.ixx_ixy_Cov"
     datatype: float
     description: Covariance of ixx and ixy.
-    mysql:datatype: FLOAT
     fits:tunit: nJy**2.arcsec**4
   - name: iyy_ixy_Cov
     "@id": "#DiaSource.iyy_ixy_Cov"
     datatype: float
     description: Covariance of iyy and ixy.
-    mysql:datatype: FLOAT
     fits:tunit: nJy**2.arcsec**4
   - name: ixxPSF
     "@id": "#DiaSource.ixxPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: iyyPSF
     "@id": "#DiaSource.iyyPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: ixyPSF
     "@id": "#DiaSource.ixyPSF"
     datatype: float
     description: Adaptive second moment for the PSF.
-    mysql:datatype: FLOAT
     fits:tunit: nJy.arcsec**2
   - name: extendedness
     "@id": "#DiaSource.extendedness"
@@ -2278,21 +2037,18 @@ tables:
       models (exact algorithm TBD). extendedness = 1 implies a high degree of confidence
       that the source is extended. extendedness = 0 implies a high degree of confidence
       that the source is point-like.
-    mysql:datatype: FLOAT
   - name: reliability
     "@id": "#DiaSource.reliability"
     datatype: float
     description: A measure of reliability, computed using information from the source
       and image characterization, as well as the information on the Telescope and
       Camera system (e.g., ghost maps, defect maps, etc.).
-    mysql:datatype: FLOAT
   - name: flags
     "@id": "#DiaSource.flags"
     datatype: long
     nullable: false
     description: Flags, bitwise OR tbd.
     value: "0"
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
   - name: band
     "@id": "#DiaSource.band"
@@ -2352,41 +2108,35 @@ tables:
     datatype: long
     nullable: false
     description: Id of the DiaObject that this DiaForcedSource was associated with.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: ccdVisitId
     "@id": "#DiaForcedSource.ccdVisitId"
     datatype: long
     nullable: false
     description: Id of the ccdVisit where this forcedSource was measured.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: psfFlux
     "@id": "#DiaForcedSource.psfFlux"
     datatype: float
     description: Point Source model flux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: phot.count
   - name: psfFluxErr
     "@id": "#DiaForcedSource.psfFluxErr"
     datatype: float
     description: Uncertainty of psfFlux.
-    mysql:datatype: FLOAT
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.count
   - name: x
     "@id": "#DiaForcedSource.x"
     datatype: float
     description: x position at which psfFlux has been measured.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: pos.cartesian.x
   - name: y
     "@id": "#DiaForcedSource.y"
     datatype: float
     description: y position at which psfFlux has been measured.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: pos.cartesian.y
   - name: flags
@@ -2394,7 +2144,6 @@ tables:
     datatype: long
     description: Flags, bitwise OR tbd
     value: "0"
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
   - name: midpointMjdTai
     "@id": "#DiaForcedSource.midpointMjdTai"
@@ -2457,27 +2206,23 @@ tables:
     datatype: long
     nullable: false
     description: Id of diaObject.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: objectId
     "@id": "#DiaObject_To_Object_Match.objectId"
     datatype: long
     nullable: false
     description: Id of a nearby object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: dist
     "@id": "#DiaObject_To_Object_Match.dist"
     datatype: float
     description: The distance between the diaObject and the object.
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: lnP
     "@id": "#DiaObject_To_Object_Match.lnP"
     datatype: float
     description: Natural log of the probability that the observed diaObject is the
       same as the nearby object.
-    mysql:datatype: FLOAT
   indexes:
   - name: IDX_DiaObjectToObjectMatch_diaObjectId
     "@id": "#IDX_DiaObjectToObjectMatch_diaObjectId"
@@ -2620,70 +2365,58 @@ tables:
     datatype: int
     description: MPC number (if the asteroid has been numbered; NULL otherwise). Provided
       for convenience.
-    mysql:datatype: INTEGER
   - name: ssObjectId
     "@id": "#MPCORB.ssObjectId"
     datatype: long
     description: LSST unique identifier (if observed by LSST)
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: mpcH
     "@id": "#MPCORB.mpcH"
     datatype: float
     description: 'MPCORB: Absolute magnitude, H'
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: mpcG
     "@id": "#MPCORB.mpcG"
     datatype: float
     description: 'MPCORB: Slope parameter, G'
-    mysql:datatype: FLOAT
   - name: epoch
     "@id": "#MPCORB.epoch"
     datatype: double
     description: 'MPCORB: Epoch (in MJD, .0 TT)'
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: M
     "@id": "#MPCORB.M"
     datatype: double
     description: 'MPCORB: Mean anomaly at the epoch, in degrees'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: peri
     "@id": "#MPCORB.peri"
     datatype: double
     description: 'MPCORB: Argument of perihelion, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: node
     "@id": "#MPCORB.node"
     datatype: double
     description: 'MPCORB: Longitude of the ascending node, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: incl
     "@id": "#MPCORB.incl"
     datatype: double
     description: 'MPCORB: Inclination to the ecliptic, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: e
     "@id": "#MPCORB.e"
     datatype: double
     description: 'MPCORB: Orbital eccentricity'
-    mysql:datatype: DOUBLE
   - name: n
     "@id": "#MPCORB.n"
     datatype: double
     description: 'MPCORB: Mean daily motion (degrees per day)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg/d
   - name: a
     "@id": "#MPCORB.a"
     datatype: double
     description: 'MPCORB: Semimajor axis (AU)'
-    mysql:datatype: DOUBLE
     fits:tunit: AU
   - name: uncertaintyParameter
     "@id": "#MPCORB.uncertaintyParameter"
@@ -2701,17 +2434,14 @@ tables:
     "@id": "#MPCORB.nobs"
     datatype: int
     description: 'MPCORB: Number of observations'
-    mysql:datatype: INTEGER
   - name: nopp
     "@id": "#MPCORB.nopp"
     datatype: int
     description: 'MPCORB: Number of oppositions'
-    mysql:datatype: INTEGER
   - name: arc
     "@id": "#MPCORB.arc"
     datatype: float
     description: 'MPCORB: Arc (days), for single-opposition objects'
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: arcStart
     "@id": "#MPCORB.arcStart"
@@ -2729,7 +2459,6 @@ tables:
     "@id": "#MPCORB.rms"
     datatype: float
     description: 'MPCORB: r.m.s residual (")'
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: pertsShort
     "@id": "#MPCORB.pertsShort"
@@ -2756,7 +2485,6 @@ tables:
     datatype: int
     description: 'MPCORB: 4-hexdigit flags. See https://minorplanetcenter.net//iau/info/MPOrbitFormat.html
       for details'
-    mysql:datatype: INTEGER
   - name: fullDesignation
     "@id": "#MPCORB.fullDesignation"
     datatype: char
@@ -2767,7 +2495,6 @@ tables:
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float
     description: 'MPCORB: Date of last observation included in orbit solution'
-    mysql:datatype: FLOAT
     fits:tunit: d
 - name: MPCORBDESIGMAP
   "@id": "#MPCORBDESIGMAP"
@@ -2788,7 +2515,6 @@ tables:
     "@id": "#MPCORBDESIGMAP.mpcNumber"
     datatype: int
     description: MPC number (if the asteroid has been numbered)
-    mysql:datatype: INTEGER
   - name: otherDesignation
     "@id": "#MPCORBDESIGMAP.otherDesignation"
     datatype: char
@@ -2799,7 +2525,6 @@ tables:
     "@id": "#MPCORBDESIGMAP.ssObjectId"
     datatype: long
     description: LSST unique identifier (if observed by LSST)
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
 - name: SSSource
   "@id": "#SSSource"
@@ -2814,270 +2539,223 @@ tables:
     datatype: long
     autoincrement: false
     description: Unique identifier of the object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: diaSourceId
     "@id": "#SSSource.diaSourceId"
     datatype: long
     description: Unique identifier of the observation
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: mpcUniqueId
     "@id": "#SSSource.mpcUniqueId"
     datatype: long
     description: MPC unique identifier of the observation
-    mysql:datatype: BIGINT
   - name: nearbyObj1
     "@id": "#SSSource.nearbyObj1"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObj2
     "@id": "#SSSource.nearbyObj2"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObj3
     "@id": "#SSSource.nearbyObj3"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObj4
     "@id": "#SSSource.nearbyObj4"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObj5
     "@id": "#SSSource.nearbyObj5"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObj6
     "@id": "#SSSource.nearbyObj6"
     datatype: long
     description: Closest Objects (3 stars and 3 galaxies) in Level 2 database.
-    mysql:datatype: BIGINT
   - name: nearbyObjDist1
     "@id": "#SSSource.nearbyObjDist1"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjDist2
     "@id": "#SSSource.nearbyObjDist2"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjDist3
     "@id": "#SSSource.nearbyObjDist3"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjDist4
     "@id": "#SSSource.nearbyObjDist4"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjDist5
     "@id": "#SSSource.nearbyObjDist5"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjDist6
     "@id": "#SSSource.nearbyObjDist6"
     datatype: float
     description: Distances to nearbyObj
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP1
     "@id": "#SSSource.nearbyObjLnP1"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP2
     "@id": "#SSSource.nearbyObjLnP2"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP3
     "@id": "#SSSource.nearbyObjLnP3"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP4
     "@id": "#SSSource.nearbyObjLnP4"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP5
     "@id": "#SSSource.nearbyObjLnP5"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: nearbyObjLnP6
     "@id": "#SSSource.nearbyObjLnP6"
     datatype: float
     description: Natural log of the probability that the observed DIAObject is the
       same as the nearby Object
-    mysql:datatype: FLOAT
   - name: eclipticLambda
     "@id": "#SSSource.eclipticLambda"
     datatype: double
     description: Ecliptic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: eclipticBeta
     "@id": "#SSSource.eclipticBeta"
     datatype: double
     description: Ecliptic latitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticL
     "@id": "#SSSource.galacticL"
     datatype: double
     description: Galactic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticB
     "@id": "#SSSource.galacticB"
     datatype: double
     description: Galactic latitute
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: phaseAngle
     "@id": "#SSSource.phaseAngle"
     datatype: float
     description: Phase angle
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: heliocentricDist
     "@id": "#SSSource.heliocentricDist"
     datatype: float
     description: Heliocentric distance
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricDist
     "@id": "#SSSource.topocentricDist"
     datatype: float
     description: Topocentric distace
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: predictedMagnitude
     "@id": "#SSSource.predictedMagnitude"
     datatype: float
     description: Predicted magnitude
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: predictedMagnitudeSigma
     "@id": "#SSSource.predictedMagnitudeSigma"
     datatype: float
     description: Prediction uncertainty (1-sigma)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: residualRa
     "@id": "#SSSource.residualRa"
     datatype: double
     description: Residual R.A. vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: residualDec
     "@id": "#SSSource.residualDec"
     datatype: double
     description: Residual Dec vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: predictedRaSigma
     "@id": "#SSSource.predictedRaSigma"
     datatype: float
     description: Predicted R.A. uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedDecSigma
     "@id": "#SSSource.predictedDecSigma"
     datatype: float
     description: Predicted Dec uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedRaDecCov
     "@id": "#SSSource.predictedRaDecCov"
     datatype: float
     description: Predicted R.A./Dec covariance
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float
     description: Cartesian heliocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricY
     "@id": "#SSSource.heliocentricY"
     datatype: float
     description: Cartesian heliocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricZ
     "@id": "#SSSource.heliocentricZ"
     datatype: float
     description: Cartesian heliocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVX
     "@id": "#SSSource.heliocentricVX"
     datatype: float
     description: Cartesian heliocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVY
     "@id": "#SSSource.heliocentricVY"
     datatype: float
     description: Cartesian heliocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVZ
     "@id": "#SSSource.heliocentricVZ"
     datatype: float
     description: Cartesian heliocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricX
     "@id": "#SSSource.topocentricX"
     datatype: float
     description: Cartesian topocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricY
     "@id": "#SSSource.topocentricY"
     datatype: float
     description: Cartesian topocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricZ
     "@id": "#SSSource.topocentricZ"
     datatype: float
     description: Cartesian topocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVX
     "@id": "#SSSource.topocentricVX"
     datatype: float
     description: Cartesian topocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVY
     "@id": "#SSSource.topocentricVY"
     datatype: float
     description: Cartesian topocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVZ
     "@id": "#SSSource.topocentricVZ"
     datatype: float
     description: Cartesian topocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
 - name: DetectorVisitProcessingSummary
   '@id': '#DetectorVisitProcessingSummary'
@@ -3087,7 +2765,6 @@ tables:
     '@id': '#DetectorVisitProcessingSummary.ccdVisitId'
     datatype: long
     description: Unique identifier.
-    mysql:datatype: BIGINT
   - name: visit
     '@id': '#DetectorVisitProcessingSummary.visit'
     datatype: long
@@ -3097,42 +2774,35 @@ tables:
     '@id': '#DetectorVisitProcessingSummary.detector'
     datatype: long
     description: Id of the detector on the instrument that took this visit.
-    mysql:datatype: BIGINT
   - name: ra
     '@id': '#DetectorVisitProcessingSummary.ra'
     datatype: double
     description: Right Ascension of detector center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     '@id': '#DetectorVisitProcessingSummary.dec'
     datatype: double
     description: Declination of detector center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: zeroPoint
     '@id': '#DetectorVisitProcessingSummary.zeroPoint'
     datatype: float
     description: Zero-point for the detector, estimated at detector center.
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: psfSigma
     '@id': '#DetectorVisitProcessingSummary.psfSigma'
     datatype: float
     description: PSF model second-moments determinant radius (center of detector).
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: skyBg
     '@id': '#DetectorVisitProcessingSummary.skyBg'
     datatype: float
     description: Average sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: skyNoise
     '@id': '#DetectorVisitProcessingSummary.skyNoise'
     datatype: float
     description: RMS noise of the sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: seeing
     '@id': '#DetectorVisitProcessingSummary.seeing'
@@ -3156,49 +2826,41 @@ tables:
     '@id': '#DetectorVisitProcessingSummary.llcra'
     datatype: double
     description: RA of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: llcdec
     '@id': '#DetectorVisitProcessingSummary.llcdec'
     datatype: double
     description: Declination of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcra
     '@id': '#DetectorVisitProcessingSummary.ulcra'
     datatype: double
     description: RA of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcdec
     '@id': '#DetectorVisitProcessingSummary.ulcdec'
     datatype: double
     description: Declination of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcra
     '@id': '#DetectorVisitProcessingSummary.urcra'
     datatype: double
     description: RA of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcdec
     '@id': '#DetectorVisitProcessingSummary.urcdec'
     datatype: double
     description: Declination of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcra
     '@id': '#DetectorVisitProcessingSummary.lrcra'
     datatype: double
     description: RA of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcdec
     '@id': '#DetectorVisitProcessingSummary.lrcdec'
     datatype: double
     description: Declination of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: astromOffsetMean
     '@id': '#DetectorVisitProcessingSummary.astromOffsetMean'

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -12,7 +12,6 @@ tables:
     '@id': '#position.objectId'
     datatype: long
     nullable: false
-    mysql:datatype: BIGINT
     tap:column_index: 1
     tap:principal: 1
     description: Unique id.
@@ -20,7 +19,6 @@ tables:
     '@id': '#position.coord_ra'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 2
     tap:principal: 1
     description: RA-coordinate
@@ -30,7 +28,6 @@ tables:
     '@id': '#position.coord_dec'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     description: Decl-coordinate
@@ -40,7 +37,6 @@ tables:
     '@id': '#position.parent'
     datatype: long
     nullable: false
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: unique ID of parent source
@@ -48,7 +44,6 @@ tables:
   - name: deblend_nChild
     '@id': '#position.deblend_nChild'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 1
     description: Number of children this object has (defaults to 0)
@@ -66,7 +61,6 @@ tables:
   - name: extinction_bv
     '@id': '#position.extinction_bv'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Milky Way dust extinction, E(B-V)
@@ -256,7 +250,6 @@ tables:
     '@id': '#reference.objectId'
     datatype: long
     nullable: false
-    mysql:datatype: BIGINT
     tap:column_index: 1
     tap:principal: 1
     description: Unique id.
@@ -264,7 +257,6 @@ tables:
     '@id': '#reference.coord_ra'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 2
     tap:principal: 1
     description: position in ra/dec
@@ -274,7 +266,6 @@ tables:
     '@id': '#reference.coord_dec'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     description: position in ra/dec
@@ -283,7 +274,6 @@ tables:
   - name: base_SdssCentroid_x
     '@id': '#reference.base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -291,7 +281,6 @@ tables:
   - name: base_SdssCentroid_y
     '@id': '#reference.base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -299,7 +288,6 @@ tables:
   - name: base_SdssCentroid_xErr
     '@id': '#reference.base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -307,7 +295,6 @@ tables:
   - name: base_SdssCentroid_yErr
     '@id': '#reference.base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -363,7 +350,6 @@ tables:
   - name: base_PsfFlux_instFlux
     '@id': '#reference.base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -371,7 +357,6 @@ tables:
   - name: base_PsfFlux_instFluxErr
     '@id': '#reference.base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -379,7 +364,6 @@ tables:
   - name: base_PsfFlux_area
     '@id': '#reference.base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -387,7 +371,6 @@ tables:
   - name: base_PsfFlux_apCorr
     '@id': '#reference.base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -395,7 +378,6 @@ tables:
   - name: base_PsfFlux_apCorrErr
     '@id': '#reference.base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -444,7 +426,6 @@ tables:
   - name: base_Blendedness_raw_instFlux
     '@id': '#reference.base_Blendedness_raw_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 'measure of how instFlux is affected by neighbors: (1 - instFlux.child/instFlux.parent)'
@@ -452,7 +433,6 @@ tables:
   - name: base_Blendedness_raw_instFlux_child
     '@id': '#reference.base_Blendedness_raw_instFlux_child'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux of the child, measured with a Gaussian weight matched to
@@ -461,7 +441,6 @@ tables:
   - name: base_Blendedness_raw_instFlux_parent
     '@id': '#reference.base_Blendedness_raw_instFlux_parent'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux of the parent, measured with a Gaussian weight matched to
@@ -470,7 +449,6 @@ tables:
   - name: base_Blendedness_abs_instFlux
     '@id': '#reference.base_Blendedness_abs_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 'measure of how instFlux is affected by neighbors: (1 - instFlux.child/instFlux.parent)'
@@ -478,7 +456,6 @@ tables:
   - name: base_Blendedness_abs_instFlux_child
     '@id': '#reference.base_Blendedness_abs_instFlux_child'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux of the child, measured with a Gaussian weight matched to
@@ -487,7 +464,6 @@ tables:
   - name: base_Blendedness_abs_instFlux_parent
     '@id': '#reference.base_Blendedness_abs_instFlux_parent'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux of the parent, measured with a Gaussian weight matched to
@@ -496,7 +472,6 @@ tables:
   - name: base_Blendedness_raw_child_xx
     '@id': '#reference.base_Blendedness_raw_child_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -505,7 +480,6 @@ tables:
   - name: base_Blendedness_raw_child_yy
     '@id': '#reference.base_Blendedness_raw_child_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -514,7 +488,6 @@ tables:
   - name: base_Blendedness_raw_child_xy
     '@id': '#reference.base_Blendedness_raw_child_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -523,7 +496,6 @@ tables:
   - name: base_Blendedness_raw_parent_xx
     '@id': '#reference.base_Blendedness_raw_parent_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -532,7 +504,6 @@ tables:
   - name: base_Blendedness_raw_parent_yy
     '@id': '#reference.base_Blendedness_raw_parent_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -541,7 +512,6 @@ tables:
   - name: base_Blendedness_raw_parent_xy
     '@id': '#reference.base_Blendedness_raw_parent_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -550,7 +520,6 @@ tables:
   - name: base_Blendedness_abs_child_xx
     '@id': '#reference.base_Blendedness_abs_child_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -560,7 +529,6 @@ tables:
   - name: base_Blendedness_abs_child_yy
     '@id': '#reference.base_Blendedness_abs_child_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -570,7 +538,6 @@ tables:
   - name: base_Blendedness_abs_child_xy
     '@id': '#reference.base_Blendedness_abs_child_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the child, measured with a Gaussian weight matched to the
@@ -580,7 +547,6 @@ tables:
   - name: base_Blendedness_abs_parent_xx
     '@id': '#reference.base_Blendedness_abs_parent_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -590,7 +556,6 @@ tables:
   - name: base_Blendedness_abs_parent_yy
     '@id': '#reference.base_Blendedness_abs_parent_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -600,7 +565,6 @@ tables:
   - name: base_Blendedness_abs_parent_xy
     '@id': '#reference.base_Blendedness_abs_parent_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Shape of the parent, measured with a Gaussian weight matched to the
@@ -610,7 +574,6 @@ tables:
   - name: base_ClassificationExtendedness_value
     '@id': '#reference.base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -626,7 +589,6 @@ tables:
   - name: base_Blendedness_old
     '@id': '#reference.base_Blendedness_old'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 'Blendedness from dot products: (child.dot(parent)/child.dot(child)
@@ -635,7 +597,6 @@ tables:
   - name: base_Blendedness_abs
     '@id': '#reference.base_Blendedness_abs'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 'Measure of how much the flux is affected by neighbors: (1 - child_instFlux/parent_instFlux).  Operates
@@ -836,7 +797,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_x
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -844,7 +804,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_y
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -852,7 +811,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_xx
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -860,7 +818,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -868,7 +825,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -916,7 +872,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_x
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -924,7 +879,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_y
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -932,7 +886,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_xx
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -940,7 +893,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_yy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -948,7 +900,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_xy
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -956,7 +907,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_e1
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_e1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) "regaussianization"
@@ -964,7 +914,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_e2
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_e2'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) "regaussianization"
@@ -972,7 +921,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_sigma
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_sigma'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF-corrected shear using Hirata & Seljak (2003) "regaussianization"
@@ -980,7 +928,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_resolution
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_resolution'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: resolution factor (0=unresolved, 1=resolved)
@@ -988,7 +935,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_x
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -996,7 +942,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_y
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM Centroid
@@ -1004,7 +949,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_xx
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -1012,7 +956,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_yy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -1020,7 +963,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_xy
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM moments
@@ -1028,7 +970,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_Flux
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_Flux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: HSM flux
@@ -1164,7 +1105,6 @@ tables:
   - name: base_SdssShape_xx
     '@id': '#reference.base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1172,7 +1112,6 @@ tables:
   - name: base_SdssShape_yy
     '@id': '#reference.base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1180,7 +1119,6 @@ tables:
   - name: base_SdssShape_xy
     '@id': '#reference.base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1188,7 +1126,6 @@ tables:
   - name: base_SdssShape_xxErr
     '@id': '#reference.base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -1196,7 +1133,6 @@ tables:
   - name: base_SdssShape_yyErr
     '@id': '#reference.base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -1204,7 +1140,6 @@ tables:
   - name: base_SdssShape_xyErr
     '@id': '#reference.base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -1212,7 +1147,6 @@ tables:
   - name: base_SdssShape_x
     '@id': '#reference.base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1220,7 +1154,6 @@ tables:
   - name: base_SdssShape_y
     '@id': '#reference.base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1228,7 +1161,6 @@ tables:
   - name: base_SdssShape_instFlux
     '@id': '#reference.base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -1236,7 +1168,6 @@ tables:
   - name: base_SdssShape_instFluxErr
     '@id': '#reference.base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -1244,7 +1175,6 @@ tables:
   - name: base_SdssShape_psf_xx
     '@id': '#reference.base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -1252,7 +1182,6 @@ tables:
   - name: base_SdssShape_psf_yy
     '@id': '#reference.base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -1260,7 +1189,6 @@ tables:
   - name: base_SdssShape_psf_xy
     '@id': '#reference.base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -1268,7 +1196,6 @@ tables:
   - name: base_SdssShape_instFlux_xx_Cov
     '@id': '#reference.base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -1276,7 +1203,6 @@ tables:
   - name: base_SdssShape_instFlux_yy_Cov
     '@id': '#reference.base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -1284,7 +1210,6 @@ tables:
   - name: base_SdssShape_instFlux_xy_Cov
     '@id': '#reference.base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -1349,7 +1274,6 @@ tables:
   - name: deblend_psfCenter_x
     '@id': '#reference.deblend_psfCenter_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: If deblended-as-psf, the PSF centroid
@@ -1357,7 +1281,6 @@ tables:
   - name: deblend_psfCenter_y
     '@id': '#reference.deblend_psfCenter_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: If deblended-as-psf, the PSF centroid
@@ -1365,7 +1288,6 @@ tables:
   - name: deblend_psf_instFlux
     '@id': '#reference.deblend_psf_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: If deblended-as-psf, the instrumental PSF flux
@@ -1439,7 +1361,6 @@ tables:
   - name: deblend_psfflux
     '@id': '#reference.deblend_psfflux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: If deblended-as-psf, the instrumental PSF flux
@@ -1447,7 +1368,6 @@ tables:
   - name: modelfit_CModel_initial_instFlux
     '@id': '#reference.modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -1455,7 +1375,6 @@ tables:
   - name: modelfit_CModel_initial_instFluxErr
     '@id': '#reference.modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -1463,7 +1382,6 @@ tables:
   - name: modelfit_CModel_initial_flux_inner
     '@id': '#reference.modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -1471,7 +1389,6 @@ tables:
   - name: modelfit_CModel_initial_ellipse_xx
     '@id': '#reference.modelfit_CModel_initial_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
@@ -1479,7 +1396,6 @@ tables:
   - name: modelfit_CModel_initial_ellipse_yy
     '@id': '#reference.modelfit_CModel_initial_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
@@ -1487,7 +1403,6 @@ tables:
   - name: modelfit_CModel_initial_ellipse_xy
     '@id': '#reference.modelfit_CModel_initial_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the initial fit
@@ -1495,7 +1410,6 @@ tables:
   - name: modelfit_CModel_initial_objective
     '@id': '#reference.modelfit_CModel_initial_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the initial fit
@@ -1503,7 +1417,6 @@ tables:
   - name: modelfit_CModel_initial_nonlinear_0
     '@id': '#reference.modelfit_CModel_initial_nonlinear_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the initial fit
@@ -1511,7 +1424,6 @@ tables:
   - name: modelfit_CModel_initial_nonlinear_1
     '@id': '#reference.modelfit_CModel_initial_nonlinear_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the initial fit
@@ -1519,7 +1431,6 @@ tables:
   - name: modelfit_CModel_initial_nonlinear_2
     '@id': '#reference.modelfit_CModel_initial_nonlinear_2'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the initial fit
@@ -1527,7 +1438,6 @@ tables:
   - name: modelfit_CModel_initial_fixed_0
     '@id': '#reference.modelfit_CModel_initial_fixed_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the initial fit
@@ -1535,7 +1445,6 @@ tables:
   - name: modelfit_CModel_initial_fixed_1
     '@id': '#reference.modelfit_CModel_initial_fixed_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the initial fit
@@ -1543,7 +1452,6 @@ tables:
   - name: modelfit_CModel_initial_nIter
     '@id': '#reference.modelfit_CModel_initial_nIter'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of total iterations in stage
@@ -1551,7 +1459,6 @@ tables:
   - name: modelfit_CModel_initial_time
     '@id': '#reference.modelfit_CModel_initial_time'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Time spent in stage
@@ -1559,7 +1466,6 @@ tables:
   - name: modelfit_CModel_exp_instFlux
     '@id': '#reference.modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -1567,7 +1473,6 @@ tables:
   - name: modelfit_CModel_exp_instFluxErr
     '@id': '#reference.modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -1575,7 +1480,6 @@ tables:
   - name: modelfit_CModel_exp_flux_inner
     '@id': '#reference.modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -1583,7 +1487,6 @@ tables:
   - name: modelfit_CModel_exp_ellipse_xx
     '@id': '#reference.modelfit_CModel_exp_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
@@ -1591,7 +1494,6 @@ tables:
   - name: modelfit_CModel_exp_ellipse_yy
     '@id': '#reference.modelfit_CModel_exp_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
@@ -1599,7 +1501,6 @@ tables:
   - name: modelfit_CModel_exp_ellipse_xy
     '@id': '#reference.modelfit_CModel_exp_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the exponential fit
@@ -1607,7 +1508,6 @@ tables:
   - name: modelfit_CModel_exp_objective
     '@id': '#reference.modelfit_CModel_exp_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the exponential fit
@@ -1615,7 +1515,6 @@ tables:
   - name: modelfit_CModel_exp_nonlinear_0
     '@id': '#reference.modelfit_CModel_exp_nonlinear_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the exponential fit
@@ -1623,7 +1522,6 @@ tables:
   - name: modelfit_CModel_exp_nonlinear_1
     '@id': '#reference.modelfit_CModel_exp_nonlinear_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the exponential fit
@@ -1631,7 +1529,6 @@ tables:
   - name: modelfit_CModel_exp_nonlinear_2
     '@id': '#reference.modelfit_CModel_exp_nonlinear_2'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the exponential fit
@@ -1639,7 +1536,6 @@ tables:
   - name: modelfit_CModel_exp_fixed_0
     '@id': '#reference.modelfit_CModel_exp_fixed_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the exponential fit
@@ -1647,7 +1543,6 @@ tables:
   - name: modelfit_CModel_exp_fixed_1
     '@id': '#reference.modelfit_CModel_exp_fixed_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the exponential fit
@@ -1655,7 +1550,6 @@ tables:
   - name: modelfit_CModel_exp_nIter
     '@id': '#reference.modelfit_CModel_exp_nIter'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of total iterations in stage
@@ -1663,7 +1557,6 @@ tables:
   - name: modelfit_CModel_exp_time
     '@id': '#reference.modelfit_CModel_exp_time'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Time spent in stage
@@ -1671,7 +1564,6 @@ tables:
   - name: modelfit_CModel_dev_instFlux
     '@id': '#reference.modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -1679,7 +1571,6 @@ tables:
   - name: modelfit_CModel_dev_instFluxErr
     '@id': '#reference.modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -1687,7 +1578,6 @@ tables:
   - name: modelfit_CModel_dev_flux_inner
     '@id': '#reference.modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -1695,7 +1585,6 @@ tables:
   - name: modelfit_CModel_dev_ellipse_xx
     '@id': '#reference.modelfit_CModel_dev_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
@@ -1703,7 +1592,6 @@ tables:
   - name: modelfit_CModel_dev_ellipse_yy
     '@id': '#reference.modelfit_CModel_dev_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
@@ -1711,7 +1599,6 @@ tables:
   - name: modelfit_CModel_dev_ellipse_xy
     '@id': '#reference.modelfit_CModel_dev_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: half-light ellipse of the de Vaucouleur fit
@@ -1719,7 +1606,6 @@ tables:
   - name: modelfit_CModel_dev_objective
     '@id': '#reference.modelfit_CModel_dev_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood*prior) at best-fit point for the de Vaucouleur fit
@@ -1727,7 +1613,6 @@ tables:
   - name: modelfit_CModel_dev_nonlinear_0
     '@id': '#reference.modelfit_CModel_dev_nonlinear_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
@@ -1735,7 +1620,6 @@ tables:
   - name: modelfit_CModel_dev_nonlinear_1
     '@id': '#reference.modelfit_CModel_dev_nonlinear_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
@@ -1743,7 +1627,6 @@ tables:
   - name: modelfit_CModel_dev_nonlinear_2
     '@id': '#reference.modelfit_CModel_dev_nonlinear_2'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: nonlinear parameters for the de Vaucouleur fit
@@ -1751,7 +1634,6 @@ tables:
   - name: modelfit_CModel_dev_fixed_0
     '@id': '#reference.modelfit_CModel_dev_fixed_0'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the de Vaucouleur fit
@@ -1759,7 +1641,6 @@ tables:
   - name: modelfit_CModel_dev_fixed_1
     '@id': '#reference.modelfit_CModel_dev_fixed_1'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fixed parameters for the de Vaucouleur fit
@@ -1767,7 +1648,6 @@ tables:
   - name: modelfit_CModel_dev_nIter
     '@id': '#reference.modelfit_CModel_dev_nIter'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of total iterations in stage
@@ -1775,7 +1655,6 @@ tables:
   - name: modelfit_CModel_dev_time
     '@id': '#reference.modelfit_CModel_dev_time'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Time spent in stage
@@ -1783,7 +1662,6 @@ tables:
   - name: modelfit_CModel_instFlux
     '@id': '#reference.modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the final cmodel fit
@@ -1791,7 +1669,6 @@ tables:
   - name: modelfit_CModel_instFluxErr
     '@id': '#reference.modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the final cmodel fit
@@ -1799,7 +1676,6 @@ tables:
   - name: modelfit_CModel_instFlux_inner
     '@id': '#reference.modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -1807,7 +1683,6 @@ tables:
   - name: modelfit_CModel_fracDev
     '@id': '#reference.modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -1815,7 +1690,6 @@ tables:
   - name: modelfit_CModel_objective
     '@id': '#reference.modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -1823,7 +1697,6 @@ tables:
   - name: modelfit_CModel_ellipse_xx
     '@id': '#reference.modelfit_CModel_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
@@ -1831,7 +1704,6 @@ tables:
   - name: modelfit_CModel_ellipse_yy
     '@id': '#reference.modelfit_CModel_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
@@ -1839,7 +1711,6 @@ tables:
   - name: modelfit_CModel_ellipse_xy
     '@id': '#reference.modelfit_CModel_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fracDev-weighted average of exp.ellipse and dev.ellipse
@@ -1847,7 +1718,6 @@ tables:
   - name: modelfit_CModel_region_initial_ellipse_xx
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
@@ -1856,7 +1726,6 @@ tables:
   - name: modelfit_CModel_region_initial_ellipse_yy
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
@@ -1865,7 +1734,6 @@ tables:
   - name: modelfit_CModel_region_initial_ellipse_xy
     '@id': '#reference.modelfit_CModel_region_initial_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the initial fit (before
@@ -1874,7 +1742,6 @@ tables:
   - name: modelfit_CModel_region_final_ellipse_xx
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
@@ -1883,7 +1750,6 @@ tables:
   - name: modelfit_CModel_region_final_ellipse_yy
     '@id': '#reference.modelfit_CModel_region_final_ellipse_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
@@ -1892,7 +1758,6 @@ tables:
   - name: modelfit_CModel_region_final_ellipse_xy
     '@id': '#reference.modelfit_CModel_region_final_ellipse_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: ellipse used to set the pixel region for the final fit (before applying
@@ -1901,7 +1766,6 @@ tables:
   - name: modelfit_CModel_exp_apCorr
     '@id': '#reference.modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -1909,7 +1773,6 @@ tables:
   - name: modelfit_CModel_exp_apCorrErr
     '@id': '#reference.modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -1917,7 +1780,6 @@ tables:
   - name: modelfit_CModel_initial_apCorr
     '@id': '#reference.modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -1925,7 +1787,6 @@ tables:
   - name: modelfit_CModel_initial_apCorrErr
     '@id': '#reference.modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -1933,7 +1794,6 @@ tables:
   - name: modelfit_CModel_dev_apCorr
     '@id': '#reference.modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -1941,7 +1801,6 @@ tables:
   - name: modelfit_CModel_dev_apCorrErr
     '@id': '#reference.modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -1949,7 +1808,6 @@ tables:
   - name: modelfit_CModel_apCorr
     '@id': '#reference.modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -1957,7 +1815,6 @@ tables:
   - name: modelfit_CModel_apCorrErr
     '@id': '#reference.modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -2206,7 +2063,6 @@ tables:
     '@id': '#forced_photometry.objectId'
     datatype: long
     nullable: false
-    mysql:datatype: BIGINT
     tap:column_index: 1
     tap:principal: 1
     description: Unique id.
@@ -2214,7 +2070,6 @@ tables:
     '@id': '#forced_photometry.coord_ra'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 2
     tap:principal: 1
     description: position in ra/dec
@@ -2224,7 +2079,6 @@ tables:
     '@id': '#forced_photometry.coord_dec'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     description: position in ra/dec
@@ -2416,7 +2270,6 @@ tables:
   - name: g_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.g_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -2432,7 +2285,6 @@ tables:
   - name: g_modelfit_CModel_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -2440,7 +2292,6 @@ tables:
   - name: g_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -2448,7 +2299,6 @@ tables:
   - name: g_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -2456,7 +2306,6 @@ tables:
   - name: g_modelfit_CModel_fracDev
     '@id': '#forced_photometry.g_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -2464,7 +2313,6 @@ tables:
   - name: g_modelfit_CModel_objective
     '@id': '#forced_photometry.g_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -2472,7 +2320,6 @@ tables:
   - name: g_modelfit_CModel_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -2480,7 +2327,6 @@ tables:
   - name: g_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -2545,7 +2391,6 @@ tables:
   - name: g_base_SdssCentroid_x
     '@id': '#forced_photometry.g_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -2553,7 +2398,6 @@ tables:
   - name: g_base_SdssCentroid_y
     '@id': '#forced_photometry.g_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -2561,7 +2405,6 @@ tables:
   - name: g_base_SdssCentroid_xErr
     '@id': '#forced_photometry.g_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -2569,7 +2412,6 @@ tables:
   - name: g_base_SdssCentroid_yErr
     '@id': '#forced_photometry.g_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -2633,7 +2475,6 @@ tables:
   - name: g_base_SdssShape_xx
     '@id': '#forced_photometry.g_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2641,7 +2482,6 @@ tables:
   - name: g_base_SdssShape_yy
     '@id': '#forced_photometry.g_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2649,7 +2489,6 @@ tables:
   - name: g_base_SdssShape_xy
     '@id': '#forced_photometry.g_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2657,7 +2496,6 @@ tables:
   - name: g_base_SdssShape_xxErr
     '@id': '#forced_photometry.g_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -2665,7 +2503,6 @@ tables:
   - name: g_base_SdssShape_yyErr
     '@id': '#forced_photometry.g_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -2673,7 +2510,6 @@ tables:
   - name: g_base_SdssShape_xyErr
     '@id': '#forced_photometry.g_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -2681,7 +2517,6 @@ tables:
   - name: g_base_SdssShape_x
     '@id': '#forced_photometry.g_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2689,7 +2524,6 @@ tables:
   - name: g_base_SdssShape_y
     '@id': '#forced_photometry.g_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2697,7 +2531,6 @@ tables:
   - name: g_base_SdssShape_instFlux
     '@id': '#forced_photometry.g_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -2705,7 +2538,6 @@ tables:
   - name: g_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.g_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -2713,7 +2545,6 @@ tables:
   - name: g_base_SdssShape_psf_xx
     '@id': '#forced_photometry.g_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -2721,7 +2552,6 @@ tables:
   - name: g_base_SdssShape_psf_yy
     '@id': '#forced_photometry.g_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -2729,7 +2559,6 @@ tables:
   - name: g_base_SdssShape_psf_xy
     '@id': '#forced_photometry.g_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -2737,7 +2566,6 @@ tables:
   - name: g_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -2745,7 +2573,6 @@ tables:
   - name: g_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -2753,7 +2580,6 @@ tables:
   - name: g_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.g_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -2818,7 +2644,6 @@ tables:
   - name: g_base_PsfFlux_instFlux
     '@id': '#forced_photometry.g_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -2826,7 +2651,6 @@ tables:
   - name: g_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.g_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -2834,7 +2658,6 @@ tables:
   - name: g_base_PsfFlux_area
     '@id': '#forced_photometry.g_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -2842,7 +2665,6 @@ tables:
   - name: g_base_PsfFlux_apCorr
     '@id': '#forced_photometry.g_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -2850,7 +2672,6 @@ tables:
   - name: g_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.g_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -2899,7 +2720,6 @@ tables:
   - name: g_base_InputCount_value
     '@id': '#forced_photometry.g_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -2931,7 +2751,6 @@ tables:
   - name: g_base_Variance_value
     '@id': '#forced_photometry.g_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -2963,7 +2782,6 @@ tables:
   - name: g_base_LocalBackground_instFlux
     '@id': '#forced_photometry.g_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -2971,7 +2789,6 @@ tables:
   - name: g_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.g_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -3011,7 +2828,6 @@ tables:
   - name: g_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -3019,7 +2835,6 @@ tables:
   - name: g_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -3027,7 +2842,6 @@ tables:
   - name: g_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -3035,7 +2849,6 @@ tables:
   - name: g_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -3043,7 +2856,6 @@ tables:
   - name: g_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -3051,7 +2863,6 @@ tables:
   - name: g_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -3059,7 +2870,6 @@ tables:
   - name: g_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.g_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -3067,7 +2877,6 @@ tables:
   - name: g_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -3075,7 +2884,6 @@ tables:
   - name: g_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -3083,7 +2891,6 @@ tables:
   - name: g_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -3091,7 +2898,6 @@ tables:
   - name: g_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -3099,7 +2905,6 @@ tables:
   - name: g_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -3107,7 +2912,6 @@ tables:
   - name: g_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -3115,7 +2919,6 @@ tables:
   - name: g_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -3123,7 +2926,6 @@ tables:
   - name: g_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -3416,7 +3218,6 @@ tables:
   - name: i_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.i_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -3432,7 +3233,6 @@ tables:
   - name: i_modelfit_CModel_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -3440,7 +3240,6 @@ tables:
   - name: i_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -3448,7 +3247,6 @@ tables:
   - name: i_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -3456,7 +3254,6 @@ tables:
   - name: i_modelfit_CModel_fracDev
     '@id': '#forced_photometry.i_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -3464,7 +3261,6 @@ tables:
   - name: i_modelfit_CModel_objective
     '@id': '#forced_photometry.i_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -3472,7 +3268,6 @@ tables:
   - name: i_modelfit_CModel_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -3480,7 +3275,6 @@ tables:
   - name: i_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -3545,7 +3339,6 @@ tables:
   - name: i_base_SdssCentroid_x
     '@id': '#forced_photometry.i_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -3553,7 +3346,6 @@ tables:
   - name: i_base_SdssCentroid_y
     '@id': '#forced_photometry.i_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -3561,7 +3353,6 @@ tables:
   - name: i_base_SdssCentroid_xErr
     '@id': '#forced_photometry.i_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -3569,7 +3360,6 @@ tables:
   - name: i_base_SdssCentroid_yErr
     '@id': '#forced_photometry.i_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -3633,7 +3423,6 @@ tables:
   - name: i_base_SdssShape_xx
     '@id': '#forced_photometry.i_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3641,7 +3430,6 @@ tables:
   - name: i_base_SdssShape_yy
     '@id': '#forced_photometry.i_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3649,7 +3437,6 @@ tables:
   - name: i_base_SdssShape_xy
     '@id': '#forced_photometry.i_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3657,7 +3444,6 @@ tables:
   - name: i_base_SdssShape_xxErr
     '@id': '#forced_photometry.i_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -3665,7 +3451,6 @@ tables:
   - name: i_base_SdssShape_yyErr
     '@id': '#forced_photometry.i_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -3673,7 +3458,6 @@ tables:
   - name: i_base_SdssShape_xyErr
     '@id': '#forced_photometry.i_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -3681,7 +3465,6 @@ tables:
   - name: i_base_SdssShape_x
     '@id': '#forced_photometry.i_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3689,7 +3472,6 @@ tables:
   - name: i_base_SdssShape_y
     '@id': '#forced_photometry.i_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3697,7 +3479,6 @@ tables:
   - name: i_base_SdssShape_instFlux
     '@id': '#forced_photometry.i_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -3705,7 +3486,6 @@ tables:
   - name: i_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.i_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -3713,7 +3493,6 @@ tables:
   - name: i_base_SdssShape_psf_xx
     '@id': '#forced_photometry.i_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -3721,7 +3500,6 @@ tables:
   - name: i_base_SdssShape_psf_yy
     '@id': '#forced_photometry.i_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -3729,7 +3507,6 @@ tables:
   - name: i_base_SdssShape_psf_xy
     '@id': '#forced_photometry.i_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -3737,7 +3514,6 @@ tables:
   - name: i_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -3745,7 +3521,6 @@ tables:
   - name: i_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -3753,7 +3528,6 @@ tables:
   - name: i_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.i_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -3818,7 +3592,6 @@ tables:
   - name: i_base_PsfFlux_instFlux
     '@id': '#forced_photometry.i_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -3826,7 +3599,6 @@ tables:
   - name: i_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.i_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -3834,7 +3606,6 @@ tables:
   - name: i_base_PsfFlux_area
     '@id': '#forced_photometry.i_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -3842,7 +3613,6 @@ tables:
   - name: i_base_PsfFlux_apCorr
     '@id': '#forced_photometry.i_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -3850,7 +3620,6 @@ tables:
   - name: i_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.i_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -3899,7 +3668,6 @@ tables:
   - name: i_base_InputCount_value
     '@id': '#forced_photometry.i_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -3931,7 +3699,6 @@ tables:
   - name: i_base_Variance_value
     '@id': '#forced_photometry.i_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -3963,7 +3730,6 @@ tables:
   - name: i_base_LocalBackground_instFlux
     '@id': '#forced_photometry.i_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -3971,7 +3737,6 @@ tables:
   - name: i_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.i_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -4011,7 +3776,6 @@ tables:
   - name: i_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -4019,7 +3783,6 @@ tables:
   - name: i_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -4027,7 +3790,6 @@ tables:
   - name: i_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -4035,7 +3797,6 @@ tables:
   - name: i_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -4043,7 +3804,6 @@ tables:
   - name: i_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -4051,7 +3811,6 @@ tables:
   - name: i_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -4059,7 +3818,6 @@ tables:
   - name: i_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.i_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -4067,7 +3825,6 @@ tables:
   - name: i_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -4075,7 +3832,6 @@ tables:
   - name: i_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -4083,7 +3839,6 @@ tables:
   - name: i_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -4091,7 +3846,6 @@ tables:
   - name: i_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -4099,7 +3853,6 @@ tables:
   - name: i_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -4107,7 +3860,6 @@ tables:
   - name: i_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -4115,7 +3867,6 @@ tables:
   - name: i_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -4123,7 +3874,6 @@ tables:
   - name: i_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -4416,7 +4166,6 @@ tables:
   - name: r_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.r_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -4432,7 +4181,6 @@ tables:
   - name: r_modelfit_CModel_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -4440,7 +4188,6 @@ tables:
   - name: r_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -4448,7 +4195,6 @@ tables:
   - name: r_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -4456,7 +4202,6 @@ tables:
   - name: r_modelfit_CModel_fracDev
     '@id': '#forced_photometry.r_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -4464,7 +4209,6 @@ tables:
   - name: r_modelfit_CModel_objective
     '@id': '#forced_photometry.r_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -4472,7 +4216,6 @@ tables:
   - name: r_modelfit_CModel_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -4480,7 +4223,6 @@ tables:
   - name: r_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -4545,7 +4287,6 @@ tables:
   - name: r_base_SdssCentroid_x
     '@id': '#forced_photometry.r_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -4553,7 +4294,6 @@ tables:
   - name: r_base_SdssCentroid_y
     '@id': '#forced_photometry.r_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -4561,7 +4301,6 @@ tables:
   - name: r_base_SdssCentroid_xErr
     '@id': '#forced_photometry.r_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -4569,7 +4308,6 @@ tables:
   - name: r_base_SdssCentroid_yErr
     '@id': '#forced_photometry.r_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -4633,7 +4371,6 @@ tables:
   - name: r_base_SdssShape_xx
     '@id': '#forced_photometry.r_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4641,7 +4378,6 @@ tables:
   - name: r_base_SdssShape_yy
     '@id': '#forced_photometry.r_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4649,7 +4385,6 @@ tables:
   - name: r_base_SdssShape_xy
     '@id': '#forced_photometry.r_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4657,7 +4392,6 @@ tables:
   - name: r_base_SdssShape_xxErr
     '@id': '#forced_photometry.r_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -4665,7 +4399,6 @@ tables:
   - name: r_base_SdssShape_yyErr
     '@id': '#forced_photometry.r_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -4673,7 +4406,6 @@ tables:
   - name: r_base_SdssShape_xyErr
     '@id': '#forced_photometry.r_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -4681,7 +4413,6 @@ tables:
   - name: r_base_SdssShape_x
     '@id': '#forced_photometry.r_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4689,7 +4420,6 @@ tables:
   - name: r_base_SdssShape_y
     '@id': '#forced_photometry.r_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4697,7 +4427,6 @@ tables:
   - name: r_base_SdssShape_instFlux
     '@id': '#forced_photometry.r_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -4705,7 +4434,6 @@ tables:
   - name: r_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.r_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -4713,7 +4441,6 @@ tables:
   - name: r_base_SdssShape_psf_xx
     '@id': '#forced_photometry.r_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -4721,7 +4448,6 @@ tables:
   - name: r_base_SdssShape_psf_yy
     '@id': '#forced_photometry.r_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -4729,7 +4455,6 @@ tables:
   - name: r_base_SdssShape_psf_xy
     '@id': '#forced_photometry.r_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -4737,7 +4462,6 @@ tables:
   - name: r_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -4745,7 +4469,6 @@ tables:
   - name: r_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -4753,7 +4476,6 @@ tables:
   - name: r_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.r_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -4818,7 +4540,6 @@ tables:
   - name: r_base_PsfFlux_instFlux
     '@id': '#forced_photometry.r_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -4826,7 +4547,6 @@ tables:
   - name: r_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.r_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -4834,7 +4554,6 @@ tables:
   - name: r_base_PsfFlux_area
     '@id': '#forced_photometry.r_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -4842,7 +4561,6 @@ tables:
   - name: r_base_PsfFlux_apCorr
     '@id': '#forced_photometry.r_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -4850,7 +4568,6 @@ tables:
   - name: r_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.r_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -4899,7 +4616,6 @@ tables:
   - name: r_base_InputCount_value
     '@id': '#forced_photometry.r_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -4931,7 +4647,6 @@ tables:
   - name: r_base_Variance_value
     '@id': '#forced_photometry.r_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -4963,7 +4678,6 @@ tables:
   - name: r_base_LocalBackground_instFlux
     '@id': '#forced_photometry.r_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -4971,7 +4685,6 @@ tables:
   - name: r_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.r_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -5011,7 +4724,6 @@ tables:
   - name: r_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -5019,7 +4731,6 @@ tables:
   - name: r_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -5027,7 +4738,6 @@ tables:
   - name: r_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -5035,7 +4745,6 @@ tables:
   - name: r_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -5043,7 +4752,6 @@ tables:
   - name: r_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -5051,7 +4759,6 @@ tables:
   - name: r_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -5059,7 +4766,6 @@ tables:
   - name: r_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.r_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -5067,7 +4773,6 @@ tables:
   - name: r_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -5075,7 +4780,6 @@ tables:
   - name: r_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -5083,7 +4787,6 @@ tables:
   - name: r_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -5091,7 +4794,6 @@ tables:
   - name: r_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -5099,7 +4801,6 @@ tables:
   - name: r_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -5107,7 +4808,6 @@ tables:
   - name: r_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -5115,7 +4815,6 @@ tables:
   - name: r_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -5123,7 +4822,6 @@ tables:
   - name: r_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -5416,7 +5114,6 @@ tables:
   - name: u_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.u_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -5432,7 +5129,6 @@ tables:
   - name: u_modelfit_CModel_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -5440,7 +5136,6 @@ tables:
   - name: u_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -5448,7 +5143,6 @@ tables:
   - name: u_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -5456,7 +5150,6 @@ tables:
   - name: u_modelfit_CModel_fracDev
     '@id': '#forced_photometry.u_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -5464,7 +5157,6 @@ tables:
   - name: u_modelfit_CModel_objective
     '@id': '#forced_photometry.u_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -5472,7 +5164,6 @@ tables:
   - name: u_modelfit_CModel_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -5480,7 +5171,6 @@ tables:
   - name: u_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -5545,7 +5235,6 @@ tables:
   - name: u_base_SdssCentroid_x
     '@id': '#forced_photometry.u_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -5553,7 +5242,6 @@ tables:
   - name: u_base_SdssCentroid_y
     '@id': '#forced_photometry.u_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -5561,7 +5249,6 @@ tables:
   - name: u_base_SdssCentroid_xErr
     '@id': '#forced_photometry.u_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -5569,7 +5256,6 @@ tables:
   - name: u_base_SdssCentroid_yErr
     '@id': '#forced_photometry.u_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -5633,7 +5319,6 @@ tables:
   - name: u_base_SdssShape_xx
     '@id': '#forced_photometry.u_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5641,7 +5326,6 @@ tables:
   - name: u_base_SdssShape_yy
     '@id': '#forced_photometry.u_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5649,7 +5333,6 @@ tables:
   - name: u_base_SdssShape_xy
     '@id': '#forced_photometry.u_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5657,7 +5340,6 @@ tables:
   - name: u_base_SdssShape_xxErr
     '@id': '#forced_photometry.u_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -5665,7 +5347,6 @@ tables:
   - name: u_base_SdssShape_yyErr
     '@id': '#forced_photometry.u_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -5673,7 +5354,6 @@ tables:
   - name: u_base_SdssShape_xyErr
     '@id': '#forced_photometry.u_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -5681,7 +5361,6 @@ tables:
   - name: u_base_SdssShape_x
     '@id': '#forced_photometry.u_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5689,7 +5368,6 @@ tables:
   - name: u_base_SdssShape_y
     '@id': '#forced_photometry.u_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5697,7 +5375,6 @@ tables:
   - name: u_base_SdssShape_instFlux
     '@id': '#forced_photometry.u_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -5705,7 +5382,6 @@ tables:
   - name: u_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.u_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -5713,7 +5389,6 @@ tables:
   - name: u_base_SdssShape_psf_xx
     '@id': '#forced_photometry.u_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -5721,7 +5396,6 @@ tables:
   - name: u_base_SdssShape_psf_yy
     '@id': '#forced_photometry.u_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -5729,7 +5403,6 @@ tables:
   - name: u_base_SdssShape_psf_xy
     '@id': '#forced_photometry.u_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -5737,7 +5410,6 @@ tables:
   - name: u_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -5745,7 +5417,6 @@ tables:
   - name: u_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -5753,7 +5424,6 @@ tables:
   - name: u_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.u_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -5818,7 +5488,6 @@ tables:
   - name: u_base_PsfFlux_instFlux
     '@id': '#forced_photometry.u_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -5826,7 +5495,6 @@ tables:
   - name: u_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.u_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -5834,7 +5502,6 @@ tables:
   - name: u_base_PsfFlux_area
     '@id': '#forced_photometry.u_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -5842,7 +5509,6 @@ tables:
   - name: u_base_PsfFlux_apCorr
     '@id': '#forced_photometry.u_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -5850,7 +5516,6 @@ tables:
   - name: u_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.u_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -5899,7 +5564,6 @@ tables:
   - name: u_base_InputCount_value
     '@id': '#forced_photometry.u_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -5931,7 +5595,6 @@ tables:
   - name: u_base_Variance_value
     '@id': '#forced_photometry.u_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -5963,7 +5626,6 @@ tables:
   - name: u_base_LocalBackground_instFlux
     '@id': '#forced_photometry.u_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -5971,7 +5633,6 @@ tables:
   - name: u_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.u_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -6011,7 +5672,6 @@ tables:
   - name: u_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -6019,7 +5679,6 @@ tables:
   - name: u_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -6027,7 +5686,6 @@ tables:
   - name: u_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -6035,7 +5693,6 @@ tables:
   - name: u_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -6043,7 +5700,6 @@ tables:
   - name: u_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -6051,7 +5707,6 @@ tables:
   - name: u_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -6059,7 +5714,6 @@ tables:
   - name: u_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.u_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -6067,7 +5721,6 @@ tables:
   - name: u_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -6075,7 +5728,6 @@ tables:
   - name: u_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -6083,7 +5735,6 @@ tables:
   - name: u_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -6091,7 +5742,6 @@ tables:
   - name: u_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -6099,7 +5749,6 @@ tables:
   - name: u_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -6107,7 +5756,6 @@ tables:
   - name: u_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -6115,7 +5763,6 @@ tables:
   - name: u_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -6123,7 +5770,6 @@ tables:
   - name: u_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -6416,7 +6062,6 @@ tables:
   - name: y_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.y_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -6432,7 +6077,6 @@ tables:
   - name: y_modelfit_CModel_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -6440,7 +6084,6 @@ tables:
   - name: y_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -6448,7 +6091,6 @@ tables:
   - name: y_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -6456,7 +6098,6 @@ tables:
   - name: y_modelfit_CModel_fracDev
     '@id': '#forced_photometry.y_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -6464,7 +6105,6 @@ tables:
   - name: y_modelfit_CModel_objective
     '@id': '#forced_photometry.y_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -6472,7 +6112,6 @@ tables:
   - name: y_modelfit_CModel_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -6480,7 +6119,6 @@ tables:
   - name: y_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -6545,7 +6183,6 @@ tables:
   - name: y_base_SdssCentroid_x
     '@id': '#forced_photometry.y_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -6553,7 +6190,6 @@ tables:
   - name: y_base_SdssCentroid_y
     '@id': '#forced_photometry.y_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -6561,7 +6197,6 @@ tables:
   - name: y_base_SdssCentroid_xErr
     '@id': '#forced_photometry.y_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -6569,7 +6204,6 @@ tables:
   - name: y_base_SdssCentroid_yErr
     '@id': '#forced_photometry.y_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -6633,7 +6267,6 @@ tables:
   - name: y_base_SdssShape_xx
     '@id': '#forced_photometry.y_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6641,7 +6274,6 @@ tables:
   - name: y_base_SdssShape_yy
     '@id': '#forced_photometry.y_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6649,7 +6281,6 @@ tables:
   - name: y_base_SdssShape_xy
     '@id': '#forced_photometry.y_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6657,7 +6288,6 @@ tables:
   - name: y_base_SdssShape_xxErr
     '@id': '#forced_photometry.y_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -6665,7 +6295,6 @@ tables:
   - name: y_base_SdssShape_yyErr
     '@id': '#forced_photometry.y_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -6673,7 +6302,6 @@ tables:
   - name: y_base_SdssShape_xyErr
     '@id': '#forced_photometry.y_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -6681,7 +6309,6 @@ tables:
   - name: y_base_SdssShape_x
     '@id': '#forced_photometry.y_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6689,7 +6316,6 @@ tables:
   - name: y_base_SdssShape_y
     '@id': '#forced_photometry.y_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6697,7 +6323,6 @@ tables:
   - name: y_base_SdssShape_instFlux
     '@id': '#forced_photometry.y_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -6705,7 +6330,6 @@ tables:
   - name: y_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.y_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -6713,7 +6337,6 @@ tables:
   - name: y_base_SdssShape_psf_xx
     '@id': '#forced_photometry.y_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -6721,7 +6344,6 @@ tables:
   - name: y_base_SdssShape_psf_yy
     '@id': '#forced_photometry.y_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -6729,7 +6351,6 @@ tables:
   - name: y_base_SdssShape_psf_xy
     '@id': '#forced_photometry.y_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -6737,7 +6358,6 @@ tables:
   - name: y_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -6745,7 +6365,6 @@ tables:
   - name: y_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -6753,7 +6372,6 @@ tables:
   - name: y_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.y_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -6818,7 +6436,6 @@ tables:
   - name: y_base_PsfFlux_instFlux
     '@id': '#forced_photometry.y_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -6826,7 +6443,6 @@ tables:
   - name: y_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.y_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -6834,7 +6450,6 @@ tables:
   - name: y_base_PsfFlux_area
     '@id': '#forced_photometry.y_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -6842,7 +6457,6 @@ tables:
   - name: y_base_PsfFlux_apCorr
     '@id': '#forced_photometry.y_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -6850,7 +6464,6 @@ tables:
   - name: y_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.y_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -6899,7 +6512,6 @@ tables:
   - name: y_base_InputCount_value
     '@id': '#forced_photometry.y_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -6931,7 +6543,6 @@ tables:
   - name: y_base_Variance_value
     '@id': '#forced_photometry.y_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -6963,7 +6574,6 @@ tables:
   - name: y_base_LocalBackground_instFlux
     '@id': '#forced_photometry.y_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -6971,7 +6581,6 @@ tables:
   - name: y_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.y_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -7011,7 +6620,6 @@ tables:
   - name: y_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -7019,7 +6627,6 @@ tables:
   - name: y_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -7027,7 +6634,6 @@ tables:
   - name: y_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -7035,7 +6641,6 @@ tables:
   - name: y_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -7043,7 +6648,6 @@ tables:
   - name: y_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -7051,7 +6655,6 @@ tables:
   - name: y_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -7059,7 +6662,6 @@ tables:
   - name: y_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.y_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -7067,7 +6669,6 @@ tables:
   - name: y_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -7075,7 +6676,6 @@ tables:
   - name: y_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -7083,7 +6683,6 @@ tables:
   - name: y_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -7091,7 +6690,6 @@ tables:
   - name: y_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -7099,7 +6697,6 @@ tables:
   - name: y_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -7107,7 +6704,6 @@ tables:
   - name: y_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -7115,7 +6711,6 @@ tables:
   - name: y_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -7123,7 +6718,6 @@ tables:
   - name: y_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -7416,7 +7010,6 @@ tables:
   - name: z_base_ClassificationExtendedness_value
     '@id': '#forced_photometry.z_base_ClassificationExtendedness_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for extended sources, 0 for point sources.
@@ -7432,7 +7025,6 @@ tables:
   - name: z_modelfit_CModel_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux from the final cmodel fit
@@ -7440,7 +7032,6 @@ tables:
   - name: z_modelfit_CModel_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     description: flux uncertainty from the final cmodel fit
@@ -7448,7 +7039,6 @@ tables:
   - name: z_modelfit_CModel_instFlux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_instFlux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux within the fit region, with no extrapolation
@@ -7456,7 +7046,6 @@ tables:
   - name: z_modelfit_CModel_fracDev
     '@id': '#forced_photometry.z_modelfit_CModel_fracDev'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: fraction of flux in de Vaucouleur component
@@ -7464,7 +7053,6 @@ tables:
   - name: z_modelfit_CModel_objective
     '@id': '#forced_photometry.z_modelfit_CModel_objective'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: -ln(likelihood) (chi^2) in cmodel fit
@@ -7472,7 +7060,6 @@ tables:
   - name: z_modelfit_CModel_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel
@@ -7480,7 +7067,6 @@ tables:
   - name: z_modelfit_CModel_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel
@@ -7545,7 +7131,6 @@ tables:
   - name: z_base_SdssCentroid_x
     '@id': '#forced_photometry.z_base_SdssCentroid_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -7553,7 +7138,6 @@ tables:
   - name: z_base_SdssCentroid_y
     '@id': '#forced_photometry.z_base_SdssCentroid_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: centroid from Sdss Centroid algorithm
@@ -7561,7 +7145,6 @@ tables:
   - name: z_base_SdssCentroid_xErr
     '@id': '#forced_photometry.z_base_SdssCentroid_xErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on x position
@@ -7569,7 +7152,6 @@ tables:
   - name: z_base_SdssCentroid_yErr
     '@id': '#forced_photometry.z_base_SdssCentroid_yErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma uncertainty on y position
@@ -7633,7 +7215,6 @@ tables:
   - name: z_base_SdssShape_xx
     '@id': '#forced_photometry.z_base_SdssShape_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7641,7 +7222,6 @@ tables:
   - name: z_base_SdssShape_yy
     '@id': '#forced_photometry.z_base_SdssShape_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7649,7 +7229,6 @@ tables:
   - name: z_base_SdssShape_xy
     '@id': '#forced_photometry.z_base_SdssShape_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7657,7 +7236,6 @@ tables:
   - name: z_base_SdssShape_xxErr
     '@id': '#forced_photometry.z_base_SdssShape_xxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xx moment
@@ -7665,7 +7243,6 @@ tables:
   - name: z_base_SdssShape_yyErr
     '@id': '#forced_photometry.z_base_SdssShape_yyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of yy moment
@@ -7673,7 +7250,6 @@ tables:
   - name: z_base_SdssShape_xyErr
     '@id': '#forced_photometry.z_base_SdssShape_xyErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Standard deviation of xy moment
@@ -7681,7 +7257,6 @@ tables:
   - name: z_base_SdssShape_x
     '@id': '#forced_photometry.z_base_SdssShape_x'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7689,7 +7264,6 @@ tables:
   - name: z_base_SdssShape_y
     '@id': '#forced_photometry.z_base_SdssShape_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7697,7 +7271,6 @@ tables:
   - name: z_base_SdssShape_instFlux
     '@id': '#forced_photometry.z_base_SdssShape_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: elliptical Gaussian adaptive moments
@@ -7705,7 +7278,6 @@ tables:
   - name: z_base_SdssShape_instFluxErr
     '@id': '#forced_photometry.z_base_SdssShape_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -7713,7 +7285,6 @@ tables:
   - name: z_base_SdssShape_psf_xx
     '@id': '#forced_photometry.z_base_SdssShape_psf_xx'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -7721,7 +7292,6 @@ tables:
   - name: z_base_SdssShape_psf_yy
     '@id': '#forced_photometry.z_base_SdssShape_psf_yy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -7729,7 +7299,6 @@ tables:
   - name: z_base_SdssShape_psf_xy
     '@id': '#forced_photometry.z_base_SdssShape_psf_xy'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: adaptive moments of the PSF model at the object position
@@ -7737,7 +7306,6 @@ tables:
   - name: z_base_SdssShape_instFlux_xx_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xx_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xx
@@ -7745,7 +7313,6 @@ tables:
   - name: z_base_SdssShape_instFlux_yy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_yy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_yy
@@ -7753,7 +7320,6 @@ tables:
   - name: z_base_SdssShape_instFlux_xy_Cov
     '@id': '#forced_photometry.z_base_SdssShape_instFlux_xy_Cov'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: uncertainty covariance between base_SdssShape_instFlux and base_SdssShape_xy
@@ -7818,7 +7384,6 @@ tables:
   - name: z_base_PsfFlux_instFlux
     '@id': '#forced_photometry.z_base_PsfFlux_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: instFlux derived from linear least-squares fit of PSF model
@@ -7826,7 +7391,6 @@ tables:
   - name: z_base_PsfFlux_instFluxErr
     '@id': '#forced_photometry.z_base_PsfFlux_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -7834,7 +7398,6 @@ tables:
   - name: z_base_PsfFlux_area
     '@id': '#forced_photometry.z_base_PsfFlux_area'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: effective area of PSF
@@ -7842,7 +7405,6 @@ tables:
   - name: z_base_PsfFlux_apCorr
     '@id': '#forced_photometry.z_base_PsfFlux_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to base_PsfFlux
@@ -7850,7 +7412,6 @@ tables:
   - name: z_base_PsfFlux_apCorrErr
     '@id': '#forced_photometry.z_base_PsfFlux_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to base_PsfFlux
@@ -7899,7 +7460,6 @@ tables:
   - name: z_base_InputCount_value
     '@id': '#forced_photometry.z_base_InputCount_value'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of images contributing at center, not including anyclipping
@@ -7931,7 +7491,6 @@ tables:
   - name: z_base_Variance_value
     '@id': '#forced_photometry.z_base_Variance_value'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Variance at object position
@@ -7963,7 +7522,6 @@ tables:
   - name: z_base_LocalBackground_instFlux
     '@id': '#forced_photometry.z_base_LocalBackground_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: background in annulus around source
@@ -7971,7 +7529,6 @@ tables:
   - name: z_base_LocalBackground_instFluxErr
     '@id': '#forced_photometry.z_base_LocalBackground_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: 1-sigma instFlux uncertainty
@@ -8011,7 +7568,6 @@ tables:
   - name: z_modelfit_CModel_initial_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_initial_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit
@@ -8019,7 +7575,6 @@ tables:
   - name: z_modelfit_CModel_initial_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the initial fit
@@ -8027,7 +7582,6 @@ tables:
   - name: z_modelfit_CModel_initial_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the initial fit region, with no extrapolation
@@ -8035,7 +7589,6 @@ tables:
   - name: z_modelfit_CModel_exp_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_exp_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit
@@ -8043,7 +7596,6 @@ tables:
   - name: z_modelfit_CModel_exp_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the exponential fit
@@ -8051,7 +7603,6 @@ tables:
   - name: z_modelfit_CModel_exp_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the exponential fit region, with no extrapolation
@@ -8059,7 +7610,6 @@ tables:
   - name: z_modelfit_CModel_dev_instFlux
     '@id': '#forced_photometry.z_modelfit_CModel_dev_instFlux'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit
@@ -8067,7 +7617,6 @@ tables:
   - name: z_modelfit_CModel_dev_instFluxErr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_instFluxErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux uncertainty from the de Vaucouleur fit
@@ -8075,7 +7624,6 @@ tables:
   - name: z_modelfit_CModel_dev_flux_inner
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flux_inner'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: flux from the de Vaucouleur fit region, with no extrapolation
@@ -8083,7 +7631,6 @@ tables:
   - name: z_modelfit_CModel_exp_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_exp
@@ -8091,7 +7638,6 @@ tables:
   - name: z_modelfit_CModel_exp_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_exp
@@ -8099,7 +7645,6 @@ tables:
   - name: z_modelfit_CModel_dev_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_dev
@@ -8107,7 +7652,6 @@ tables:
   - name: z_modelfit_CModel_dev_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_dev
@@ -8115,7 +7659,6 @@ tables:
   - name: z_modelfit_CModel_initial_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_apCorr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: aperture correction applied to modelfit_CModel_initial
@@ -8123,7 +7666,6 @@ tables:
   - name: z_modelfit_CModel_initial_apCorrErr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_apCorrErr'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: standard deviation of aperture correction applied to modelfit_CModel_initial
@@ -8240,7 +7782,6 @@ tables:
     datatype: long
     nullable: false
     description: Unique id.
-    mysql:datatype: BIGINT
     tap:column_index: 1
     tap:principal: 1
     ivoa:ucd: meta.id;src
@@ -8248,7 +7789,6 @@ tables:
     '@id': '#object.parentObjectId'
     datatype: long
     description: Id of the parent object this object has been deblended from, if any.
-    mysql:datatype: BIGINT
     tap:column_index: 2
     tap:principal: 1
   - name: ra
@@ -8256,7 +7796,6 @@ tables:
     datatype: double
     nullable: false
     description: RA-coordinate of the center of the object for the Point Source model.
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     fits:tunit: deg
@@ -8267,7 +7806,6 @@ tables:
     nullable: false
     description: Decl-coordinate of the center of the object for the Point Source
       model.
-    mysql:datatype: DOUBLE
     tap:column_index: 4
     tap:principal: 1
     fits:tunit: deg
@@ -8276,7 +7814,6 @@ tables:
     '@id': '#object.tract'
     datatype: long
     description: tract ID
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
   - name: patch
@@ -8291,7 +7828,6 @@ tables:
     '@id': '#object.x'
     datatype: double
     description: 2D centroid location (x coordinate)
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: pixel
@@ -8300,7 +7836,6 @@ tables:
     '@id': '#object.y'
     datatype: double
     description: 2D centroid location (y coordinate)
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: pixel
@@ -8309,7 +7844,6 @@ tables:
     '@id': '#object.xErr'
     datatype: float
     description: error on x
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: pixel
@@ -8318,7 +7852,6 @@ tables:
     '@id': '#object.yErr'
     datatype: float
     description: error on Y
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: pixel
@@ -8334,14 +7867,12 @@ tables:
     '@id': '#object.psNdata'
     datatype: float
     description: Number of data points (pixels) used to fit the model
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
   - name: extendedness
     '@id': '#object.extendedness'
     datatype: double
     description: 0:star, 1:extended.  DM Stack `base_ClassificationExtendedness_value
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
   - name: blendedness
@@ -8349,14 +7880,12 @@ tables:
     datatype: double
     description: measure of how flux is affected by neighbors (1 - flux.child/flux.parent)
       (see 4.9.11 of [1705.06766](https://arxiv.org/abs/1705.06766))
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
   - name: Ixx_pixel
     '@id': '#object.Ixx_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8364,7 +7893,6 @@ tables:
     '@id': '#object.Iyy_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8372,7 +7900,6 @@ tables:
     '@id': '#object.Ixy_pixel'
     datatype: double
     description: Adaptive second moment of the source intensity across bands.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8387,7 +7914,6 @@ tables:
     '@id': '#object.IxxPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8395,7 +7921,6 @@ tables:
     '@id': '#object.IyyPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8403,7 +7928,6 @@ tables:
     '@id': '#object.IxyPSF_pixel'
     datatype: double
     description: Adaptive second moment of the PSF across bands
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy.arcsec**2
@@ -8411,7 +7935,6 @@ tables:
     '@id': '#object.mag_g_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for g filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8419,7 +7942,6 @@ tables:
     '@id': '#object.mag_i_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for i filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8427,7 +7949,6 @@ tables:
     '@id': '#object.mag_r_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for r filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8435,7 +7956,6 @@ tables:
     '@id': '#object.mag_u_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for u filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8443,7 +7963,6 @@ tables:
     '@id': '#object.mag_y_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for y filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8451,7 +7970,6 @@ tables:
     '@id': '#object.mag_z_cModel'
     datatype: double
     description: Composite model (cModel) magnitude for z filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8459,7 +7977,6 @@ tables:
     '@id': '#object.magerr_g_cModel'
     datatype: double
     description: Error on mag_g_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8468,7 +7985,6 @@ tables:
     '@id': '#object.magerr_i_cModel'
     datatype: double
     description: Error on mag_i_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8477,7 +7993,6 @@ tables:
     '@id': '#object.magerr_r_cModel'
     datatype: double
     description: Error on mag_r_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8486,7 +8001,6 @@ tables:
     '@id': '#object.magerr_u_cModel'
     datatype: double
     description: Error on mag_u_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8495,7 +8009,6 @@ tables:
     '@id': '#object.magerr_y_cModel'
     datatype: double
     description: Error on mag_y_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8504,7 +8017,6 @@ tables:
     '@id': '#object.magerr_z_cModel'
     datatype: double
     description: Error on mag_z_cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -8513,7 +8025,6 @@ tables:
     '@id': '#object.snr_g_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for g filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8521,7 +8032,6 @@ tables:
     '@id': '#object.snr_i_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for i filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8529,7 +8039,6 @@ tables:
     '@id': '#object.snr_r_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for r filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8537,7 +8046,6 @@ tables:
     '@id': '#object.snr_u_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for u filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8545,7 +8053,6 @@ tables:
     '@id': '#object.snr_y_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for y filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8553,7 +8060,6 @@ tables:
     '@id': '#object.snr_z_cModel'
     datatype: double
     description: Signal to noise ratio for magnitude for z filter fitted by cModel
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     ivoa:ucd: stat.snr
@@ -8561,7 +8067,6 @@ tables:
     '@id': '#object.psFlux_g'
     datatype: double
     description: Calibrated flux for Point Source model for g filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8570,7 +8075,6 @@ tables:
     '@id': '#object.psFlux_i'
     datatype: double
     description: Calibrated flux for Point Source model for i filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8579,7 +8083,6 @@ tables:
     '@id': '#object.psFlux_r'
     datatype: double
     description: Calibrated flux for Point Source model for r filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8588,7 +8091,6 @@ tables:
     '@id': '#object.psFlux_u'
     datatype: double
     description: Calibrated flux for Point Source model for u filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8597,7 +8099,6 @@ tables:
     '@id': '#object.psFlux_y'
     datatype: double
     description: Calibrated flux for Point Source model for y filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8606,7 +8107,6 @@ tables:
     '@id': '#object.psFlux_z'
     datatype: double
     description: Calibrated flux for Point Source model for z filter.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8657,7 +8157,6 @@ tables:
     '@id': '#object.psFluxErr_g'
     datatype: double
     description: Uncertainty of psFlux_g.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8666,7 +8165,6 @@ tables:
     '@id': '#object.psFluxErr_i'
     datatype: double
     description: Uncertainty of psFlux_i.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8675,7 +8173,6 @@ tables:
     '@id': '#object.psFluxErr_r'
     datatype: double
     description: Uncertainty of psFlux_r.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8684,7 +8181,6 @@ tables:
     '@id': '#object.psFluxErr_u'
     datatype: double
     description: Uncertainty of psFlux_u.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8693,7 +8189,6 @@ tables:
     '@id': '#object.psFluxErr_y'
     datatype: double
     description: Uncertainty of psFlux_y.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8702,7 +8197,6 @@ tables:
     '@id': '#object.psFluxErr_z'
     datatype: double
     description: Uncertainty of psFlux_z.
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nmgy
@@ -8711,7 +8205,6 @@ tables:
     '@id': '#object.mag_g'
     datatype: double
     description: Magnitude for g filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8719,7 +8212,6 @@ tables:
     '@id': '#object.mag_i'
     datatype: double
     description: Magnitude for i filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8727,7 +8219,6 @@ tables:
     '@id': '#object.mag_r'
     datatype: double
     description: Magnitude for r filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8735,7 +8226,6 @@ tables:
     '@id': '#object.mag_u'
     datatype: double
     description: Magnitude for u filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8743,7 +8233,6 @@ tables:
     '@id': '#object.mag_y'
     datatype: double
     description: Magnitude for y filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8751,7 +8240,6 @@ tables:
     '@id': '#object.mag_z'
     datatype: double
     description: magnitude for z filter
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8759,7 +8247,6 @@ tables:
     '@id': '#object.magerr_g'
     datatype: double
     description: Error on mag_g
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8768,7 +8255,6 @@ tables:
     '@id': '#object.magerr_i'
     datatype: double
     description: Error on mag_i
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8777,7 +8263,6 @@ tables:
     '@id': '#object.magerr_r'
     datatype: double
     description: Error on mag_r
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8786,7 +8271,6 @@ tables:
     '@id': '#object.magerr_u'
     datatype: double
     description: Error on mag_u
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8795,7 +8279,6 @@ tables:
     '@id': '#object.magerr_y'
     datatype: double
     description: Error on mag_y
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8804,7 +8287,6 @@ tables:
     '@id': '#object.magerr_z'
     datatype: double
     description: Error on mag_z
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: mag
@@ -8855,7 +8337,6 @@ tables:
     '@id': '#object.Ixx_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8863,7 +8344,6 @@ tables:
     '@id': '#object.Ixx_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8871,7 +8351,6 @@ tables:
     '@id': '#object.Ixx_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8879,7 +8358,6 @@ tables:
     '@id': '#object.Ixx_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8887,7 +8365,6 @@ tables:
     '@id': '#object.Ixx_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8895,7 +8372,6 @@ tables:
     '@id': '#object.Ixx_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8903,7 +8379,6 @@ tables:
     '@id': '#object.Iyy_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8911,7 +8386,6 @@ tables:
     '@id': '#object.Iyy_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8919,7 +8393,6 @@ tables:
     '@id': '#object.Iyy_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8927,7 +8400,6 @@ tables:
     '@id': '#object.Iyy_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8935,7 +8407,6 @@ tables:
     '@id': '#object.Iyy_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8943,7 +8414,6 @@ tables:
     '@id': '#object.Iyy_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8951,7 +8421,6 @@ tables:
     '@id': '#object.Ixy_pixel_g'
     datatype: double
     description: Adaptive second moment of the source intensity, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8959,7 +8428,6 @@ tables:
     '@id': '#object.Ixy_pixel_i'
     datatype: double
     description: Adaptive second moment of the source intensity, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8967,7 +8435,6 @@ tables:
     '@id': '#object.Ixy_pixel_r'
     datatype: double
     description: Adaptive second moment of the source intensity, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8975,7 +8442,6 @@ tables:
     '@id': '#object.Ixy_pixel_u'
     datatype: double
     description: Adaptive second moment of the source intensity, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8983,7 +8449,6 @@ tables:
     '@id': '#object.Ixy_pixel_y'
     datatype: double
     description: Adaptive second moment of the source intensity, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8991,7 +8456,6 @@ tables:
     '@id': '#object.Ixy_pixel_z'
     datatype: double
     description: Adaptive second moment of the source intensity, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -8999,7 +8463,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9007,7 +8470,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9015,7 +8477,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9023,7 +8484,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9031,7 +8491,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9039,7 +8498,6 @@ tables:
     '@id': '#object.IxxPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9047,7 +8505,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9055,7 +8512,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9063,7 +8519,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9071,7 +8526,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9079,7 +8533,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9087,7 +8540,6 @@ tables:
     '@id': '#object.IyyPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9095,7 +8547,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_g'
     datatype: double
     description: Adaptive second moment of the PSF, g band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9103,7 +8554,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_i'
     datatype: double
     description: Adaptive second moment of the PSF, i band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9111,7 +8561,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_r'
     datatype: double
     description: Adaptive second moment of the PSF, r band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9119,7 +8568,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_u'
     datatype: double
     description: Adaptive second moment of the PSF, u band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9127,7 +8575,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_y'
     datatype: double
     description: Adaptive second moment of the PSF, y band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9135,7 +8582,6 @@ tables:
     '@id': '#object.IxyPSF_pixel_z'
     datatype: double
     description: Adaptive second moment of the PSF, z band
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: arcsec**2
@@ -9156,84 +8602,72 @@ tables:
   - name: cModelFlux_g
     '@id': '#object.cModelFlux_g'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_i
     '@id': '#object.cModelFlux_i'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_r
     '@id': '#object.cModelFlux_r'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_u
     '@id': '#object.cModelFlux_u'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_y
     '@id': '#object.cModelFlux_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFlux_z
     '@id': '#object.cModelFlux_z'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: composite model (CModel) flux in _<band>
   - name: cModelFluxErr_g
     '@id': '#object.cModelFluxErr_g'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_i
     '@id': '#object.cModelFluxErr_i'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_r
     '@id': '#object.cModelFluxErr_r'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_u
     '@id': '#object.cModelFluxErr_u'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_y
     '@id': '#object.cModelFluxErr_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
   - name: cModelFluxErr_z
     '@id': '#object.cModelFluxErr_z'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: Error value for cModel flux in _<band>
@@ -9282,42 +8716,36 @@ tables:
   - name: psf_fwhm_g
     '@id': '#object.psf_fwhm_g'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_i
     '@id': '#object.psf_fwhm_i'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_r
     '@id': '#object.psf_fwhm_r'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_u
     '@id': '#object.psf_fwhm_u'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_y
     '@id': '#object.psf_fwhm_y'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
   - name: psf_fwhm_z
     '@id': '#object.psf_fwhm_z'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: PSF FWHM calculated from base_SdssShape
@@ -9337,7 +8765,6 @@ tables:
   - name: host_galaxy
     '@id': '#truth_match.host_galaxy'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: ID of the host galaxy for a SN/AGN entry (-1 for other truth types)
@@ -9345,7 +8772,6 @@ tables:
     '@id': '#truth_match.ra'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 2
     tap:principal: 1
     fits:tunit: deg
@@ -9355,7 +8781,6 @@ tables:
     '@id': '#truth_match.dec'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     fits:tunit: deg
@@ -9364,28 +8789,24 @@ tables:
   - name: redshift
     '@id': '#truth_match.redshift'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     description: Redshift
   - name: is_variable
     '@id': '#truth_match.is_variable'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 1
     description: 1 for a variable source
   - name: is_pointsource
     '@id': '#truth_match.is_pointsource'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 1
     description: 1 for a point source
   - name: flux_u
     '@id': '#truth_match.flux_u'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9393,7 +8814,6 @@ tables:
   - name: flux_g
     '@id': '#truth_match.flux_g'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9401,7 +8821,6 @@ tables:
   - name: flux_r
     '@id': '#truth_match.flux_r'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9409,7 +8828,6 @@ tables:
   - name: flux_i
     '@id': '#truth_match.flux_i'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9417,7 +8835,6 @@ tables:
   - name: flux_z
     '@id': '#truth_match.flux_z'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9425,7 +8842,6 @@ tables:
   - name: flux_y
     '@id': '#truth_match.flux_y'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9433,7 +8849,6 @@ tables:
   - name: flux_u_noMW
     '@id': '#truth_match.flux_u_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9441,7 +8856,6 @@ tables:
   - name: flux_g_noMW
     '@id': '#truth_match.flux_g_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9449,7 +8863,6 @@ tables:
   - name: flux_r_noMW
     '@id': '#truth_match.flux_r_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9457,7 +8870,6 @@ tables:
   - name: flux_i_noMW
     '@id': '#truth_match.flux_i_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9465,7 +8877,6 @@ tables:
   - name: flux_z_noMW
     '@id': '#truth_match.flux_z_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9473,7 +8884,6 @@ tables:
   - name: flux_y_noMW
     '@id': '#truth_match.flux_y_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9481,7 +8891,6 @@ tables:
   - name: mag_r
     '@id': '#truth_match.mag_r'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -9489,7 +8898,6 @@ tables:
   - name: tract
     '@id': '#truth_match.tract'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: Tract ID in Sky Map
@@ -9504,35 +8912,30 @@ tables:
   - name: cosmodc2_hp
     '@id': '#truth_match.cosmodc2_hp'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 0
     description: Healpix ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: cosmodc2_id
     '@id': '#truth_match.cosmodc2_id'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 0
     description: Galaxy ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: truth_type
     '@id': '#truth_match.truth_type'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: 1 for galaxies, 2 for stars, and 3 for SNe
   - name: match_objectId
     '@id': '#truth_match.match_objectId'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: objectId of the matching object entry (-1 for unmatched truth entries)
   - name: match_sep
     '@id': '#truth_match.match_sep'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: arcsec

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -14,27 +14,23 @@ tables:
     "@id": "#Object.objectId"
     datatype: long
     description: Unique id. Unique ObjectID
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src;meta.main
   - name: coord_dec
     "@id": "#Object.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: coord_ra
     "@id": "#Object.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: deblend_nChild
     "@id": "#Object.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Object.deblend_skipped"
@@ -88,7 +84,6 @@ tables:
     "@id": "#Object.footprintArea"
     datatype: int
     description: Number of pixels in the source's detection footprint. Reference band.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: merge_peak_sky
     "@id": "#Object.merge_peak_sky"
@@ -100,14 +95,12 @@ tables:
     "@id": "#Object.parentObjectId"
     datatype: long
     description: Unique ID of parent source. Reference band.
-    mysql:datatype: BIGINT
     fits:tunit:
     ivoa:ucd: meta.id.parent
   - name: patch
     "@id": "#Object.patch"
     datatype: long
     description: Skymap patch ID
-    mysql:datatype: BIGINT
     fits:tunit:
     ivoa:ucd: meta.id.part;obs.field
   - name: refBand
@@ -123,13 +116,11 @@ tables:
     "@id": "#Object.refExtendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: refFwhm
     "@id": "#Object.refFwhm"
     datatype: double
     description: Estimated FWHM on the reference band at source center assuming a Gaussian profile
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: shape_flag
     "@id": "#Object.shape_flag"
@@ -141,19 +132,16 @@ tables:
     "@id": "#Object.shape_xx"
     datatype: double
     description: Hirata-Seljak-Mandelbaum (HSM) moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
@@ -172,20 +160,17 @@ tables:
     "@id": "#Object.tract"
     datatype: long
     description: Skymap tract ID
-    mysql:datatype: BIGINT
     fits:tunit:
     ivoa:ucd: meta.id;obs.field
   - name: x
     "@id": "#Object.x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Object.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: xy_flag
     "@id": "#Object.xy_flag"
@@ -197,25 +182,21 @@ tables:
     "@id": "#Object.y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: yErr
     "@id": "#Object.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_ap03Flux
     "@id": "#Object.g_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03FluxErr
     "@id": "#Object.g_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03Flux_flag
     "@id": "#Object.g_ap03Flux_flag"
@@ -227,13 +208,11 @@ tables:
     "@id": "#Object.g_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06FluxErr
     "@id": "#Object.g_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06Flux_flag
     "@id": "#Object.g_ap06Flux_flag"
@@ -245,13 +224,11 @@ tables:
     "@id": "#Object.g_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09FluxErr
     "@id": "#Object.g_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09Flux_flag
     "@id": "#Object.g_ap09Flux_flag"
@@ -263,13 +240,11 @@ tables:
     "@id": "#Object.g_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12FluxErr
     "@id": "#Object.g_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12Flux_flag
     "@id": "#Object.g_ap12Flux_flag"
@@ -281,13 +256,11 @@ tables:
     "@id": "#Object.g_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17FluxErr
     "@id": "#Object.g_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17Flux_flag
     "@id": "#Object.g_ap17Flux_flag"
@@ -299,13 +272,11 @@ tables:
     "@id": "#Object.g_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25FluxErr
     "@id": "#Object.g_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25Flux_flag
     "@id": "#Object.g_ap25Flux_flag"
@@ -317,13 +288,11 @@ tables:
     "@id": "#Object.g_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35FluxErr
     "@id": "#Object.g_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35Flux_flag
     "@id": "#Object.g_ap35Flux_flag"
@@ -335,13 +304,11 @@ tables:
     "@id": "#Object.g_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50FluxErr
     "@id": "#Object.g_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50Flux_flag
     "@id": "#Object.g_ap50Flux_flag"
@@ -353,13 +320,11 @@ tables:
     "@id": "#Object.g_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70FluxErr
     "@id": "#Object.g_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70Flux_flag
     "@id": "#Object.g_ap70Flux_flag"
@@ -389,61 +354,51 @@ tables:
     "@id": "#Object.g_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_bdE1
     "@id": "#Object.g_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxBErr
     "@id": "#Object.g_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxD
     "@id": "#Object.g_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxDErr
     "@id": "#Object.g_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdReB
     "@id": "#Object.g_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_blendedness_flag
     "@id": "#Object.g_blendedness_flag"
@@ -455,19 +410,16 @@ tables:
     "@id": "#Object.g_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFluxErr
     "@id": "#Object.g_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFlux_inner
     "@id": "#Object.g_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModel_flag
     "@id": "#Object.g_cModel_flag"
@@ -485,13 +437,11 @@ tables:
     "@id": "#Object.g_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFluxErr
     "@id": "#Object.g_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFlux_flag
     "@id": "#Object.g_calibFlux_flag"
@@ -557,38 +507,32 @@ tables:
     "@id": "#Object.g_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_xErr
     "@id": "#Object.g_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_centroid_y
     "@id": "#Object.g_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_yErr
     "@id": "#Object.g_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_decl
     "@id": "#Object.g_decl"
     datatype: double
     description: Position in Declination. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: g_extendedness
     "@id": "#Object.g_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_extendedness_flag
     "@id": "#Object.g_extendedness_flag"
@@ -600,13 +544,11 @@ tables:
     "@id": "#Object.g_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFluxErr
     "@id": "#Object.g_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFlux_flag
     "@id": "#Object.g_free_cModelFlux_flag"
@@ -618,19 +560,16 @@ tables:
     "@id": "#Object.g_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux
     "@id": "#Object.g_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFluxErr
     "@id": "#Object.g_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux_flag
     "@id": "#Object.g_free_psfFlux_flag"
@@ -642,19 +581,16 @@ tables:
     "@id": "#Object.g_fwhm"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_gaap0p5Flux
     "@id": "#Object.g_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p5FluxErr
     "@id": "#Object.g_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap0p5Flux_flag_bigPsf"
@@ -666,13 +602,11 @@ tables:
     "@id": "#Object.g_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p7FluxErr
     "@id": "#Object.g_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
@@ -684,13 +618,11 @@ tables:
     "@id": "#Object.g_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0FluxErr
     "@id": "#Object.g_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
@@ -702,13 +634,11 @@ tables:
     "@id": "#Object.g_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5FluxErr
     "@id": "#Object.g_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
@@ -720,13 +650,11 @@ tables:
     "@id": "#Object.g_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5FluxErr
     "@id": "#Object.g_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
@@ -738,13 +666,11 @@ tables:
     "@id": "#Object.g_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0FluxErr
     "@id": "#Object.g_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
@@ -774,13 +700,11 @@ tables:
     "@id": "#Object.g_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFluxErr
     "@id": "#Object.g_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
@@ -792,25 +716,21 @@ tables:
     "@id": "#Object.g_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapPsfFluxErr
     "@id": "#Object.g_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_hsmShapeRegauss_e1
     "@id": "#Object.g_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_e2
     "@id": "#Object.g_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_flag
     "@id": "#Object.g_hsmShapeRegauss_flag"
@@ -822,7 +742,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_iDebiasedPSF_flag
     "@id": "#Object.g_iDebiasedPSF_flag"
@@ -840,7 +759,6 @@ tables:
     "@id": "#Object.g_iRound_flag"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
@@ -852,7 +770,6 @@ tables:
     "@id": "#Object.g_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on g-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: g_inputCount_flag
     "@id": "#Object.g_inputCount_flag"
@@ -870,85 +787,71 @@ tables:
     "@id": "#Object.g_ixx"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_kronFlux
     "@id": "#Object.g_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFluxErr
     "@id": "#Object.g_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFlux_flag
     "@id": "#Object.g_kronFlux_flag"
@@ -1014,7 +917,6 @@ tables:
     "@id": "#Object.g_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_pixelFlags_bad
     "@id": "#Object.g_pixelFlags_bad"
@@ -1122,19 +1024,16 @@ tables:
     "@id": "#Object.g_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFluxErr
     "@id": "#Object.g_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFlux_area
     "@id": "#Object.g_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_psfFlux_flag
     "@id": "#Object.g_psfFlux_flag"
@@ -1164,20 +1063,17 @@ tables:
     "@id": "#Object.g_ra"
     datatype: double
     description: Position in Right Ascension. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: i_ap03Flux
     "@id": "#Object.i_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03FluxErr
     "@id": "#Object.i_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03Flux_flag
     "@id": "#Object.i_ap03Flux_flag"
@@ -1189,13 +1085,11 @@ tables:
     "@id": "#Object.i_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06FluxErr
     "@id": "#Object.i_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06Flux_flag
     "@id": "#Object.i_ap06Flux_flag"
@@ -1207,13 +1101,11 @@ tables:
     "@id": "#Object.i_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09FluxErr
     "@id": "#Object.i_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09Flux_flag
     "@id": "#Object.i_ap09Flux_flag"
@@ -1225,13 +1117,11 @@ tables:
     "@id": "#Object.i_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12FluxErr
     "@id": "#Object.i_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12Flux_flag
     "@id": "#Object.i_ap12Flux_flag"
@@ -1243,13 +1133,11 @@ tables:
     "@id": "#Object.i_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17FluxErr
     "@id": "#Object.i_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17Flux_flag
     "@id": "#Object.i_ap17Flux_flag"
@@ -1261,13 +1149,11 @@ tables:
     "@id": "#Object.i_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25FluxErr
     "@id": "#Object.i_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25Flux_flag
     "@id": "#Object.i_ap25Flux_flag"
@@ -1279,13 +1165,11 @@ tables:
     "@id": "#Object.i_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35FluxErr
     "@id": "#Object.i_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35Flux_flag
     "@id": "#Object.i_ap35Flux_flag"
@@ -1297,13 +1181,11 @@ tables:
     "@id": "#Object.i_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50FluxErr
     "@id": "#Object.i_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50Flux_flag
     "@id": "#Object.i_ap50Flux_flag"
@@ -1315,13 +1197,11 @@ tables:
     "@id": "#Object.i_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70FluxErr
     "@id": "#Object.i_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70Flux_flag
     "@id": "#Object.i_ap70Flux_flag"
@@ -1351,61 +1231,51 @@ tables:
     "@id": "#Object.i_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_bdE1
     "@id": "#Object.i_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxBErr
     "@id": "#Object.i_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxD
     "@id": "#Object.i_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxDErr
     "@id": "#Object.i_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdReB
     "@id": "#Object.i_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_blendedness_flag
     "@id": "#Object.i_blendedness_flag"
@@ -1417,19 +1287,16 @@ tables:
     "@id": "#Object.i_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFluxErr
     "@id": "#Object.i_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFlux_inner
     "@id": "#Object.i_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModel_flag
     "@id": "#Object.i_cModel_flag"
@@ -1447,13 +1314,11 @@ tables:
     "@id": "#Object.i_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFluxErr
     "@id": "#Object.i_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFlux_flag
     "@id": "#Object.i_calibFlux_flag"
@@ -1519,38 +1384,32 @@ tables:
     "@id": "#Object.i_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_xErr
     "@id": "#Object.i_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_centroid_y
     "@id": "#Object.i_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_yErr
     "@id": "#Object.i_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_decl
     "@id": "#Object.i_decl"
     datatype: double
     description: Position in Declination. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: i_extendedness
     "@id": "#Object.i_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_extendedness_flag
     "@id": "#Object.i_extendedness_flag"
@@ -1562,13 +1421,11 @@ tables:
     "@id": "#Object.i_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFluxErr
     "@id": "#Object.i_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFlux_flag
     "@id": "#Object.i_free_cModelFlux_flag"
@@ -1580,19 +1437,16 @@ tables:
     "@id": "#Object.i_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux
     "@id": "#Object.i_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFluxErr
     "@id": "#Object.i_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux_flag
     "@id": "#Object.i_free_psfFlux_flag"
@@ -1604,19 +1458,16 @@ tables:
     "@id": "#Object.i_fwhm"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_gaap0p5Flux
     "@id": "#Object.i_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p5FluxErr
     "@id": "#Object.i_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap0p5Flux_flag_bigPsf"
@@ -1628,13 +1479,11 @@ tables:
     "@id": "#Object.i_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p7FluxErr
     "@id": "#Object.i_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
@@ -1646,13 +1495,11 @@ tables:
     "@id": "#Object.i_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0FluxErr
     "@id": "#Object.i_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
@@ -1664,13 +1511,11 @@ tables:
     "@id": "#Object.i_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5FluxErr
     "@id": "#Object.i_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
@@ -1682,13 +1527,11 @@ tables:
     "@id": "#Object.i_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5FluxErr
     "@id": "#Object.i_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
@@ -1700,13 +1543,11 @@ tables:
     "@id": "#Object.i_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0FluxErr
     "@id": "#Object.i_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
@@ -1736,13 +1577,11 @@ tables:
     "@id": "#Object.i_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFluxErr
     "@id": "#Object.i_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
@@ -1754,25 +1593,21 @@ tables:
     "@id": "#Object.i_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapPsfFluxErr
     "@id": "#Object.i_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_hsmShapeRegauss_e1
     "@id": "#Object.i_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_e2
     "@id": "#Object.i_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_flag
     "@id": "#Object.i_hsmShapeRegauss_flag"
@@ -1784,7 +1619,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_iDebiasedPSF_flag
     "@id": "#Object.i_iDebiasedPSF_flag"
@@ -1802,7 +1636,6 @@ tables:
     "@id": "#Object.i_iRound_flag"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
@@ -1814,7 +1647,6 @@ tables:
     "@id": "#Object.i_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on i-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: i_inputCount_flag
     "@id": "#Object.i_inputCount_flag"
@@ -1832,85 +1664,71 @@ tables:
     "@id": "#Object.i_ixx"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_kronFlux
     "@id": "#Object.i_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFluxErr
     "@id": "#Object.i_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFlux_flag
     "@id": "#Object.i_kronFlux_flag"
@@ -1976,7 +1794,6 @@ tables:
     "@id": "#Object.i_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_pixelFlags_bad
     "@id": "#Object.i_pixelFlags_bad"
@@ -2084,19 +1901,16 @@ tables:
     "@id": "#Object.i_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFluxErr
     "@id": "#Object.i_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFlux_area
     "@id": "#Object.i_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_psfFlux_flag
     "@id": "#Object.i_psfFlux_flag"
@@ -2126,20 +1940,17 @@ tables:
     "@id": "#Object.i_ra"
     datatype: double
     description: Position in Right Ascension. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: r_ap03Flux
     "@id": "#Object.r_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03FluxErr
     "@id": "#Object.r_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03Flux_flag
     "@id": "#Object.r_ap03Flux_flag"
@@ -2151,13 +1962,11 @@ tables:
     "@id": "#Object.r_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06FluxErr
     "@id": "#Object.r_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06Flux_flag
     "@id": "#Object.r_ap06Flux_flag"
@@ -2169,13 +1978,11 @@ tables:
     "@id": "#Object.r_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09FluxErr
     "@id": "#Object.r_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09Flux_flag
     "@id": "#Object.r_ap09Flux_flag"
@@ -2187,13 +1994,11 @@ tables:
     "@id": "#Object.r_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12FluxErr
     "@id": "#Object.r_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12Flux_flag
     "@id": "#Object.r_ap12Flux_flag"
@@ -2205,13 +2010,11 @@ tables:
     "@id": "#Object.r_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17FluxErr
     "@id": "#Object.r_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17Flux_flag
     "@id": "#Object.r_ap17Flux_flag"
@@ -2223,13 +2026,11 @@ tables:
     "@id": "#Object.r_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25FluxErr
     "@id": "#Object.r_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25Flux_flag
     "@id": "#Object.r_ap25Flux_flag"
@@ -2241,13 +2042,11 @@ tables:
     "@id": "#Object.r_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35FluxErr
     "@id": "#Object.r_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35Flux_flag
     "@id": "#Object.r_ap35Flux_flag"
@@ -2259,13 +2058,11 @@ tables:
     "@id": "#Object.r_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50FluxErr
     "@id": "#Object.r_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50Flux_flag
     "@id": "#Object.r_ap50Flux_flag"
@@ -2277,13 +2074,11 @@ tables:
     "@id": "#Object.r_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70FluxErr
     "@id": "#Object.r_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70Flux_flag
     "@id": "#Object.r_ap70Flux_flag"
@@ -2313,61 +2108,51 @@ tables:
     "@id": "#Object.r_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_bdE1
     "@id": "#Object.r_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxBErr
     "@id": "#Object.r_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxD
     "@id": "#Object.r_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxDErr
     "@id": "#Object.r_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdReB
     "@id": "#Object.r_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_blendedness_flag
     "@id": "#Object.r_blendedness_flag"
@@ -2379,19 +2164,16 @@ tables:
     "@id": "#Object.r_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFluxErr
     "@id": "#Object.r_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFlux_inner
     "@id": "#Object.r_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModel_flag
     "@id": "#Object.r_cModel_flag"
@@ -2409,13 +2191,11 @@ tables:
     "@id": "#Object.r_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFluxErr
     "@id": "#Object.r_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFlux_flag
     "@id": "#Object.r_calibFlux_flag"
@@ -2481,38 +2261,32 @@ tables:
     "@id": "#Object.r_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_xErr
     "@id": "#Object.r_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_centroid_y
     "@id": "#Object.r_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_yErr
     "@id": "#Object.r_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_decl
     "@id": "#Object.r_decl"
     datatype: double
     description: Position in Declination. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: r_extendedness
     "@id": "#Object.r_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_extendedness_flag
     "@id": "#Object.r_extendedness_flag"
@@ -2524,13 +2298,11 @@ tables:
     "@id": "#Object.r_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFluxErr
     "@id": "#Object.r_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFlux_flag
     "@id": "#Object.r_free_cModelFlux_flag"
@@ -2542,19 +2314,16 @@ tables:
     "@id": "#Object.r_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux
     "@id": "#Object.r_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFluxErr
     "@id": "#Object.r_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux_flag
     "@id": "#Object.r_free_psfFlux_flag"
@@ -2566,19 +2335,16 @@ tables:
     "@id": "#Object.r_fwhm"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_gaap0p5Flux
     "@id": "#Object.r_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p5FluxErr
     "@id": "#Object.r_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap0p5Flux_flag_bigPsf"
@@ -2590,13 +2356,11 @@ tables:
     "@id": "#Object.r_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p7FluxErr
     "@id": "#Object.r_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
@@ -2608,13 +2372,11 @@ tables:
     "@id": "#Object.r_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0FluxErr
     "@id": "#Object.r_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
@@ -2626,13 +2388,11 @@ tables:
     "@id": "#Object.r_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5FluxErr
     "@id": "#Object.r_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
@@ -2644,13 +2404,11 @@ tables:
     "@id": "#Object.r_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5FluxErr
     "@id": "#Object.r_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
@@ -2662,13 +2420,11 @@ tables:
     "@id": "#Object.r_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0FluxErr
     "@id": "#Object.r_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
@@ -2698,13 +2454,11 @@ tables:
     "@id": "#Object.r_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFluxErr
     "@id": "#Object.r_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
@@ -2716,25 +2470,21 @@ tables:
     "@id": "#Object.r_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapPsfFluxErr
     "@id": "#Object.r_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_hsmShapeRegauss_e1
     "@id": "#Object.r_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_e2
     "@id": "#Object.r_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_flag
     "@id": "#Object.r_hsmShapeRegauss_flag"
@@ -2746,7 +2496,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_iDebiasedPSF_flag
     "@id": "#Object.r_iDebiasedPSF_flag"
@@ -2764,7 +2513,6 @@ tables:
     "@id": "#Object.r_iRound_flag"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
@@ -2776,7 +2524,6 @@ tables:
     "@id": "#Object.r_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on r-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: r_inputCount_flag
     "@id": "#Object.r_inputCount_flag"
@@ -2794,85 +2541,71 @@ tables:
     "@id": "#Object.r_ixx"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_kronFlux
     "@id": "#Object.r_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFluxErr
     "@id": "#Object.r_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFlux_flag
     "@id": "#Object.r_kronFlux_flag"
@@ -2938,7 +2671,6 @@ tables:
     "@id": "#Object.r_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_pixelFlags_bad
     "@id": "#Object.r_pixelFlags_bad"
@@ -3046,19 +2778,16 @@ tables:
     "@id": "#Object.r_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFluxErr
     "@id": "#Object.r_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFlux_area
     "@id": "#Object.r_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_psfFlux_flag
     "@id": "#Object.r_psfFlux_flag"
@@ -3088,20 +2817,17 @@ tables:
     "@id": "#Object.r_ra"
     datatype: double
     description: Position in Right Ascension. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: u_ap03Flux
     "@id": "#Object.u_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap03FluxErr
     "@id": "#Object.u_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap03Flux_flag
     "@id": "#Object.u_ap03Flux_flag"
@@ -3113,13 +2839,11 @@ tables:
     "@id": "#Object.u_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap06FluxErr
     "@id": "#Object.u_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap06Flux_flag
     "@id": "#Object.u_ap06Flux_flag"
@@ -3131,13 +2855,11 @@ tables:
     "@id": "#Object.u_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap09FluxErr
     "@id": "#Object.u_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap09Flux_flag
     "@id": "#Object.u_ap09Flux_flag"
@@ -3149,13 +2871,11 @@ tables:
     "@id": "#Object.u_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap12FluxErr
     "@id": "#Object.u_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap12Flux_flag
     "@id": "#Object.u_ap12Flux_flag"
@@ -3167,13 +2887,11 @@ tables:
     "@id": "#Object.u_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap17FluxErr
     "@id": "#Object.u_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap17Flux_flag
     "@id": "#Object.u_ap17Flux_flag"
@@ -3185,13 +2903,11 @@ tables:
     "@id": "#Object.u_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap25FluxErr
     "@id": "#Object.u_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap25Flux_flag
     "@id": "#Object.u_ap25Flux_flag"
@@ -3203,13 +2919,11 @@ tables:
     "@id": "#Object.u_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap35FluxErr
     "@id": "#Object.u_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap35Flux_flag
     "@id": "#Object.u_ap35Flux_flag"
@@ -3221,13 +2935,11 @@ tables:
     "@id": "#Object.u_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap50FluxErr
     "@id": "#Object.u_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap50Flux_flag
     "@id": "#Object.u_ap50Flux_flag"
@@ -3239,13 +2951,11 @@ tables:
     "@id": "#Object.u_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap70FluxErr
     "@id": "#Object.u_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap70Flux_flag
     "@id": "#Object.u_ap70Flux_flag"
@@ -3275,61 +2985,51 @@ tables:
     "@id": "#Object.u_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_bdE1
     "@id": "#Object.u_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdE2
     "@id": "#Object.u_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdFluxB
     "@id": "#Object.u_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxBErr
     "@id": "#Object.u_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxD
     "@id": "#Object.u_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxDErr
     "@id": "#Object.u_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdReB
     "@id": "#Object.u_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdReD
     "@id": "#Object.u_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_blendedness
     "@id": "#Object.u_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_blendedness_flag
     "@id": "#Object.u_blendedness_flag"
@@ -3341,19 +3041,16 @@ tables:
     "@id": "#Object.u_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModelFluxErr
     "@id": "#Object.u_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModelFlux_inner
     "@id": "#Object.u_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModel_flag
     "@id": "#Object.u_cModel_flag"
@@ -3371,13 +3068,11 @@ tables:
     "@id": "#Object.u_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_calibFluxErr
     "@id": "#Object.u_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_calibFlux_flag
     "@id": "#Object.u_calibFlux_flag"
@@ -3443,38 +3138,32 @@ tables:
     "@id": "#Object.u_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: u_centroid_xErr
     "@id": "#Object.u_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_centroid_y
     "@id": "#Object.u_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: u_centroid_yErr
     "@id": "#Object.u_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_decl
     "@id": "#Object.u_decl"
     datatype: double
     description: Position in Declination. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: u_extendedness
     "@id": "#Object.u_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_extendedness_flag
     "@id": "#Object.u_extendedness_flag"
@@ -3486,13 +3175,11 @@ tables:
     "@id": "#Object.u_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_cModelFluxErr
     "@id": "#Object.u_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_cModelFlux_flag
     "@id": "#Object.u_free_cModelFlux_flag"
@@ -3504,19 +3191,16 @@ tables:
     "@id": "#Object.u_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFlux
     "@id": "#Object.u_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFluxErr
     "@id": "#Object.u_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFlux_flag
     "@id": "#Object.u_free_psfFlux_flag"
@@ -3528,19 +3212,16 @@ tables:
     "@id": "#Object.u_fwhm"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_gaap0p5Flux
     "@id": "#Object.u_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p5FluxErr
     "@id": "#Object.u_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.u_gaap0p5Flux_flag_bigPsf"
@@ -3552,13 +3233,11 @@ tables:
     "@id": "#Object.u_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p7FluxErr
     "@id": "#Object.u_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.u_gaap0p7Flux_flag_bigPsf"
@@ -3570,13 +3249,11 @@ tables:
     "@id": "#Object.u_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p0FluxErr
     "@id": "#Object.u_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.u_gaap1p0Flux_flag_bigPsf"
@@ -3588,13 +3265,11 @@ tables:
     "@id": "#Object.u_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p5FluxErr
     "@id": "#Object.u_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.u_gaap1p5Flux_flag_bigPsf"
@@ -3606,13 +3281,11 @@ tables:
     "@id": "#Object.u_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap2p5FluxErr
     "@id": "#Object.u_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.u_gaap2p5Flux_flag_bigPsf"
@@ -3624,13 +3297,11 @@ tables:
     "@id": "#Object.u_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap3p0FluxErr
     "@id": "#Object.u_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.u_gaap3p0Flux_flag_bigPsf"
@@ -3660,13 +3331,11 @@ tables:
     "@id": "#Object.u_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapOptimalFluxErr
     "@id": "#Object.u_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.u_gaapOptimalFlux_flag_bigPsf"
@@ -3678,25 +3347,21 @@ tables:
     "@id": "#Object.u_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapPsfFluxErr
     "@id": "#Object.u_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_hsmShapeRegauss_e1
     "@id": "#Object.u_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsmShapeRegauss_e2
     "@id": "#Object.u_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsmShapeRegauss_flag
     "@id": "#Object.u_hsmShapeRegauss_flag"
@@ -3708,7 +3373,6 @@ tables:
     "@id": "#Object.u_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_iDebiasedPSF_flag
     "@id": "#Object.u_iDebiasedPSF_flag"
@@ -3726,7 +3390,6 @@ tables:
     "@id": "#Object.u_iRound_flag"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_i_flag
     "@id": "#Object.u_i_flag"
@@ -3738,7 +3401,6 @@ tables:
     "@id": "#Object.u_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on u-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: u_inputCount_flag
     "@id": "#Object.u_inputCount_flag"
@@ -3756,85 +3418,71 @@ tables:
     "@id": "#Object.u_ixx"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxDebiasedPSF
     "@id": "#Object.u_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxPSF
     "@id": "#Object.u_ixxPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxRound
     "@id": "#Object.u_ixxRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixy
     "@id": "#Object.u_ixy"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyDebiasedPSF
     "@id": "#Object.u_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyPSF
     "@id": "#Object.u_ixyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyRound
     "@id": "#Object.u_ixyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyy
     "@id": "#Object.u_iyy"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyDebiasedPSF
     "@id": "#Object.u_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyPSF
     "@id": "#Object.u_iyyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyRound
     "@id": "#Object.u_iyyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_kronFlux
     "@id": "#Object.u_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_kronFluxErr
     "@id": "#Object.u_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_kronFlux_flag
     "@id": "#Object.u_kronFlux_flag"
@@ -3900,7 +3548,6 @@ tables:
     "@id": "#Object.u_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_pixelFlags_bad
     "@id": "#Object.u_pixelFlags_bad"
@@ -4008,19 +3655,16 @@ tables:
     "@id": "#Object.u_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_psfFluxErr
     "@id": "#Object.u_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_psfFlux_area
     "@id": "#Object.u_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_psfFlux_flag
     "@id": "#Object.u_psfFlux_flag"
@@ -4050,20 +3694,17 @@ tables:
     "@id": "#Object.u_ra"
     datatype: double
     description: Position in Right Ascension. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: y_ap03Flux
     "@id": "#Object.y_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03FluxErr
     "@id": "#Object.y_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03Flux_flag
     "@id": "#Object.y_ap03Flux_flag"
@@ -4075,13 +3716,11 @@ tables:
     "@id": "#Object.y_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06FluxErr
     "@id": "#Object.y_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06Flux_flag
     "@id": "#Object.y_ap06Flux_flag"
@@ -4093,13 +3732,11 @@ tables:
     "@id": "#Object.y_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09FluxErr
     "@id": "#Object.y_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09Flux_flag
     "@id": "#Object.y_ap09Flux_flag"
@@ -4111,13 +3748,11 @@ tables:
     "@id": "#Object.y_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12FluxErr
     "@id": "#Object.y_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12Flux_flag
     "@id": "#Object.y_ap12Flux_flag"
@@ -4129,13 +3764,11 @@ tables:
     "@id": "#Object.y_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17FluxErr
     "@id": "#Object.y_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17Flux_flag
     "@id": "#Object.y_ap17Flux_flag"
@@ -4147,13 +3780,11 @@ tables:
     "@id": "#Object.y_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25FluxErr
     "@id": "#Object.y_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25Flux_flag
     "@id": "#Object.y_ap25Flux_flag"
@@ -4165,13 +3796,11 @@ tables:
     "@id": "#Object.y_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35FluxErr
     "@id": "#Object.y_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35Flux_flag
     "@id": "#Object.y_ap35Flux_flag"
@@ -4183,13 +3812,11 @@ tables:
     "@id": "#Object.y_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50FluxErr
     "@id": "#Object.y_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50Flux_flag
     "@id": "#Object.y_ap50Flux_flag"
@@ -4201,13 +3828,11 @@ tables:
     "@id": "#Object.y_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70FluxErr
     "@id": "#Object.y_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70Flux_flag
     "@id": "#Object.y_ap70Flux_flag"
@@ -4237,61 +3862,51 @@ tables:
     "@id": "#Object.y_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_bdE1
     "@id": "#Object.y_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxBErr
     "@id": "#Object.y_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxD
     "@id": "#Object.y_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxDErr
     "@id": "#Object.y_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdReB
     "@id": "#Object.y_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_blendedness_flag
     "@id": "#Object.y_blendedness_flag"
@@ -4303,19 +3918,16 @@ tables:
     "@id": "#Object.y_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFluxErr
     "@id": "#Object.y_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFlux_inner
     "@id": "#Object.y_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModel_flag
     "@id": "#Object.y_cModel_flag"
@@ -4333,13 +3945,11 @@ tables:
     "@id": "#Object.y_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFluxErr
     "@id": "#Object.y_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFlux_flag
     "@id": "#Object.y_calibFlux_flag"
@@ -4405,38 +4015,32 @@ tables:
     "@id": "#Object.y_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_xErr
     "@id": "#Object.y_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_centroid_y
     "@id": "#Object.y_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_yErr
     "@id": "#Object.y_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_decl
     "@id": "#Object.y_decl"
     datatype: double
     description: Position in Declination. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: y_extendedness
     "@id": "#Object.y_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_extendedness_flag
     "@id": "#Object.y_extendedness_flag"
@@ -4448,13 +4052,11 @@ tables:
     "@id": "#Object.y_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFluxErr
     "@id": "#Object.y_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFlux_flag
     "@id": "#Object.y_free_cModelFlux_flag"
@@ -4466,19 +4068,16 @@ tables:
     "@id": "#Object.y_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux
     "@id": "#Object.y_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFluxErr
     "@id": "#Object.y_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux_flag
     "@id": "#Object.y_free_psfFlux_flag"
@@ -4490,19 +4089,16 @@ tables:
     "@id": "#Object.y_fwhm"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_gaap0p5Flux
     "@id": "#Object.y_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p5FluxErr
     "@id": "#Object.y_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap0p5Flux_flag_bigPsf"
@@ -4514,13 +4110,11 @@ tables:
     "@id": "#Object.y_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p7FluxErr
     "@id": "#Object.y_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
@@ -4532,13 +4126,11 @@ tables:
     "@id": "#Object.y_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0FluxErr
     "@id": "#Object.y_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
@@ -4550,13 +4142,11 @@ tables:
     "@id": "#Object.y_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5FluxErr
     "@id": "#Object.y_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
@@ -4568,13 +4158,11 @@ tables:
     "@id": "#Object.y_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5FluxErr
     "@id": "#Object.y_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
@@ -4586,13 +4174,11 @@ tables:
     "@id": "#Object.y_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0FluxErr
     "@id": "#Object.y_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
@@ -4622,13 +4208,11 @@ tables:
     "@id": "#Object.y_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFluxErr
     "@id": "#Object.y_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
@@ -4640,25 +4224,21 @@ tables:
     "@id": "#Object.y_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapPsfFluxErr
     "@id": "#Object.y_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_hsmShapeRegauss_e1
     "@id": "#Object.y_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_e2
     "@id": "#Object.y_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_flag
     "@id": "#Object.y_hsmShapeRegauss_flag"
@@ -4670,7 +4250,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_iDebiasedPSF_flag
     "@id": "#Object.y_iDebiasedPSF_flag"
@@ -4688,7 +4267,6 @@ tables:
     "@id": "#Object.y_iRound_flag"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
@@ -4700,7 +4278,6 @@ tables:
     "@id": "#Object.y_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on y-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: y_inputCount_flag
     "@id": "#Object.y_inputCount_flag"
@@ -4718,85 +4295,71 @@ tables:
     "@id": "#Object.y_ixx"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_kronFlux
     "@id": "#Object.y_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFluxErr
     "@id": "#Object.y_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFlux_flag
     "@id": "#Object.y_kronFlux_flag"
@@ -4862,7 +4425,6 @@ tables:
     "@id": "#Object.y_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_pixelFlags_bad
     "@id": "#Object.y_pixelFlags_bad"
@@ -4970,19 +4532,16 @@ tables:
     "@id": "#Object.y_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFluxErr
     "@id": "#Object.y_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFlux_area
     "@id": "#Object.y_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_psfFlux_flag
     "@id": "#Object.y_psfFlux_flag"
@@ -5012,20 +4571,17 @@ tables:
     "@id": "#Object.y_ra"
     datatype: double
     description: Position in Right Ascension. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: z_ap03Flux
     "@id": "#Object.z_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03FluxErr
     "@id": "#Object.z_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03Flux_flag
     "@id": "#Object.z_ap03Flux_flag"
@@ -5037,13 +4593,11 @@ tables:
     "@id": "#Object.z_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06FluxErr
     "@id": "#Object.z_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06Flux_flag
     "@id": "#Object.z_ap06Flux_flag"
@@ -5055,13 +4609,11 @@ tables:
     "@id": "#Object.z_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09FluxErr
     "@id": "#Object.z_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09Flux_flag
     "@id": "#Object.z_ap09Flux_flag"
@@ -5073,13 +4625,11 @@ tables:
     "@id": "#Object.z_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12FluxErr
     "@id": "#Object.z_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12Flux_flag
     "@id": "#Object.z_ap12Flux_flag"
@@ -5091,13 +4641,11 @@ tables:
     "@id": "#Object.z_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17FluxErr
     "@id": "#Object.z_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17Flux_flag
     "@id": "#Object.z_ap17Flux_flag"
@@ -5109,13 +4657,11 @@ tables:
     "@id": "#Object.z_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25FluxErr
     "@id": "#Object.z_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25Flux_flag
     "@id": "#Object.z_ap25Flux_flag"
@@ -5127,13 +4673,11 @@ tables:
     "@id": "#Object.z_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35FluxErr
     "@id": "#Object.z_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35Flux_flag
     "@id": "#Object.z_ap35Flux_flag"
@@ -5145,13 +4689,11 @@ tables:
     "@id": "#Object.z_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50FluxErr
     "@id": "#Object.z_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50Flux_flag
     "@id": "#Object.z_ap50Flux_flag"
@@ -5163,13 +4705,11 @@ tables:
     "@id": "#Object.z_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70FluxErr
     "@id": "#Object.z_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70Flux_flag
     "@id": "#Object.z_ap70Flux_flag"
@@ -5199,61 +4739,51 @@ tables:
     "@id": "#Object.z_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_bdE1
     "@id": "#Object.z_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleurs fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxBErr
     "@id": "#Object.z_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxD
     "@id": "#Object.z_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxDErr
     "@id": "#Object.z_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdReB
     "@id": "#Object.z_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleurs fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_blendedness_flag
     "@id": "#Object.z_blendedness_flag"
@@ -5265,19 +4795,16 @@ tables:
     "@id": "#Object.z_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFluxErr
     "@id": "#Object.z_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFlux_inner
     "@id": "#Object.z_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModel_flag
     "@id": "#Object.z_cModel_flag"
@@ -5295,13 +4822,11 @@ tables:
     "@id": "#Object.z_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFluxErr
     "@id": "#Object.z_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFlux_flag
     "@id": "#Object.z_calibFlux_flag"
@@ -5367,38 +4892,32 @@ tables:
     "@id": "#Object.z_centroid_x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_xErr
     "@id": "#Object.z_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_centroid_y
     "@id": "#Object.z_centroid_y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_yErr
     "@id": "#Object.z_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_decl
     "@id": "#Object.z_decl"
     datatype: double
     description: Position in Declination. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: z_extendedness
     "@id": "#Object.z_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_extendedness_flag
     "@id": "#Object.z_extendedness_flag"
@@ -5410,13 +4929,11 @@ tables:
     "@id": "#Object.z_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFluxErr
     "@id": "#Object.z_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFlux_flag
     "@id": "#Object.z_free_cModelFlux_flag"
@@ -5428,19 +4945,16 @@ tables:
     "@id": "#Object.z_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux
     "@id": "#Object.z_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFluxErr
     "@id": "#Object.z_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux_flag
     "@id": "#Object.z_free_psfFlux_flag"
@@ -5452,19 +4966,16 @@ tables:
     "@id": "#Object.z_fwhm"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_gaap0p5Flux
     "@id": "#Object.z_gaap0p5Flux"
     datatype: double
     description: GaaP flux with 0.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p5FluxErr
     "@id": "#Object.z_gaap0p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap0p5Flux_flag_bigPsf"
@@ -5476,13 +4987,11 @@ tables:
     "@id": "#Object.z_gaap0p7Flux"
     datatype: double
     description: GaaP flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p7FluxErr
     "@id": "#Object.z_gaap0p7FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
@@ -5494,13 +5003,11 @@ tables:
     "@id": "#Object.z_gaap1p0Flux"
     datatype: double
     description: GaaP flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0FluxErr
     "@id": "#Object.z_gaap1p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
@@ -5512,13 +5019,11 @@ tables:
     "@id": "#Object.z_gaap1p5Flux"
     datatype: double
     description: GaaP flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5FluxErr
     "@id": "#Object.z_gaap1p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
@@ -5530,13 +5035,11 @@ tables:
     "@id": "#Object.z_gaap2p5Flux"
     datatype: double
     description: GaaP flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5FluxErr
     "@id": "#Object.z_gaap2p5FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
@@ -5548,13 +5051,11 @@ tables:
     "@id": "#Object.z_gaap3p0Flux"
     datatype: double
     description: GaaP flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0FluxErr
     "@id": "#Object.z_gaap3p0FluxErr"
     datatype: double
     description: GaaP flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
@@ -5584,13 +5085,11 @@ tables:
     "@id": "#Object.z_gaapOptimalFlux"
     datatype: double
     description: GaaP flux with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFluxErr
     "@id": "#Object.z_gaapOptimalFluxErr"
     datatype: double
     description: GaaP flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
@@ -5602,25 +5101,21 @@ tables:
     "@id": "#Object.z_gaapPsfFlux"
     datatype: double
     description: GaaP flux with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapPsfFluxErr
     "@id": "#Object.z_gaapPsfFluxErr"
     datatype: double
     description: GaaP flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_hsmShapeRegauss_e1
     "@id": "#Object.z_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_e2
     "@id": "#Object.z_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_flag
     "@id": "#Object.z_hsmShapeRegauss_flag"
@@ -5632,7 +5127,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_iDebiasedPSF_flag
     "@id": "#Object.z_iDebiasedPSF_flag"
@@ -5650,7 +5144,6 @@ tables:
     "@id": "#Object.z_iRound_flag"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
@@ -5662,7 +5155,6 @@ tables:
     "@id": "#Object.z_inputCount"
     datatype: int
     description: Number of images contributing at center, not including any clipping. Forced on z-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: z_inputCount_flag
     "@id": "#Object.z_inputCount_flag"
@@ -5680,85 +5172,71 @@ tables:
     "@id": "#Object.z_ixx"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_kronFlux
     "@id": "#Object.z_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFluxErr
     "@id": "#Object.z_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFlux_flag
     "@id": "#Object.z_kronFlux_flag"
@@ -5824,7 +5302,6 @@ tables:
     "@id": "#Object.z_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_pixelFlags_bad
     "@id": "#Object.z_pixelFlags_bad"
@@ -5932,19 +5409,16 @@ tables:
     "@id": "#Object.z_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFluxErr
     "@id": "#Object.z_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFlux_area
     "@id": "#Object.z_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_psfFlux_flag
     "@id": "#Object.z_psfFlux_flag"
@@ -5974,7 +5448,6 @@ tables:
     "@id": "#Object.z_ra"
     datatype: double
     description: Position in Right Ascension. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
 - name: Source
@@ -5988,97 +5461,82 @@ tables:
     datatype: long
     nullable: false
     description: Unique id. Unique Source ID. Primary Key.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src;meta.main
   - name: coord_ra
     "@id": "#Source.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: coord_dec
     "@id": "#Source.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: ccdVisitId
     "@id": "#Source.ccdVisitId"
     datatype: long
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
-    mysql:datatype: BIGINT
     fits:tunit:
     ivoa:ucd: meta.id;obs.image
   - name: parentSourceId
     "@id": "#Source.parentSourceId"
     datatype: long
     description: Unique ID of parent source
-    mysql:datatype: BIGINT
     fits:tunit:
     ivoa:ucd: meta.id.parent
   - name: x
     "@id": "#Source.x"
     datatype: double
     description: Centroid from SDSS Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y
     "@id": "#Source.y"
     datatype: double
     description: Centroid from SDSS Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Source.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: yErr
     "@id": "#Source.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: ra
     "@id": "#Source.ra"
     datatype: double
     description: Position in Right Ascension
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: decl
     "@id": "#Source.decl"
     datatype: double
     description: Position in Declination
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: calibFlux
     "@id": "#Source.calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: calibFluxErr
     "@id": "#Source.calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux
     "@id": "#Source.ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03FluxErr
     "@id": "#Source.ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux_flag
     "@id": "#Source.ap03Flux_flag"
@@ -6090,13 +5548,11 @@ tables:
     "@id": "#Source.ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06FluxErr
     "@id": "#Source.ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06Flux_flag
     "@id": "#Source.ap06Flux_flag"
@@ -6108,13 +5564,11 @@ tables:
     "@id": "#Source.ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09FluxErr
     "@id": "#Source.ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09Flux_flag
     "@id": "#Source.ap09Flux_flag"
@@ -6126,13 +5580,11 @@ tables:
     "@id": "#Source.ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12FluxErr
     "@id": "#Source.ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12Flux_flag
     "@id": "#Source.ap12Flux_flag"
@@ -6144,13 +5596,11 @@ tables:
     "@id": "#Source.ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17FluxErr
     "@id": "#Source.ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17Flux_flag
     "@id": "#Source.ap17Flux_flag"
@@ -6162,13 +5612,11 @@ tables:
     "@id": "#Source.ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25FluxErr
     "@id": "#Source.ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25Flux_flag
     "@id": "#Source.ap25Flux_flag"
@@ -6180,13 +5628,11 @@ tables:
     "@id": "#Source.ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35FluxErr
     "@id": "#Source.ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35Flux_flag
     "@id": "#Source.ap35Flux_flag"
@@ -6198,13 +5644,11 @@ tables:
     "@id": "#Source.ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50FluxErr
     "@id": "#Source.ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50Flux_flag
     "@id": "#Source.ap50Flux_flag"
@@ -6216,13 +5660,11 @@ tables:
     "@id": "#Source.ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70FluxErr
     "@id": "#Source.ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70Flux_flag
     "@id": "#Source.ap70Flux_flag"
@@ -6234,85 +5676,71 @@ tables:
     "@id": "#Source.sky"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: skyErr
     "@id": "#Source.skyErr"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFlux
     "@id": "#Source.psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#Source.psfFluxErr"
     datatype: double
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ixx
     "@id": "#Source.ixx"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double
     description: Flux from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: gaussianFluxErr
     "@id": "#Source.gaussianFluxErr"
     datatype: double
     description: Flux uncertainty from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib
     "@id": "#Source.localPhotoCalib"
     datatype: double
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib_flag
     "@id": "#Source.localPhotoCalib_flag"
@@ -6324,7 +5752,6 @@ tables:
     "@id": "#Source.localPhotoCalibErr"
     datatype: double
     description: Uncertainty on the local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_flag
     "@id": "#Source.localWcs_flag"
@@ -6336,31 +5763,26 @@ tables:
     "@id": "#Source.localWcs_CDMatrix_2_1"
     datatype: double
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_1
     "@id": "#Source.localWcs_CDMatrix_1_1"
     datatype: double
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_2
     "@id": "#Source.localWcs_CDMatrix_1_2"
     datatype: double
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_2_2
     "@id": "#Source.localWcs_CDMatrix_2_2"
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_abs
     "@id": "#Source.blendedness_abs"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_flag
     "@id": "#Source.blendedness_flag"
@@ -6402,13 +5824,11 @@ tables:
     "@id": "#Source.apFlux_12_0_instFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_12_0_instFluxErr
     "@id": "#Source.apFlux_12_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_flag
     "@id": "#Source.apFlux_17_0_flag"
@@ -6420,13 +5840,11 @@ tables:
     "@id": "#Source.apFlux_17_0_instFlux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_instFluxErr
     "@id": "#Source.apFlux_17_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: extendedness_flag
     "@id": "#Source.extendedness_flag"
@@ -6438,7 +5856,6 @@ tables:
     "@id": "#Source.footprintArea_value"
     datatype: int
     description: Number of pixels in the source's detection footprint.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: jacobian_flag
     "@id": "#Source.jacobian_flag"
@@ -6450,19 +5867,16 @@ tables:
     "@id": "#Source.jacobian_value"
     datatype: double
     description: Jacobian correction
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localBackground_instFlux
     "@id": "#Source.localBackground_instFlux"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_instFluxErr
     "@id": "#Source.localBackground_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_flag
     "@id": "#Source.localBackground_flag"
@@ -6552,19 +5966,16 @@ tables:
     "@id": "#Source.psfFlux_apCorr"
     datatype: double
     description: Aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_apCorrErr
     "@id": "#Source.psfFlux_apCorrErr"
     datatype: double
     description: Standard deviation of aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_area
     "@id": "#Source.psfFlux_area"
     datatype: float
     description: Effective area of PSF
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: psfFlux_flag
     "@id": "#Source.psfFlux_flag"
@@ -6654,7 +6065,6 @@ tables:
     "@id": "#Source.variance_value"
     datatype: double
     description: Variance at object position
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: calib_astrometry_used
     "@id": "#Source.calib_astrometry_used"
@@ -6720,7 +6130,6 @@ tables:
     "@id": "#Source.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_parentTooBig
     "@id": "#Source.deblend_parentTooBig"
@@ -6837,7 +6246,6 @@ tables:
     "@id": "#Source.detector"
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: physical_filter
     "@id": "#Source.physical_filter"
@@ -6850,13 +6258,11 @@ tables:
     "@id": "#Source.visit_system"
     datatype: long
     description: ID of visit system, the system of self-consistent visit definitions
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: visit
     "@id": "#Source.visit"
     datatype: long
     description: ID of visit, the identifier for an observation within a sequence of observations.
-    mysql:datatype: BIGINT
     fits:tunit:
   constraints:
   - name: CcdV_Src
@@ -6878,7 +6284,6 @@ tables:
   - name: forcedSourceId
     "@id": "#ForcedSource.forcedSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of forced source. Primary Key.
     fits:tunit:
     ivoa:ucd: meta.id;meta.main
@@ -6887,7 +6292,6 @@ tables:
   - name: objectId
     "@id": "#ForcedSource.objectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique Object ID. Primary Key of the Object Table
     fits:tunit:
     ivoa:ucd: meta.id
@@ -6896,7 +6300,6 @@ tables:
   - name: parentObjectId
     "@id": "#ForcedSource.parentObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
     fits:tunit:
     ivoa:ucd: meta.id.parent
@@ -6905,7 +6308,6 @@ tables:
   - name: coord_ra
     "@id": "#ForcedSource.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of Object centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
@@ -6914,7 +6316,6 @@ tables:
   - name: coord_dec
     "@id": "#ForcedSource.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of Object centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
@@ -6932,7 +6333,6 @@ tables:
   - name: tract
     "@id": "#ForcedSource.tract"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
     ivoa:ucd: meta.id
@@ -6941,7 +6341,6 @@ tables:
   - name: patch
     "@id": "#ForcedSource.patch"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap patch ID
     fits:tunit:
     ivoa:ucd: meta.id.part
@@ -6961,7 +6360,6 @@ tables:
   - name: ccdVisitId
     "@id": "#ForcedSource.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of visit and detector for which forced photometry was performed. Primary Key of the CcdVisit Table.
     fits:tunit:
     ivoa:ucd: meta.id;obs.image
@@ -6997,7 +6395,6 @@ tables:
   - name: localBackground_instFluxErr
     "@id": "#ForcedSource.localBackground_instFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 1-sigma uncertainty on the background in an annulus around source
     fits:tunit: count
     ivoa:ucd: stat.error;phot.count
@@ -7006,7 +6403,6 @@ tables:
   - name: localBackground_instFlux
     "@id": "#ForcedSource.localBackground_instFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Background in annulus around source
     fits:tunit: count
     ivoa:ucd: phot.count
@@ -7015,7 +6411,6 @@ tables:
   - name: localPhotoCalibErr
     "@id": "#ForcedSource.localPhotoCalibErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
     ivoa:ucd: stat.error;phot.calib
@@ -7033,7 +6428,6 @@ tables:
   - name: localPhotoCalib
     "@id": "#ForcedSource.localPhotoCalib"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
     ivoa:ucd: phot.calib
@@ -7042,7 +6436,6 @@ tables:
   - name: localWcs_CDMatrix_1_1
     "@id": "#ForcedSource.localWcs_CDMatrix_1_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -7051,7 +6444,6 @@ tables:
   - name: localWcs_CDMatrix_1_2
     "@id": "#ForcedSource.localWcs_CDMatrix_1_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -7060,7 +6452,6 @@ tables:
   - name: localWcs_CDMatrix_2_1
     "@id": "#ForcedSource.localWcs_CDMatrix_2_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -7069,7 +6460,6 @@ tables:
   - name: localWcs_CDMatrix_2_2
     "@id": "#ForcedSource.localWcs_CDMatrix_2_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -7177,7 +6567,6 @@ tables:
   - name: psfDiffFluxErr
     "@id": "#ForcedSource.psfDiffFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.flux
@@ -7195,7 +6584,6 @@ tables:
   - name: psfDiffFlux
     "@id": "#ForcedSource.psfDiffFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
     ivoa:ucd: phot.flux
@@ -7204,7 +6592,6 @@ tables:
   - name: psfFluxErr
     "@id": "#ForcedSource.psfFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.flux
@@ -7222,7 +6609,6 @@ tables:
   - name: psfFlux
     "@id": "#ForcedSource.psfFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
     ivoa:ucd: phot.flux
@@ -7255,697 +6641,559 @@ tables:
   - name: decl
     "@id": "#DiaObject.decl"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean Declination of DIASources in the diaObject
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: diaObjectId
     "@id": "#DiaObject.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique id.
     ivoa:ucd: meta.id;meta.main
   - name: gPSFluxChi2
     "@id": "#DiaObject.gPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of gPSFlux around gPSFluxMean
   - name: gPSFluxErrMean
     "@id": "#DiaObject.gPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: gPSFluxLinearIntercept
     "@id": "#DiaObject.gPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: gPSFluxLinearSlope
     "@id": "#DiaObject.gPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: gPSFluxMAD
     "@id": "#DiaObject.gPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: gPSFluxMax
     "@id": "#DiaObject.gPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: gPSFluxMaxSlope
     "@id": "#DiaObject.gPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: gPSFluxMean
     "@id": "#DiaObject.gPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: gPSFluxMeanErr
     "@id": "#DiaObject.gPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: gPSFluxMin
     "@id": "#DiaObject.gPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: gPSFluxNdata
     "@id": "#DiaObject.gPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute gPSFluxChi2
   - name: gPSFluxPercentile05
     "@id": "#DiaObject.gPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: gPSFluxPercentile25
     "@id": "#DiaObject.gPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: gPSFluxPercentile50
     "@id": "#DiaObject.gPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: gPSFluxPercentile75
     "@id": "#DiaObject.gPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: gPSFluxPercentile95
     "@id": "#DiaObject.gPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: gPSFluxSigma
     "@id": "#DiaObject.gPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of gPSFlux
   - name: gPSFluxSkew
     "@id": "#DiaObject.gPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: gPSFluxStetsonJ
     "@id": "#DiaObject.gPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: gTOTFluxMean
     "@id": "#DiaObject.gTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: gTOTFluxMeanErr
     "@id": "#DiaObject.gTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on gTOTFluxMean
   - name: gTOTFluxSigma
     "@id": "#DiaObject.gTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: iPSFluxChi2
     "@id": "#DiaObject.iPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of iPSFlux around iPSFluxMean
   - name: iPSFluxErrMean
     "@id": "#DiaObject.iPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: iPSFluxLinearIntercept
     "@id": "#DiaObject.iPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: iPSFluxLinearSlope
     "@id": "#DiaObject.iPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: iPSFluxMAD
     "@id": "#DiaObject.iPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: iPSFluxMax
     "@id": "#DiaObject.iPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: iPSFluxMaxSlope
     "@id": "#DiaObject.iPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: iPSFluxMean
     "@id": "#DiaObject.iPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: iPSFluxMeanErr
     "@id": "#DiaObject.iPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: iPSFluxMin
     "@id": "#DiaObject.iPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: iPSFluxNdata
     "@id": "#DiaObject.iPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute iPSFluxChi2
   - name: iPSFluxPercentile05
     "@id": "#DiaObject.iPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: iPSFluxPercentile25
     "@id": "#DiaObject.iPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: iPSFluxPercentile50
     "@id": "#DiaObject.iPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: iPSFluxPercentile75
     "@id": "#DiaObject.iPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: iPSFluxPercentile95
     "@id": "#DiaObject.iPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: iPSFluxSigma
     "@id": "#DiaObject.iPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of iPSFlux
   - name: iPSFluxSkew
     "@id": "#DiaObject.iPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: iPSFluxStetsonJ
     "@id": "#DiaObject.iPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: iTOTFluxMean
     "@id": "#DiaObject.iTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: iTOTFluxMeanErr
     "@id": "#DiaObject.iTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on iTOTFluxMean
   - name: iTOTFluxSigma
     "@id": "#DiaObject.iTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: nDiaSources
     "@id": "#DiaObject.nDiaSources"
     datatype: long
-    mysql:datatype: BIGINT
     description: Number of diaSources associated with this diaObject
   - name: pixelId
     "@id": "#DiaObject.pixelId"
     datatype: double
-    mysql:datatype: DOUBLE
     description: HtmIndex20 of ra, decl coordinate
   - name: rPSFluxChi2
     "@id": "#DiaObject.rPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of rPSFlux around rPSFluxMean
   - name: rPSFluxErrMean
     "@id": "#DiaObject.rPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: rPSFluxLinearIntercept
     "@id": "#DiaObject.rPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: rPSFluxLinearSlope
     "@id": "#DiaObject.rPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: rPSFluxMAD
     "@id": "#DiaObject.rPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: rPSFluxMax
     "@id": "#DiaObject.rPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: rPSFluxMaxSlope
     "@id": "#DiaObject.rPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: rPSFluxMean
     "@id": "#DiaObject.rPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: rPSFluxMeanErr
     "@id": "#DiaObject.rPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: rPSFluxMin
     "@id": "#DiaObject.rPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: rPSFluxNdata
     "@id": "#DiaObject.rPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute rPSFluxChi2
   - name: rPSFluxPercentile05
     "@id": "#DiaObject.rPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: rPSFluxPercentile25
     "@id": "#DiaObject.rPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: rPSFluxPercentile50
     "@id": "#DiaObject.rPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: rPSFluxPercentile75
     "@id": "#DiaObject.rPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: rPSFluxPercentile95
     "@id": "#DiaObject.rPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: rPSFluxSigma
     "@id": "#DiaObject.rPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of rPSFlux
   - name: rPSFluxSkew
     "@id": "#DiaObject.rPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: rPSFluxStetsonJ
     "@id": "#DiaObject.rPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: rTOTFluxMean
     "@id": "#DiaObject.rTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: rTOTFluxMeanErr
     "@id": "#DiaObject.rTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on rTOTFluxMean
   - name: rTOTFluxSigma
     "@id": "#DiaObject.rTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: ra
     "@id": "#DiaObject.ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean Right Ascension of DIASources in the diaObject
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: radecTai
     "@id": "#DiaObject.radecTai"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Not used in DP0.2
   - name: uPSFluxChi2
     "@id": "#DiaObject.uPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of uPSFlux around uPSFluxMean
   - name: uPSFluxErrMean
     "@id": "#DiaObject.uPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: uPSFluxLinearIntercept
     "@id": "#DiaObject.uPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: uPSFluxLinearSlope
     "@id": "#DiaObject.uPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: uPSFluxMAD
     "@id": "#DiaObject.uPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: uPSFluxMax
     "@id": "#DiaObject.uPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: uPSFluxMaxSlope
     "@id": "#DiaObject.uPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: uPSFluxMean
     "@id": "#DiaObject.uPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: uPSFluxMeanErr
     "@id": "#DiaObject.uPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: uPSFluxMin
     "@id": "#DiaObject.uPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: uPSFluxNdata
     "@id": "#DiaObject.uPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute uPSFluxChi2
   - name: uPSFluxPercentile05
     "@id": "#DiaObject.uPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: uPSFluxPercentile25
     "@id": "#DiaObject.uPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: uPSFluxPercentile50
     "@id": "#DiaObject.uPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: uPSFluxPercentile75
     "@id": "#DiaObject.uPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: uPSFluxPercentile95
     "@id": "#DiaObject.uPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: uPSFluxSigma
     "@id": "#DiaObject.uPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of uPSFlux
   - name: uPSFluxSkew
     "@id": "#DiaObject.uPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: uPSFluxStetsonJ
     "@id": "#DiaObject.uPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: uTOTFluxMean
     "@id": "#DiaObject.uTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: uTOTFluxMeanErr
     "@id": "#DiaObject.uTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on uTOTFluxMean
   - name: uTOTFluxSigma
     "@id": "#DiaObject.uTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: yPSFluxChi2
     "@id": "#DiaObject.yPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of yPSFlux around yPSFluxMean
   - name: yPSFluxErrMean
     "@id": "#DiaObject.yPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: yPSFluxLinearIntercept
     "@id": "#DiaObject.yPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: yPSFluxLinearSlope
     "@id": "#DiaObject.yPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: yPSFluxMAD
     "@id": "#DiaObject.yPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: yPSFluxMax
     "@id": "#DiaObject.yPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: yPSFluxMaxSlope
     "@id": "#DiaObject.yPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: yPSFluxMean
     "@id": "#DiaObject.yPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: yPSFluxMeanErr
     "@id": "#DiaObject.yPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: yPSFluxMin
     "@id": "#DiaObject.yPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: yPSFluxNdata
     "@id": "#DiaObject.yPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute yPSFluxChi2
   - name: yPSFluxPercentile05
     "@id": "#DiaObject.yPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: yPSFluxPercentile25
     "@id": "#DiaObject.yPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: yPSFluxPercentile50
     "@id": "#DiaObject.yPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: yPSFluxPercentile75
     "@id": "#DiaObject.yPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: yPSFluxPercentile95
     "@id": "#DiaObject.yPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: yPSFluxSigma
     "@id": "#DiaObject.yPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of yPSFlux
   - name: yPSFluxSkew
     "@id": "#DiaObject.yPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: yPSFluxStetsonJ
     "@id": "#DiaObject.yPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: yTOTFluxMean
     "@id": "#DiaObject.yTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: yTOTFluxMeanErr
     "@id": "#DiaObject.yTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on yTOTFluxMean
   - name: yTOTFluxSigma
     "@id": "#DiaObject.yTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: zPSFluxChi2
     "@id": "#DiaObject.zPSFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of zPSFlux around zPSFluxMean
   - name: zPSFluxErrMean
     "@id": "#DiaObject.zPSFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux uncertainties
   - name: zPSFluxLinearIntercept
     "@id": "#DiaObject.zPSFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: zPSFluxLinearSlope
     "@id": "#DiaObject.zPSFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: zPSFluxMAD
     "@id": "#DiaObject.zPSFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: zPSFluxMax
     "@id": "#DiaObject.zPSFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: zPSFluxMaxSlope
     "@id": "#DiaObject.zPSFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: zPSFluxMean
     "@id": "#DiaObject.zPSFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: zPSFluxMeanErr
     "@id": "#DiaObject.zPSFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: zPSFluxMin
     "@id": "#DiaObject.zPSFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: zPSFluxNdata
     "@id": "#DiaObject.zPSFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute zPSFluxChi2
   - name: zPSFluxPercentile05
     "@id": "#DiaObject.zPSFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: zPSFluxPercentile25
     "@id": "#DiaObject.zPSFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: zPSFluxPercentile50
     "@id": "#DiaObject.zPSFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: zPSFluxPercentile75
     "@id": "#DiaObject.zPSFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: zPSFluxPercentile95
     "@id": "#DiaObject.zPSFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: zPSFluxSigma
     "@id": "#DiaObject.zPSFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of zPSFlux
   - name: zPSFluxSkew
     "@id": "#DiaObject.zPSFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: zPSFluxStetsonJ
     "@id": "#DiaObject.zPSFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: zTOTFluxMean
     "@id": "#DiaObject.zTOTFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: zTOTFluxMeanErr
     "@id": "#DiaObject.zTOTFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on zTOTFluxMean
   - name: zTOTFluxSigma
     "@id": "#DiaObject.zTOTFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
 - name: DiaSource
   "@id": "#DiaSource"
@@ -7955,13 +7203,11 @@ tables:
   - name: apFlux
     "@id": "#DiaSource.apFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux within 12.0-pixel aperture
     fits:tunit: nJy
   - name: apFluxErr
     "@id": "#DiaSource.apFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux uncertainty within 12.0-pixel aperture
     fits:tunit: nJy
   - name: apFlux_flag
@@ -7979,13 +7225,11 @@ tables:
   - name: bboxSize
     "@id": "#DiaSource.bboxSize"
     datatype: long
-    mysql:datatype: BIGINT
     description: Bounding box of diaSource footprint
     fits:tunit:
   - name: ccdVisitId
     "@id": "#DiaSource.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
     fits:tunit:
     ivoa:ucd: meta.id;obs.image
@@ -8010,78 +7254,66 @@ tables:
   - name: coord_dec
     "@id": "#DiaSource.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: coord_ra
     "@id": "#DiaSource.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: decl
     "@id": "#DiaSource.decl"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Position in Declination
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: diaObjectId
     "@id": "#DiaSource.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique DiaObject ID. Primary Key of the DIA Object Table
     fits:tunit:
     ivoa:ucd: meta.id.assoc;src
   - name: diaSourceId
     "@id": "#DiaSource.diaSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID
     fits:tunit:
     ivoa:ucd: meta.id;src;meta.main
   - name: dipAngle
     "@id": "#DiaSource.dipAngle"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Dipole orientation
     fits:tunit: deg
   - name: dipChi2
     "@id": "#DiaSource.dipChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi2 per degree of freedom of dipole fit
     fits:tunit:
   - name: dipFluxDiff
     "@id": "#DiaSource.dipFluxDiff"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux counts, positive lobe
     fits:tunit: nJy
   - name: dipFluxDiffErr
     "@id": "#DiaSource.dipFluxDiffErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux uncertainty counts, positive lobe
     fits:tunit: nJy
   - name: dipLength
     "@id": "#DiaSource.dipLength"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Pixel separation between positive and negative lobes of dipole
     fits:tunit: pixel
   - name: dipMeanFlux
     "@id": "#DiaSource.dipMeanFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux counts, positive lobe
     fits:tunit: count
   - name: dipMeanFluxErr
     "@id": "#DiaSource.dipMeanFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux uncertainty counts, positive lobe
     fits:tunit: count
   - name: filterName
@@ -8118,50 +7350,42 @@ tables:
   - name: ixx
     "@id": "#DiaSource.ixx"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments
     fits:tunit: arcsec**2
   - name: ixxPSF
     "@id": "#DiaSource.ixxPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position
     fits:tunit: arcsec**2
   - name: ixy
     "@id": "#DiaSource.ixy"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments
     fits:tunit: arcsec**2
   - name: ixyPSF
     "@id": "#DiaSource.ixyPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position
     fits:tunit: arcsec**2
   - name: iyy
     "@id": "#DiaSource.iyy"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments
     fits:tunit: arcsec**2
   - name: iyyPSF
     "@id": "#DiaSource.iyyPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position
     fits:tunit: arcsec**2
   - name: midPointTai
     "@id": "#DiaSource.midPointTai"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Effective mid-exposure time for this diaSource.
     fits:tunit: d
     ivoa:ucd: time.epoch;obs.exposure
   - name: parentDiaSourceId
     "@id": "#DiaSource.parentDiaSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of parent source
     fits:tunit:
   - name: pixelFlags
@@ -8239,19 +7463,16 @@ tables:
   - name: pixelId
     "@id": "#DiaSource.pixelId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Position in ra/dec
     fits:tunit:
   - name: psFlux
     "@id": "#DiaSource.psFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of PSF model
     fits:tunit: nJy
   - name: psFluxErr
     "@id": "#DiaSource.psFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux uncertainty derived from linear least-squares fit of PSF model
     fits:tunit: nJy
   - name: psfFlux_flag
@@ -8275,7 +7496,6 @@ tables:
   - name: ra
     "@id": "#DiaSource.ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Position in Right Ascension
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
@@ -8318,49 +7538,41 @@ tables:
   - name: snr
     "@id": "#DiaSource.snr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Ratio of apFlux/apFluxErr
     fits:tunit:
   - name: ssObjectId
     "@id": "#DiaSource.ssObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Id of the solar system object (ssObject) this source was associated with, if any. If not, it is set to 0
     fits:tunit:
   - name: totFlux
     "@id": "#DiaSource.totFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Forced PSF flux measured on the direct image.
     fits:tunit: nJy
   - name: totFluxErr
     "@id": "#DiaSource.totFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Forced PSF flux uncertainty measured on the direct image.
     fits:tunit: nJy
   - name: x
     "@id": "#DiaSource.x"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Unweighted first moment centroid, overall centroid
     fits:tunit: pixel
   - name: xErr
     "@id": "#DiaSource.xErr"
     datatype: float
-    mysql:datatype: FLOAT
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: y
     "@id": "#DiaSource.y"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Unweighted first moment centroid, overall centroid
     fits:tunit: pixel
   - name: yErr
     "@id": "#DiaSource.yErr"
     datatype: float
-    mysql:datatype: FLOAT
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   constraints:
@@ -8401,7 +7613,6 @@ tables:
   - name: ccdVisitId
     "@id": "#ForcedSourceOnDiaObject.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of visit and detector for which forced photometry was performed. Primary Key of the CcdVisit Table.
     fits:tunit:
     ivoa:ucd: meta.id;obs.image
@@ -8410,7 +7621,6 @@ tables:
   - name: coord_dec
     "@id": "#ForcedSourceOnDiaObject.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of DiaObject centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
@@ -8419,7 +7629,6 @@ tables:
   - name: coord_ra
     "@id": "#ForcedSourceOnDiaObject.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of DiaObject centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
@@ -8428,7 +7637,6 @@ tables:
   - name: diaObjectId
     "@id": "#ForcedSourceOnDiaObject.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique DiaObject ID. Primary Key of the DiaObject Table
     fits:tunit:
     ivoa:ucd: meta.id;src
@@ -8437,7 +7645,6 @@ tables:
   - name: forcedSourceOnDiaObjectId
     "@id": "#ForcedSourceOnDiaObject.forcedSourceOnDiaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of forced source. Primary Key.
     fits:tunit:
     ivoa:ucd: meta.id;src;meta.main
@@ -8446,7 +7653,6 @@ tables:
   - name: localBackground_instFlux
     "@id": "#ForcedSourceOnDiaObject.localBackground_instFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Background in annulus around source
     fits:tunit: count
     ivoa:ucd: phot.count
@@ -8455,7 +7661,6 @@ tables:
   - name: localBackground_instFluxErr
     "@id": "#ForcedSourceOnDiaObject.localBackground_instFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 1-sigma uncertainty on the background in an annulus around source
     fits:tunit: count
     ivoa:ucd: stat.error;phot.count
@@ -8464,7 +7669,6 @@ tables:
   - name: localPhotoCalib
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalib"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
     ivoa:ucd: phot.calib
@@ -8473,7 +7677,6 @@ tables:
   - name: localPhotoCalibErr
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalibErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
     ivoa:ucd: stat.error;phot.calib
@@ -8491,7 +7694,6 @@ tables:
   - name: localWcs_CDMatrix_1_1
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_1_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -8500,7 +7702,6 @@ tables:
   - name: localWcs_CDMatrix_1_2
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_1_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -8509,7 +7710,6 @@ tables:
   - name: localWcs_CDMatrix_2_1
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_2_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -8518,7 +7718,6 @@ tables:
   - name: localWcs_CDMatrix_2_2
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_2_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
     ivoa:ucd: pos.wcs.cdmatrix
@@ -8536,7 +7735,6 @@ tables:
   - name: parentObjectId
     "@id": "#ForcedSourceOnDiaObject.parentObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
     fits:tunit:
     ivoa:ucd: meta.id.parent
@@ -8545,7 +7743,6 @@ tables:
   - name: patch
     "@id": "#ForcedSourceOnDiaObject.patch"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap patch ID
     fits:tunit:
     ivoa:ucd: meta.id.part;obs.field
@@ -8644,7 +7841,6 @@ tables:
   - name: psfDiffFlux
     "@id": "#ForcedSourceOnDiaObject.psfDiffFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
     ivoa:ucd: phot.flux
@@ -8653,7 +7849,6 @@ tables:
   - name: psfDiffFluxErr
     "@id": "#ForcedSourceOnDiaObject.psfDiffFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.flux
@@ -8671,7 +7866,6 @@ tables:
   - name: psfFlux
     "@id": "#ForcedSourceOnDiaObject.psfFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
     ivoa:ucd: phot.flux
@@ -8680,7 +7874,6 @@ tables:
   - name: psfFluxErr
     "@id": "#ForcedSourceOnDiaObject.psfFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
     ivoa:ucd: stat.error;phot.flux
@@ -8707,7 +7900,6 @@ tables:
   - name: tract
     "@id": "#ForcedSourceOnDiaObject.tract"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
     ivoa:ucd: meta.id;obs.field
@@ -8763,7 +7955,6 @@ tables:
     '@id': '#Visit.ra'
     datatype: double
     description: RA of focal plane center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
     tap:principal: 1
@@ -8772,7 +7963,6 @@ tables:
     '@id': '#Visit.decl'
     datatype: double
     description: Declination of focal plane center
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
     tap:principal: 1
@@ -8781,7 +7971,6 @@ tables:
     '@id': '#Visit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.posAng
     tap:principal: 1
@@ -8790,7 +7979,6 @@ tables:
     '@id': '#Visit.azimuth'
     datatype: double
     description: Azimuth of focal plane center at the middle of the exposure.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.az.azi
     tap:principal: 0
@@ -8799,7 +7987,6 @@ tables:
     '@id': '#Visit.altitude'
     datatype: double
     description: Altitude of focal plane center at the middle of the exposure.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.az.alt
     tap:principal: 0
@@ -8826,7 +8013,6 @@ tables:
     '@id': '#Visit.expTime'
     datatype: double
     description: Spatially-averaged duration of exposure, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
     ivoa:ucd: time.duration;obs.exposure
     tap:principal: 1
@@ -8846,7 +8032,6 @@ tables:
     datatype: double
     description: Midpoint time for exposure at the fiducial center of the focal plane array in MJD.
       TAI, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 1
@@ -8865,7 +8050,6 @@ tables:
     '@id': '#Visit.obsStartMJD'
     datatype: double
     description: Start of the exposure in MJD, TAI, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.start;obs.exposure
     tap:principal: 0
@@ -8880,7 +8064,6 @@ tables:
     '@id': '#CcdVisit.ccdVisitId'
     datatype: long
     description: Primary key (unique identifier).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image;meta.main
     tap:principal: 1
     tap:column_index: 1
@@ -8919,7 +8102,6 @@ tables:
     '@id': '#CcdVisit.ra'
     datatype: double
     description: RA of CCD center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
     tap:principal: 1
@@ -8928,7 +8110,6 @@ tables:
     '@id': '#CcdVisit.decl'
     datatype: double
     description: Declination of CCD center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
     tap:principal: 1
@@ -8937,7 +8118,6 @@ tables:
     '@id': '#CcdVisit.zenithDistance'
     datatype: float
     description: Zenith distance at observation mid-point.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: pos.az.zd
     tap:principal: 1
@@ -8946,7 +8126,6 @@ tables:
     '@id': '#CcdVisit.zeroPoint'
     datatype: float
     description: Zero-point for the CCD, estimated at CCD center.
-    mysql:datatype: FLOAT
     fits:tunit: mag
     ivoa:ucd: arith.zp;instr.calib
     tap:principal: 0
@@ -8955,7 +8134,6 @@ tables:
     '@id': '#CcdVisit.psfSigma'
     datatype: float
     description: PSF model second-moments determinant radius (center of chip)
-    mysql:datatype: FLOAT
     fits:tunit: pixel
     ivoa:ucd: stat.stdev;instr.det.psf
     tap:principal: 0
@@ -8964,7 +8142,6 @@ tables:
     '@id': '#CcdVisit.skyBg'
     datatype: float
     description: Average sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
     ivoa:ucd: instr.skyLevel
     tap:principal: 0
@@ -8973,7 +8150,6 @@ tables:
     '@id': '#CcdVisit.skyNoise'
     datatype: float
     description: RMS noise of the sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
     ivoa:ucd: stat.rms;instr.skyLevel
     tap:principal: 0
@@ -8982,7 +8158,6 @@ tables:
     '@id': '#CcdVisit.detector'
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id.part;instr.det
     tap:principal: 1
     tap:column_index: 3
@@ -8999,7 +8174,6 @@ tables:
     '@id': '#CcdVisit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.posAng
     tap:principal: 0
@@ -9016,7 +8190,6 @@ tables:
     '@id': '#CcdVisit.expMidptMJD'
     datatype: double
     description: Midpoint for exposure in MJD. TAI, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch;obs.exposure
     tap:principal: 1
@@ -9025,7 +8198,6 @@ tables:
     '@id': '#CcdVisit.expTime'
     datatype: double
     description: Spatially-averaged duration of exposure, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
     ivoa:ucd: time.duration;obs.exposure
     tap:principal: 1
@@ -9043,7 +8215,6 @@ tables:
     '@id': '#CcdVisit.obsStartMJD'
     datatype: double
     description: Start of the exposure in MJD, TAI, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.start;obs.exposure
     tap:principal: 0
@@ -9052,7 +8223,6 @@ tables:
     '@id': '#CcdVisit.darkTime'
     datatype: double
     description: Average dark current accumulation time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
     ivoa:ucd: time.duration;obs.calib.dark
     tap:principal: 0
@@ -9079,7 +8249,6 @@ tables:
     '@id': '#CcdVisit.llcra'
     datatype: double
     description: RA of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
@@ -9088,7 +8257,6 @@ tables:
     '@id': '#CcdVisit.llcdec'
     datatype: double
     description: Declination of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
@@ -9097,7 +8265,6 @@ tables:
     '@id': '#CcdVisit.ulcra'
     datatype: double
     description: RA of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
@@ -9106,7 +8273,6 @@ tables:
     '@id': '#CcdVisit.ulcdec'
     datatype: double
     description: Declination of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
@@ -9115,7 +8281,6 @@ tables:
     '@id': '#CcdVisit.urcra'
     datatype: double
     description: RA of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
@@ -9124,7 +8289,6 @@ tables:
     '@id': '#CcdVisit.urcdec'
     datatype: double
     description: Declination of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
@@ -9133,7 +8297,6 @@ tables:
     '@id': '#CcdVisit.lrcra'
     datatype: double
     description: RA of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;pos.outline;obs.field
     tap:principal: 0
@@ -9142,7 +8305,6 @@ tables:
     '@id': '#CcdVisit.lrcdec'
     datatype: double
     description: Declination of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;pos.outline;obs.field
     tap:principal: 0
@@ -9239,21 +8401,18 @@ tables:
   - name: match_count
     '@id': '#MatchesTruth.match_count'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: Number of candidate object matches within match radius
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: DOUBLE
     tap:column_index: 999
     tap:principal: 0
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 0
     description: The number of finite columns used to compute the match chisq
@@ -9276,7 +8435,6 @@ tables:
   - name: match_objectId
     '@id': '#MatchesTruth.match_objectId'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 1
     tap:principal: 1
     description: objectId of matched entry in the Object table, if any
@@ -9363,7 +8521,6 @@ tables:
   - name: host_galaxy
     '@id': '#TruthSummary.host_galaxy'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: ID of the host galaxy for a SN/AGN entry (-1 for other truth types)
@@ -9371,7 +8528,6 @@ tables:
     '@id': '#TruthSummary.ra'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 2
     tap:principal: 1
     fits:tunit: deg
@@ -9381,7 +8537,6 @@ tables:
     '@id': '#TruthSummary.dec'
     datatype: double
     nullable: false
-    mysql:datatype: DOUBLE
     tap:column_index: 3
     tap:principal: 1
     fits:tunit: deg
@@ -9390,28 +8545,24 @@ tables:
   - name: redshift
     '@id': '#TruthSummary.redshift'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     description: Redshift
   - name: is_variable
     '@id': '#TruthSummary.is_variable'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 1
     description: 1 for a variable source
   - name: is_pointsource
     '@id': '#TruthSummary.is_pointsource'
     datatype: int
-    mysql:datatype: INTEGER
     tap:column_index: 999
     tap:principal: 1
     description: 1 for a point source
   - name: flux_u
     '@id': '#TruthSummary.flux_u'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9419,7 +8570,6 @@ tables:
   - name: flux_g
     '@id': '#TruthSummary.flux_g'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9427,7 +8577,6 @@ tables:
   - name: flux_r
     '@id': '#TruthSummary.flux_r'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9435,7 +8584,6 @@ tables:
   - name: flux_i
     '@id': '#TruthSummary.flux_i'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9443,7 +8591,6 @@ tables:
   - name: flux_z
     '@id': '#TruthSummary.flux_z'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9451,7 +8598,6 @@ tables:
   - name: flux_y
     '@id': '#TruthSummary.flux_y'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: nJy
@@ -9459,7 +8605,6 @@ tables:
   - name: flux_u_noMW
     '@id': '#TruthSummary.flux_u_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9467,7 +8612,6 @@ tables:
   - name: flux_g_noMW
     '@id': '#TruthSummary.flux_g_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9475,7 +8619,6 @@ tables:
   - name: flux_r_noMW
     '@id': '#TruthSummary.flux_r_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9483,7 +8626,6 @@ tables:
   - name: flux_i_noMW
     '@id': '#TruthSummary.flux_i_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9491,7 +8633,6 @@ tables:
   - name: flux_z_noMW
     '@id': '#TruthSummary.flux_z_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9499,7 +8640,6 @@ tables:
   - name: flux_y_noMW
     '@id': '#TruthSummary.flux_y_noMW'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 0
     fits:tunit: nJy
@@ -9507,7 +8647,6 @@ tables:
   - name: mag_r
     '@id': '#TruthSummary.mag_r'
     datatype: float
-    mysql:datatype: FLOAT
     tap:column_index: 999
     tap:principal: 1
     fits:tunit: mag
@@ -9515,21 +8654,18 @@ tables:
   - name: cosmodc2_hp
     '@id': '#TruthSummary.cosmodc2_hp'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 0
     description: Healpix ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: cosmodc2_id
     '@id': '#TruthSummary.cosmodc2_id'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 0
     description: Galaxy ID in cosmoDC2 (for galaxies only; -1 for stars and SNe)
   - name: truth_type
     '@id': '#TruthSummary.truth_type'
     datatype: long
-    mysql:datatype: BIGINT
     tap:column_index: 999
     tap:principal: 1
     description: 1 for galaxies, 2 for stars, and 3 for SNe

--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -19,7 +19,6 @@ tables:
     datatype: long
     nullable: false
     description: Unique identifier.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;meta.main;src
   - name: discoverySubmissionDate
     "@id": "#SSObject.discoverySubmissionDate"
@@ -27,335 +26,281 @@ tables:
     description: The date the LSST first linked and submitted the discovery observations
       to the MPC. May be NULL if not an LSST discovery. The date format will follow
       general LSST conventions (MJD TAI, at the moment).
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: firstObservationDate
     "@id": "#SSObject.firstObservationDate"
     datatype: double
     description: The time of the first LSST observation of this object (could be precovered)
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: arc
     "@id": "#SSObject.arc"
     datatype: float
     description: Arc of LSST observations
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: numObs
     "@id": "#SSObject.numObs"
     datatype: int
     description: Number of LSST observations of this object
-    mysql:datatype: INTEGER
   - name: MOID
     "@id": "#SSObject.MOID"
     datatype: float
     description: Minimum orbit intersection distance to Earth
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: MOIDTrueAnomaly
     "@id": "#SSObject.MOIDTrueAnomaly"
     datatype: float
     description: True anomaly of the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDEclipticLongitude
     "@id": "#SSObject.MOIDEclipticLongitude"
     datatype: float
     description: Ecliptic longitude of the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDDeltaV
     "@id": "#SSObject.MOIDDeltaV"
     datatype: float
     description: DeltaV at the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: km/s
   - name: u_H
     "@id": "#SSObject.u_H"
     datatype: float
     description: Best fit absolute magnitude (u band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_G12
     "@id": "#SSObject.u_G12"
     datatype: float
     description: Best fit G12 slope parameter (u band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_HErr
     "@id": "#SSObject.u_HErr"
     datatype: float
     description: Uncertainty of H (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_G12Err
     "@id": "#SSObject.u_G12Err"
     datatype: float
     description: Uncertainty of G12 (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_H_uG12_Cov
     "@id": "#SSObject.u_H_uG12_Cov"
     datatype: float
     description: H-G12 covariance (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: u_Ndata
     "@id": "#SSObject.u_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (u band)
-    mysql:datatype: INTEGER
   - name: g_H
     "@id": "#SSObject.g_H"
     datatype: float
     description: Best fit absolute magnitude (g band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_G12
     "@id": "#SSObject.g_G12"
     datatype: float
     description: Best fit G12 slope parameter (g band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_HErr
     "@id": "#SSObject.g_HErr"
     datatype: float
     description: Uncertainty of H (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_G12Err
     "@id": "#SSObject.g_G12Err"
     datatype: float
     description: Uncertainty of G12 (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_H_gG12_Cov
     "@id": "#SSObject.g_H_gG12_Cov"
     datatype: float
     description: H-G12 covariance (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: g_Ndata
     "@id": "#SSObject.g_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (g band)
-    mysql:datatype: INTEGER
   - name: r_H
     "@id": "#SSObject.r_H"
     datatype: float
     description: Best fit absolute magnitude (r band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_G12
     "@id": "#SSObject.r_G12"
     datatype: float
     description: Best fit G12 slope parameter (r band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_HErr
     "@id": "#SSObject.r_HErr"
     datatype: float
     description: Uncertainty of H (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_G12Err
     "@id": "#SSObject.r_G12Err"
     datatype: float
     description: Uncertainty of G12 (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_H_rG12_Cov
     "@id": "#SSObject.r_H_rG12_Cov"
     datatype: float
     description: H-G12 covariance (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: r_Ndata
     "@id": "#SSObject.r_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (r band)
-    mysql:datatype: INTEGER
   - name: i_H
     "@id": "#SSObject.i_H"
     datatype: float
     description: Best fit absolute magnitude (i band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_G12
     "@id": "#SSObject.i_G12"
     datatype: float
     description: Best fit G12 slope parameter (i band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_HErr
     "@id": "#SSObject.i_HErr"
     datatype: float
     description: Uncertainty of H (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_G12Err
     "@id": "#SSObject.i_G12Err"
     datatype: float
     description: Uncertainty of G12 (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_H_iG12_Cov
     "@id": "#SSObject.i_H_iG12_Cov"
     datatype: float
     description: H-G12 covariance (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: i_Ndata
     "@id": "#SSObject.i_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (i band)
-    mysql:datatype: INTEGER
   - name: z_H
     "@id": "#SSObject.z_H"
     datatype: float
     description: Best fit absolute magnitude (z band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_G12
     "@id": "#SSObject.z_G12"
     datatype: float
     description: Best fit G12 slope parameter (z band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_HErr
     "@id": "#SSObject.z_HErr"
     datatype: float
     description: Uncertainty of H (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_G12Err
     "@id": "#SSObject.z_G12Err"
     datatype: float
     description: Uncertainty of G12 (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_H_zG12_Cov
     "@id": "#SSObject.z_H_zG12_Cov"
     datatype: float
     description: H-G12 covariance (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: z_Ndata
     "@id": "#SSObject.z_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (z band)
-    mysql:datatype: INTEGER
   - name: y_H
     "@id": "#SSObject.y_H"
     datatype: float
     description: Best fit absolute magnitude (y band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_G12
     "@id": "#SSObject.y_G12"
     datatype: float
     description: Best fit G12 slope parameter (y band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_HErr
     "@id": "#SSObject.y_HErr"
     datatype: float
     description: Uncertainty of H (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_G12Err
     "@id": "#SSObject.y_G12Err"
     datatype: float
     description: Uncertainty of G12 (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_H_yG12_Cov
     "@id": "#SSObject.y_H_yG12_Cov"
     datatype: float
     description: H-G12 covariance (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: y_Ndata
     "@id": "#SSObject.y_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (y band)
-    mysql:datatype: INTEGER
   - name: maxExtendedness
     "@id": "#SSObject.maxExtendedness"
     datatype: float
     description: maximum `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: minExtendedness
     "@id": "#SSObject.minExtendedness"
     datatype: float
     description: minimum `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: medianExtendedness
     "@id": "#SSObject.medianExtendedness"
     datatype: float
     description: median `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: flags
     "@id": "#SSObject.flags"
     datatype: long
     nullable: false
     description: Flags, bitwise OR tbd.
     value: 0
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
 - name: DiaSource
   "@id": "#DiaSource"
@@ -366,7 +311,6 @@ tables:
     "@id": "#DiaSource.diaSourceId"
     datatype: long
     description: Unique id.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;meta.main;src
   - name: ccdVisitId
     "@id": "#DiaSource.ccdVisitId"
@@ -374,7 +318,6 @@ tables:
     description: Id of the ccdVisit where this diaSource was measured. Note that we
       are allowing a diaSource to belong to multiple amplifiers, but it may not span
       multiple ccds.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: diaObjectId
     "@id": "#DiaSource.diaObjectId"
@@ -382,7 +325,6 @@ tables:
     description: Id of the diaObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: ssObjectId
     "@id": "#DiaSource.ssObjectId"
@@ -390,7 +332,6 @@ tables:
     description: Id of the ssObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nameTrue
     "@id": "#DiaSource.nameTrue"
@@ -408,42 +349,36 @@ tables:
     "@id": "#DiaSource.midPointMjdTai"
     datatype: double
     description: Effective mid-exposure time for this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch
   - name: ra
     "@id": "#DiaSource.ra"
     datatype: double
     description: RA-coordinate of the center of this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: raErr
     "@id": "#DiaSource.raErr"
     datatype: float
     description: Uncertainty of ra.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: dec
     "@id": "#DiaSource.dec"
     datatype: double
     description: "Dec-coordinate of the center of this diaSource."
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: decErr
     "@id": "#DiaSource.decErr"
     datatype: float
     description: Uncertainty of dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: ra_dec_Cov
     "@id": "#DiaSource.ra_dec_Cov"
     datatype: float
     description: Covariance between ra and dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: snr
@@ -451,7 +386,6 @@ tables:
     datatype: float
     description: The signal-to-noise ratio at which this source was detected in the
       difference image.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.snr
   - name: band
     "@id": "#DiaSource.band"
@@ -463,27 +397,22 @@ tables:
     "@id": "#DiaSource.mag"
     datatype: float
     description: Magnitude. This is a placeholder and should be replaced by flux.
-    mysql:datatype: FLOAT
   - name: magErr
     "@id": "#DiaSource.magErr"
     datatype: float
     description: Magnitude error. This is a placeholder and should be replaced by flux error.
-    mysql:datatype: FLOAT
   - name: magTrueVband
     "@id": "#DiaSource.magTrueVband"
     datatype: float
     description: True (noiseless) V-band magnitude of the simulated diaSource
-    mysql:datatype: FLOAT
   - name: raTrue
     "@id": "#DiaSource.raTrue"
     datatype: double
     description: True (noiseless) right ascension of the simulated diaSource
-    mysql:datatype: DOUBLE
   - name: decTrue
     "@id": "#DiaSource.decTrue"
     datatype: double
     description: True (noiseless) declination of the simulated diaSource
-    mysql:datatype: DOUBLE
   primaryKey: "#DiaSource.diaSourceId"
   indexes:
   - name: IDX_DiaSource_ccdVisitId
@@ -522,174 +451,145 @@ tables:
     "@id": "#SSSource.ssObjectId"
     datatype: long
     description: Unique identifier of the object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: diaSourceId
     "@id": "#SSSource.diaSourceId"
     datatype: long
     description: Unique identifier of the observation
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;meta.main;src
   - name: mpcUniqueId
     "@id": "#SSSource.mpcUniqueId"
     datatype: long
     description: MPC unique identifier of the observation
-    mysql:datatype: BIGINT
   - name: eclipticLambda
     "@id": "#SSSource.eclipticLambda"
     datatype: double
     description: Ecliptic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: eclipticBeta
     "@id": "#SSSource.eclipticBeta"
     datatype: double
     description: Ecliptic latitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticL
     "@id": "#SSSource.galacticL"
     datatype: double
     description: Galactic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticB
     "@id": "#SSSource.galacticB"
     datatype: double
     description: Galactic latitute
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: phaseAngle
     "@id": "#SSSource.phaseAngle"
     datatype: float
     description: Phase angle
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: heliocentricDist
     "@id": "#SSSource.heliocentricDist"
     datatype: float
     description: Heliocentric distance
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricDist
     "@id": "#SSSource.topocentricDist"
     datatype: float
     description: Topocentric distace
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: predictedMagnitude
     "@id": "#SSSource.predictedMagnitude"
     datatype: float
     description: Predicted magnitude
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: predictedMagnitudeErr
     "@id": "#SSSource.predictedMagnitudeErr"
     datatype: float
     description: Prediction uncertainty (1-sigma)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: residualRa
     "@id": "#SSSource.residualRa"
     datatype: double
     description: Residual R.A. vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: residualDec
     "@id": "#SSSource.residualDec"
     datatype: double
     description: Residual Dec vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: predictedRaErr
     "@id": "#SSSource.predictedRaErr"
     datatype: float
     description: Predicted R.A. uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedDecErr
     "@id": "#SSSource.predictedDecErr"
     datatype: float
     description: Predicted Dec uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedRaDecCov
     "@id": "#SSSource.predictedRaDecCov"
     datatype: float
     description: Predicted R.A./Dec covariance
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float
     description: Cartesian heliocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricY
     "@id": "#SSSource.heliocentricY"
     datatype: float
     description: Cartesian heliocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricZ
     "@id": "#SSSource.heliocentricZ"
     datatype: float
     description: Cartesian heliocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVX
     "@id": "#SSSource.heliocentricVX"
     datatype: float
     description: Cartesian heliocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVY
     "@id": "#SSSource.heliocentricVY"
     datatype: float
     description: Cartesian heliocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVZ
     "@id": "#SSSource.heliocentricVZ"
     datatype: float
     description: Cartesian heliocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricX
     "@id": "#SSSource.topocentricX"
     datatype: float
     description: Cartesian topocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricY
     "@id": "#SSSource.topocentricY"
     datatype: float
     description: Cartesian topocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricZ
     "@id": "#SSSource.topocentricZ"
     datatype: float
     description: Cartesian topocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVX
     "@id": "#SSSource.topocentricVX"
     datatype: float
     description: Cartesian topocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVY
     "@id": "#SSSource.topocentricVY"
     datatype: float
     description: Cartesian topocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVZ
     "@id": "#SSSource.topocentricVZ"
     datatype: float
     description: Cartesian topocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   constraints:
   - name: SSO_SSS_10yr
@@ -721,70 +621,58 @@ tables:
     datatype: int
     description: MPC number (if the asteroid has been numbered; NULL otherwise). Provided
       for convenience.
-    mysql:datatype: INTEGER
   - name: ssObjectId
     "@id": "#MPCORB.ssObjectId"
     datatype: long
     description: LSST unique identifier (if observed by LSST)
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: mpcH
     "@id": "#MPCORB.mpcH"
     datatype: float
     description: 'MPCORB: Absolute magnitude, H'
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: mpcG
     "@id": "#MPCORB.mpcG"
     datatype: float
     description: 'MPCORB: Slope parameter, G'
-    mysql:datatype: FLOAT
   - name: epoch
     "@id": "#MPCORB.epoch"
     datatype: double
     description: 'MPCORB: Epoch (in MJD, .0 TT)'
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: tperi
     "@id": "#MPCORB.tperi"
     datatype: double
     description: 'MPCORB: MJD of pericentric passage'
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: peri
     "@id": "#MPCORB.peri"
     datatype: double
     description: 'MPCORB: Argument of perihelion, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: node
     "@id": "#MPCORB.node"
     datatype: double
     description: 'MPCORB: Longitude of the ascending node, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: incl
     "@id": "#MPCORB.incl"
     datatype: double
     description: 'MPCORB: Inclination to the ecliptic, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: e
     "@id": "#MPCORB.e"
     datatype: double
     description: 'MPCORB: Orbital eccentricity'
-    mysql:datatype: DOUBLE
   - name: n
     "@id": "#MPCORB.n"
     datatype: double
     description: 'MPCORB: Mean daily motion (degrees per day)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg/d
   - name: q
     "@id": "#MPCORB.q"
     datatype: double
     description: 'MPCORB: Perihelion distance (AU)'
-    mysql:datatype: DOUBLE
     fits:tunit: AU
   - name: uncertaintyParameter
     "@id": "#MPCORB.uncertaintyParameter"
@@ -802,17 +690,14 @@ tables:
     "@id": "#MPCORB.nobs"
     datatype: int
     description: 'MPCORB: Number of observations'
-    mysql:datatype: INTEGER
   - name: nopp
     "@id": "#MPCORB.nopp"
     datatype: int
     description: 'MPCORB: Number of oppositions'
-    mysql:datatype: INTEGER
   - name: arc
     "@id": "#MPCORB.arc"
     datatype: float
     description: 'MPCORB: Arc (days), for single-opposition objects'
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: arcStart
     "@id": "#MPCORB.arcStart"
@@ -828,7 +713,6 @@ tables:
     "@id": "#MPCORB.rms"
     datatype: float
     description: 'MPCORB: r.m.s residual (")'
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: pertsShort
     "@id": "#MPCORB.pertsShort"
@@ -855,7 +739,6 @@ tables:
     datatype: int
     description: 'MPCORB: 4-hexdigit flags. See https://minorplanetcenter.net//iau/info/MPOrbitFormat.html
       for details'
-    mysql:datatype: INTEGER
   - name: fullDesignation
     "@id": "#MPCORB.fullDesignation"
     datatype: char
@@ -866,5 +749,4 @@ tables:
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float
     description: 'MPCORB: Date of last observation included in orbit solution'
-    mysql:datatype: FLOAT
     fits:tunit: d

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -19,7 +19,6 @@ tables:
     datatype: long
     nullable: false
     description: Unique identifier.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: discoverySubmissionDate
     "@id": "#SSObject.discoverySubmissionDate"
@@ -27,335 +26,281 @@ tables:
     description: The date the LSST first linked and submitted the discovery observations
       to the MPC. May be NULL if not an LSST discovery. The date format will follow
       general LSST conventions (MJD TAI, at the moment).
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: firstObservationDate
     "@id": "#SSObject.firstObservationDate"
     datatype: double
     description: The time of the first LSST observation of this object (could be precovered)
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: arc
     "@id": "#SSObject.arc"
     datatype: float
     description: Arc of LSST observations
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: numObs
     "@id": "#SSObject.numObs"
     datatype: int
     description: Number of LSST observations of this object
-    mysql:datatype: INTEGER
   - name: MOID
     "@id": "#SSObject.MOID"
     datatype: float
     description: Minimum orbit intersection distance to Earth
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: MOIDTrueAnomaly
     "@id": "#SSObject.MOIDTrueAnomaly"
     datatype: float
     description: True anomaly of the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDEclipticLongitude
     "@id": "#SSObject.MOIDEclipticLongitude"
     datatype: float
     description: Ecliptic longitude of the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: MOIDDeltaV
     "@id": "#SSObject.MOIDDeltaV"
     datatype: float
     description: DeltaV at the MOID point
-    mysql:datatype: FLOAT
     fits:tunit: km/s
   - name: u_H
     "@id": "#SSObject.u_H"
     datatype: float
     description: Best fit absolute magnitude (u band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_G12
     "@id": "#SSObject.u_G12"
     datatype: float
     description: Best fit G12 slope parameter (u band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: u_HErr
     "@id": "#SSObject.u_HErr"
     datatype: float
     description: Uncertainty of H (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_G12Err
     "@id": "#SSObject.u_G12Err"
     datatype: float
     description: Uncertainty of G12 (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: u_H_uG12_Cov
     "@id": "#SSObject.u_H_uG12_Cov"
     datatype: float
     description: H-G12 covariance (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: u_Chi2
     "@id": "#SSObject.u_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (u band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: u_Ndata
     "@id": "#SSObject.u_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (u band)
-    mysql:datatype: INTEGER
   - name: g_H
     "@id": "#SSObject.g_H"
     datatype: float
     description: Best fit absolute magnitude (g band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_G12
     "@id": "#SSObject.g_G12"
     datatype: float
     description: Best fit G12 slope parameter (g band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: g_HErr
     "@id": "#SSObject.g_HErr"
     datatype: float
     description: Uncertainty of H (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_G12Err
     "@id": "#SSObject.g_G12Err"
     datatype: float
     description: Uncertainty of G12 (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: g_H_gG12_Cov
     "@id": "#SSObject.g_H_gG12_Cov"
     datatype: float
     description: H-G12 covariance (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: g_Chi2
     "@id": "#SSObject.g_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (g band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: g_Ndata
     "@id": "#SSObject.g_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (g band)
-    mysql:datatype: INTEGER
   - name: r_H
     "@id": "#SSObject.r_H"
     datatype: float
     description: Best fit absolute magnitude (r band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_G12
     "@id": "#SSObject.r_G12"
     datatype: float
     description: Best fit G12 slope parameter (r band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: r_HErr
     "@id": "#SSObject.r_HErr"
     datatype: float
     description: Uncertainty of H (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_G12Err
     "@id": "#SSObject.r_G12Err"
     datatype: float
     description: Uncertainty of G12 (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: r_H_rG12_Cov
     "@id": "#SSObject.r_H_rG12_Cov"
     datatype: float
     description: H-G12 covariance (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: r_Chi2
     "@id": "#SSObject.r_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (r band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: r_Ndata
     "@id": "#SSObject.r_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (r band)
-    mysql:datatype: INTEGER
   - name: i_H
     "@id": "#SSObject.i_H"
     datatype: float
     description: Best fit absolute magnitude (i band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_G12
     "@id": "#SSObject.i_G12"
     datatype: float
     description: Best fit G12 slope parameter (i band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: i_HErr
     "@id": "#SSObject.i_HErr"
     datatype: float
     description: Uncertainty of H (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_G12Err
     "@id": "#SSObject.i_G12Err"
     datatype: float
     description: Uncertainty of G12 (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: i_H_iG12_Cov
     "@id": "#SSObject.i_H_iG12_Cov"
     datatype: float
     description: H-G12 covariance (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: i_Chi2
     "@id": "#SSObject.i_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (i band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: i_Ndata
     "@id": "#SSObject.i_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (i band)
-    mysql:datatype: INTEGER
   - name: z_H
     "@id": "#SSObject.z_H"
     datatype: float
     description: Best fit absolute magnitude (z band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_G12
     "@id": "#SSObject.z_G12"
     datatype: float
     description: Best fit G12 slope parameter (z band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: z_HErr
     "@id": "#SSObject.z_HErr"
     datatype: float
     description: Uncertainty of H (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_G12Err
     "@id": "#SSObject.z_G12Err"
     datatype: float
     description: Uncertainty of G12 (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: z_H_zG12_Cov
     "@id": "#SSObject.z_H_zG12_Cov"
     datatype: float
     description: H-G12 covariance (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: z_Chi2
     "@id": "#SSObject.z_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (z band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: z_Ndata
     "@id": "#SSObject.z_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (z band)
-    mysql:datatype: INTEGER
   - name: y_H
     "@id": "#SSObject.y_H"
     datatype: float
     description: Best fit absolute magnitude (y band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_G12
     "@id": "#SSObject.y_G12"
     datatype: float
     description: Best fit G12 slope parameter (y band)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: y_HErr
     "@id": "#SSObject.y_HErr"
     datatype: float
     description: Uncertainty of H (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_G12Err
     "@id": "#SSObject.y_G12Err"
     datatype: float
     description: Uncertainty of G12 (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.error
     fits:tunit: mag
   - name: y_H_yG12_Cov
     "@id": "#SSObject.y_H_yG12_Cov"
     datatype: float
     description: H-G12 covariance (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.covariance
     fits:tunit: mag**2
   - name: y_Chi2
     "@id": "#SSObject.y_Chi2"
     datatype: float
     description: Chi^2 statistic of the phase curve fit (y band)
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.fit.chi2
   - name: y_Ndata
     "@id": "#SSObject.y_Ndata"
     datatype: int
     description: The number of data points used to fit the phase curve (y band)
-    mysql:datatype: INTEGER
   - name: maxExtendedness
     "@id": "#SSObject.maxExtendedness"
     datatype: float
     description: maximum `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: minExtendedness
     "@id": "#SSObject.minExtendedness"
     datatype: float
     description: minimum `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: medianExtendedness
     "@id": "#SSObject.medianExtendedness"
     datatype: float
     description: median `extendedness` value from the DIASource
-    mysql:datatype: FLOAT
   - name: flags
     "@id": "#SSObject.flags"
     datatype: long
     nullable: false
     description: Flags, bitwise OR tbd.
     value: 0
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.code
 - name: DiaSource
   "@id": "#DiaSource"
@@ -366,7 +311,6 @@ tables:
     "@id": "#DiaSource.diaSourceId"
     datatype: long
     description: Unique id.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: ccdVisitId
     "@id": "#DiaSource.ccdVisitId"
@@ -374,7 +318,6 @@ tables:
     description: Id of the ccdVisit where this diaSource was measured. Note that we
       are allowing a diaSource to belong to multiple amplifiers, but it may not span
       multiple ccds.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;obs.image
   - name: diaObjectId
     "@id": "#DiaSource.diaObjectId"
@@ -382,7 +325,6 @@ tables:
     description: Id of the diaObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: ssObjectId
     "@id": "#DiaSource.ssObjectId"
@@ -390,7 +332,6 @@ tables:
     description: Id of the ssObject this source was associated with, if any. If not,
       it is set to NULL (each diaSource will be associated with either a diaObject
       or ssObject).
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: nameTrue
     "@id": "#DiaSource.nameTrue"
@@ -408,42 +349,36 @@ tables:
     "@id": "#DiaSource.midPointMjdTai"
     datatype: double
     description: Effective mid-exposure time for this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: d
     ivoa:ucd: time.epoch
   - name: ra
     "@id": "#DiaSource.ra"
     datatype: double
     description: RA-coordinate of the center of this diaSource.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: raErr
     "@id": "#DiaSource.raErr"
     datatype: float
     description: Uncertainty of ra.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: dec
     "@id": "#DiaSource.dec"
     datatype: double
     description: "Dec-coordinate of the center of this diaSource."
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: decErr
     "@id": "#DiaSource.decErr"
     datatype: float
     description: Uncertainty of dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: ra_dec_Cov
     "@id": "#DiaSource.ra_dec_Cov"
     datatype: float
     description: Covariance between ra and dec.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance
   - name: snr
@@ -451,7 +386,6 @@ tables:
     datatype: float
     description: The signal-to-noise ratio at which this source was detected in the
       difference image.
-    mysql:datatype: FLOAT
     ivoa:ucd: stat.snr
   - name: band
     "@id": "#DiaSource.band"
@@ -463,27 +397,22 @@ tables:
     "@id": "#DiaSource.mag"
     datatype: float
     description: Magnitude. This is a placeholder and should be replaced by flux.
-    mysql:datatype: FLOAT
   - name: magErr
     "@id": "#DiaSource.magErr"
     datatype: float
     description: Magnitude error. This is a placeholder and should be replaced by flux error.
-    mysql:datatype: FLOAT
   - name: magTrueVband
     "@id": "#DiaSource.magTrueVband"
     datatype: float
     description: True (noiseless) V-band magnitude of the simulated diaSource
-    mysql:datatype: FLOAT
   - name: raTrue
     "@id": "#DiaSource.raTrue"
     datatype: double
     description: True (noiseless) right ascension of the simulated diaSource
-    mysql:datatype: DOUBLE
   - name: decTrue
     "@id": "#DiaSource.decTrue"
     datatype: double
     description: True (noiseless) declination of the simulated diaSource
-    mysql:datatype: DOUBLE
   primaryKey: "#DiaSource.diaSourceId"
   indexes:
   - name: IDX_DiaSource_ccdVisitId
@@ -513,174 +442,145 @@ tables:
     "@id": "#SSSource.ssObjectId"
     datatype: long
     description: Unique identifier of the object.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: diaSourceId
     "@id": "#SSSource.diaSourceId"
     datatype: long
     description: Unique identifier of the observation
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: mpcUniqueId
     "@id": "#SSSource.mpcUniqueId"
     datatype: long
     description: MPC unique identifier of the observation
-    mysql:datatype: BIGINT
   - name: eclipticLambda
     "@id": "#SSSource.eclipticLambda"
     datatype: double
     description: Ecliptic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: eclipticBeta
     "@id": "#SSSource.eclipticBeta"
     datatype: double
     description: Ecliptic latitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticL
     "@id": "#SSSource.galacticL"
     datatype: double
     description: Galactic longitude
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: galacticB
     "@id": "#SSSource.galacticB"
     datatype: double
     description: Galactic latitute
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: phaseAngle
     "@id": "#SSSource.phaseAngle"
     datatype: float
     description: Phase angle
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: heliocentricDist
     "@id": "#SSSource.heliocentricDist"
     datatype: float
     description: Heliocentric distance
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricDist
     "@id": "#SSSource.topocentricDist"
     datatype: float
     description: Topocentric distace
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: predictedMagnitude
     "@id": "#SSSource.predictedMagnitude"
     datatype: float
     description: Predicted magnitude
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: predictedMagnitudeErr
     "@id": "#SSSource.predictedMagnitudeErr"
     datatype: float
     description: Prediction uncertainty (1-sigma)
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: residualRa
     "@id": "#SSSource.residualRa"
     datatype: double
     description: Residual R.A. vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: residualDec
     "@id": "#SSSource.residualDec"
     datatype: double
     description: Residual Dec vs. ephemeris
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: predictedRaErr
     "@id": "#SSSource.predictedRaErr"
     datatype: float
     description: Predicted R.A. uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedDecErr
     "@id": "#SSSource.predictedDecErr"
     datatype: float
     description: Predicted Dec uncertainty
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: predictedRaDecCov
     "@id": "#SSSource.predictedRaDecCov"
     datatype: float
     description: Predicted R.A./Dec covariance
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: heliocentricX
     "@id": "#SSSource.heliocentricX"
     datatype: float
     description: Cartesian heliocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricY
     "@id": "#SSSource.heliocentricY"
     datatype: float
     description: Cartesian heliocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricZ
     "@id": "#SSSource.heliocentricZ"
     datatype: float
     description: Cartesian heliocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVX
     "@id": "#SSSource.heliocentricVX"
     datatype: float
     description: Cartesian heliocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVY
     "@id": "#SSSource.heliocentricVY"
     datatype: float
     description: Cartesian heliocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: heliocentricVZ
     "@id": "#SSSource.heliocentricVZ"
     datatype: float
     description: Cartesian heliocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricX
     "@id": "#SSSource.topocentricX"
     datatype: float
     description: Cartesian topocentric X coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricY
     "@id": "#SSSource.topocentricY"
     datatype: float
     description: Cartesian topocentric Y coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricZ
     "@id": "#SSSource.topocentricZ"
     datatype: float
     description: Cartesian topocentric Z coordinate (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVX
     "@id": "#SSSource.topocentricVX"
     datatype: float
     description: Cartesian topocentric X velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVY
     "@id": "#SSSource.topocentricVY"
     datatype: float
     description: Cartesian topocentric Y velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
   - name: topocentricVZ
     "@id": "#SSSource.topocentricVZ"
     datatype: float
     description: Cartesian topocentric Z velocity (at the emit time)
-    mysql:datatype: FLOAT
     fits:tunit: AU
 - name: MPCORB
   "@id": "#MPCORB"
@@ -703,70 +603,58 @@ tables:
     datatype: int
     description: MPC number (if the asteroid has been numbered; NULL otherwise). Provided
       for convenience.
-    mysql:datatype: INTEGER
   - name: ssObjectId
     "@id": "#MPCORB.ssObjectId"
     datatype: long
     description: LSST unique identifier (if observed by LSST)
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: mpcH
     "@id": "#MPCORB.mpcH"
     datatype: float
     description: 'MPCORB: Absolute magnitude, H'
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: mpcG
     "@id": "#MPCORB.mpcG"
     datatype: float
     description: 'MPCORB: Slope parameter, G'
-    mysql:datatype: FLOAT
   - name: epoch
     "@id": "#MPCORB.epoch"
     datatype: double
     description: 'MPCORB: Epoch (in MJD, .0 TT)'
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: tperi
     "@id": "#MPCORB.tperi"
     datatype: double
     description: 'MPCORB: MJD of pericentric passage'
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: peri
     "@id": "#MPCORB.peri"
     datatype: double
     description: 'MPCORB: Argument of perihelion, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: node
     "@id": "#MPCORB.node"
     datatype: double
     description: 'MPCORB: Longitude of the ascending node, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: incl
     "@id": "#MPCORB.incl"
     datatype: double
     description: 'MPCORB: Inclination to the ecliptic, J2000.0 (degrees)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: e
     "@id": "#MPCORB.e"
     datatype: double
     description: 'MPCORB: Orbital eccentricity'
-    mysql:datatype: DOUBLE
   - name: n
     "@id": "#MPCORB.n"
     datatype: double
     description: 'MPCORB: Mean daily motion (degrees per day)'
-    mysql:datatype: DOUBLE
     fits:tunit: deg/d
   - name: q
     "@id": "#MPCORB.q"
     datatype: double
     description: 'MPCORB: Perihelion distance (AU)'
-    mysql:datatype: DOUBLE
     fits:tunit: AU
   - name: uncertaintyParameter
     "@id": "#MPCORB.uncertaintyParameter"
@@ -784,17 +672,14 @@ tables:
     "@id": "#MPCORB.nobs"
     datatype: int
     description: 'MPCORB: Number of observations'
-    mysql:datatype: INTEGER
   - name: nopp
     "@id": "#MPCORB.nopp"
     datatype: int
     description: 'MPCORB: Number of oppositions'
-    mysql:datatype: INTEGER
   - name: arc
     "@id": "#MPCORB.arc"
     datatype: float
     description: 'MPCORB: Arc (days), for single-opposition objects'
-    mysql:datatype: FLOAT
     fits:tunit: d
   - name: arcStart
     "@id": "#MPCORB.arcStart"
@@ -810,7 +695,6 @@ tables:
     "@id": "#MPCORB.rms"
     datatype: float
     description: 'MPCORB: r.m.s residual (")'
-    mysql:datatype: FLOAT
     fits:tunit: arcsec
   - name: pertsShort
     "@id": "#MPCORB.pertsShort"
@@ -837,7 +721,6 @@ tables:
     datatype: int
     description: 'MPCORB: 4-hexdigit flags. See https://minorplanetcenter.net//iau/info/MPOrbitFormat.html
       for details'
-    mysql:datatype: INTEGER
   - name: fullDesignation
     "@id": "#MPCORB.fullDesignation"
     datatype: char
@@ -848,5 +731,4 @@ tables:
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float
     description: 'MPCORB: Date of last observation included in orbit solution'
-    mysql:datatype: FLOAT
     fits:tunit: d

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -14,49 +14,41 @@ tables:
     "@id": "#Object.objectId"
     datatype: long
     description: Unique id. Unique ObjectID
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: coord_dec
     "@id": "#Object.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: coord_ra
     "@id": "#Object.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: coord_decErr
     "@id": "#Object.coord_decErr"
     datatype: float
     description: Error in fiducial ICRS Declination of centroid.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: coord_raErr
     "@id": "#Object.coord_raErr"
     datatype: float
     description: Error in fiducial ICRS Right Ascension of centroid.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: coord_ra_dec_Cov
     "@id": "#Object.coord_ra_dec_Cov"
     datatype: float
     description: Covariance between fiducial ICRS Right Ascension and Declination of centroid.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: deblend_nChild
     "@id": "#Object.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_nPeaks
     "@id": "#Object.deblend_nPeaks"
     datatype: int
     description: Number of peaks this parent footprint has (even if the deblender failed or skipped this blend)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_failed
     "@id": "#Object.deblend_failed"
@@ -104,25 +96,21 @@ tables:
     "@id": "#Object.deblend_iterations"
     datatype: int
     description: Number of iterations during deblending
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_peak_center_x
     "@id": "#Object.deblend_peak_center_x"
     datatype: int
     description: x-coordinate of the peak after source detection
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: deblend_peak_center_y
     "@id": "#Object.deblend_peak_center_y"
     datatype: int
     description: y-coordinate of the peak after source detection
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: deblend_logL
     "@id": "#Object.deblend_logL"
     datatype: float
     description: Log likelihood of the entire blend in scarlet_lite.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: detect_fromBlend
     "@id": "#Object.detect_fromBlend"
@@ -170,13 +158,11 @@ tables:
     "@id": "#Object.ebv"
     datatype: double
     description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
-    mysql:datatype: DOUBLE
     fits:tunit: mag
   - name: footprintArea
     "@id": "#Object.footprintArea"
     datatype: int
     description: Number of pixels in the sources detection footprint. Reference band.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: merge_peak_sky
     "@id": "#Object.merge_peak_sky"
@@ -188,13 +174,11 @@ tables:
     "@id": "#Object.parentObjectId"
     datatype: long
     description: Unique ID of parent source. Reference band.
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: patch
     "@id": "#Object.patch"
     datatype: long
     description: Skymap patch ID
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: refBand
     "@id": "#Object.refBand"
@@ -207,19 +191,16 @@ tables:
     "@id": "#Object.refExtendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: refSizeExtendedness
     "@id": "#Object.refSizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: refFwhm
     "@id": "#Object.refFwhm"
     datatype: double
     description: Estimated FWHM on the reference band at source center assuming a Gaussian profile
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: shape_flag
     "@id": "#Object.shape_flag"
@@ -231,19 +212,16 @@ tables:
     "@id": "#Object.shape_xx"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
@@ -255,19 +233,16 @@ tables:
     "@id": "#Object.tract"
     datatype: long
     description: Skymap tract ID
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: x
     "@id": "#Object.x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Object.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: xy_flag
     "@id": "#Object.xy_flag"
@@ -279,25 +254,21 @@ tables:
     "@id": "#Object.y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: yErr
     "@id": "#Object.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_ap03Flux
     "@id": "#Object.g_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03FluxErr
     "@id": "#Object.g_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03Flux_flag
     "@id": "#Object.g_ap03Flux_flag"
@@ -309,13 +280,11 @@ tables:
     "@id": "#Object.g_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06FluxErr
     "@id": "#Object.g_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06Flux_flag
     "@id": "#Object.g_ap06Flux_flag"
@@ -327,13 +296,11 @@ tables:
     "@id": "#Object.g_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09FluxErr
     "@id": "#Object.g_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09Flux_flag
     "@id": "#Object.g_ap09Flux_flag"
@@ -345,13 +312,11 @@ tables:
     "@id": "#Object.g_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12FluxErr
     "@id": "#Object.g_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12Flux_flag
     "@id": "#Object.g_ap12Flux_flag"
@@ -363,13 +328,11 @@ tables:
     "@id": "#Object.g_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17FluxErr
     "@id": "#Object.g_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17Flux_flag
     "@id": "#Object.g_ap17Flux_flag"
@@ -381,13 +344,11 @@ tables:
     "@id": "#Object.g_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25FluxErr
     "@id": "#Object.g_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25Flux_flag
     "@id": "#Object.g_ap25Flux_flag"
@@ -399,13 +360,11 @@ tables:
     "@id": "#Object.g_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35FluxErr
     "@id": "#Object.g_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35Flux_flag
     "@id": "#Object.g_ap35Flux_flag"
@@ -417,13 +376,11 @@ tables:
     "@id": "#Object.g_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50FluxErr
     "@id": "#Object.g_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50Flux_flag
     "@id": "#Object.g_ap50Flux_flag"
@@ -435,13 +392,11 @@ tables:
     "@id": "#Object.g_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70FluxErr
     "@id": "#Object.g_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70Flux_flag
     "@id": "#Object.g_ap70Flux_flag"
@@ -471,61 +426,51 @@ tables:
     "@id": "#Object.g_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_bdE1
     "@id": "#Object.g_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxBErr
     "@id": "#Object.g_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxD
     "@id": "#Object.g_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxDErr
     "@id": "#Object.g_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdReB
     "@id": "#Object.g_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_blendedness_flag
     "@id": "#Object.g_blendedness_flag"
@@ -537,19 +482,16 @@ tables:
     "@id": "#Object.g_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFluxErr
     "@id": "#Object.g_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFlux_inner
     "@id": "#Object.g_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModel_flag
     "@id": "#Object.g_cModel_flag"
@@ -567,13 +509,11 @@ tables:
     "@id": "#Object.g_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFluxErr
     "@id": "#Object.g_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFlux_flag
     "@id": "#Object.g_calibFlux_flag"
@@ -639,50 +579,42 @@ tables:
     "@id": "#Object.g_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_xErr
     "@id": "#Object.g_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_centroid_y
     "@id": "#Object.g_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_yErr
     "@id": "#Object.g_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_dec
     "@id": "#Object.g_dec"
     datatype: double
     description: Position in declination, measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: g_decErr
     "@id": "#Object.g_decErr"
     datatype: float
     description: Error in declination, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: g_decl
     "@id": "#Object.g_decl"
     datatype: double
     description: Deprecated duplicate of g_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: g_extendedness
     "@id": "#Object.g_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_extendedness_flag
     "@id": "#Object.g_extendedness_flag"
@@ -694,7 +626,6 @@ tables:
     "@id": "#Object.g_sizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_sizeExtendedness_flag
     "@id": "#Object.g_sizeExtendedness_flag"
@@ -706,13 +637,11 @@ tables:
     "@id": "#Object.g_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFluxErr
     "@id": "#Object.g_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFlux_flag
     "@id": "#Object.g_free_cModelFlux_flag"
@@ -724,19 +653,16 @@ tables:
     "@id": "#Object.g_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux
     "@id": "#Object.g_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFluxErr
     "@id": "#Object.g_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux_flag
     "@id": "#Object.g_free_psfFlux_flag"
@@ -748,61 +674,51 @@ tables:
     "@id": "#Object.g_fwhm"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_gaap0p7FluxErr
     "@id": "#Object.g_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0FluxErr
     "@id": "#Object.g_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5FluxErr
     "@id": "#Object.g_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5FluxErr
     "@id": "#Object.g_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0FluxErr
     "@id": "#Object.g_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFluxErr
     "@id": "#Object.g_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapPsfFluxErr
     "@id": "#Object.g_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapPsfFlux
     "@id": "#Object.g_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFlux
     "@id": "#Object.g_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
@@ -814,7 +730,6 @@ tables:
     "@id": "#Object.g_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
@@ -826,7 +741,6 @@ tables:
     "@id": "#Object.g_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
@@ -838,7 +752,6 @@ tables:
     "@id": "#Object.g_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
@@ -850,7 +763,6 @@ tables:
     "@id": "#Object.g_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
@@ -862,7 +774,6 @@ tables:
     "@id": "#Object.g_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
@@ -892,13 +803,11 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_e2
     "@id": "#Object.g_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_flag
     "@id": "#Object.g_hsmShapeRegauss_flag"
@@ -910,7 +819,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_iDebiasedPSF_flag
     "@id": "#Object.g_iDebiasedPSF_flag"
@@ -928,7 +836,6 @@ tables:
     "@id": "#Object.g_iRound_flag"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
@@ -940,7 +847,6 @@ tables:
     "@id": "#Object.g_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on g-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: g_inputCount_flag
     "@id": "#Object.g_inputCount_flag"
@@ -958,181 +864,151 @@ tables:
     "@id": "#Object.g_ixx"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_hsm_moments_30
     "@id": "#Object.g_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_30
     "@id": "#Object.g_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_21
     "@id": "#Object.g_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_21
     "@id": "#Object.g_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_12
     "@id": "#Object.g_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_12
     "@id": "#Object.g_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_03
     "@id": "#Object.g_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_03
     "@id": "#Object.g_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_40
     "@id": "#Object.g_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_40
     "@id": "#Object.g_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_31
     "@id": "#Object.g_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_31
     "@id": "#Object.g_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_22
     "@id": "#Object.g_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_22
     "@id": "#Object.g_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_13
     "@id": "#Object.g_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_13
     "@id": "#Object.g_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_04
     "@id": "#Object.g_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_04
     "@id": "#Object.g_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_flag
     "@id": "#Object.g_hsm_moments_flag"
@@ -1150,13 +1026,11 @@ tables:
     "@id": "#Object.g_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFluxErr
     "@id": "#Object.g_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFlux_flag
     "@id": "#Object.g_kronFlux_flag"
@@ -1222,7 +1096,6 @@ tables:
     "@id": "#Object.g_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_pixelFlags_bad
     "@id": "#Object.g_pixelFlags_bad"
@@ -1342,19 +1215,16 @@ tables:
     "@id": "#Object.g_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFluxErr
     "@id": "#Object.g_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFlux_area
     "@id": "#Object.g_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_psfFlux_flag
     "@id": "#Object.g_psfFlux_flag"
@@ -1384,43 +1254,36 @@ tables:
     "@id": "#Object.g_ra"
     datatype: double
     description: Position in right ascension, measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: g_raErr
     "@id": "#Object.g_raErr"
     datatype: float
     description: Error in right ascension, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: g_ra_dec_Cov
     "@id": "#Object.g_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: g_deblend_dataCoverage
     "@id": "#Object.g_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the g-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_blendedness
     "@id": "#Object.g_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_fluxOverlap
     "@id": "#Object.g_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_fluxOverlapFraction
     "@id": "#Object.g_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_zeroFlux
     "@id": "#Object.g_deblend_zeroFlux"
@@ -1432,13 +1295,11 @@ tables:
     "@id": "#Object.i_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03FluxErr
     "@id": "#Object.i_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03Flux_flag
     "@id": "#Object.i_ap03Flux_flag"
@@ -1450,13 +1311,11 @@ tables:
     "@id": "#Object.i_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06FluxErr
     "@id": "#Object.i_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06Flux_flag
     "@id": "#Object.i_ap06Flux_flag"
@@ -1468,13 +1327,11 @@ tables:
     "@id": "#Object.i_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09FluxErr
     "@id": "#Object.i_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09Flux_flag
     "@id": "#Object.i_ap09Flux_flag"
@@ -1486,13 +1343,11 @@ tables:
     "@id": "#Object.i_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12FluxErr
     "@id": "#Object.i_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12Flux_flag
     "@id": "#Object.i_ap12Flux_flag"
@@ -1504,13 +1359,11 @@ tables:
     "@id": "#Object.i_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17FluxErr
     "@id": "#Object.i_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17Flux_flag
     "@id": "#Object.i_ap17Flux_flag"
@@ -1522,13 +1375,11 @@ tables:
     "@id": "#Object.i_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25FluxErr
     "@id": "#Object.i_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25Flux_flag
     "@id": "#Object.i_ap25Flux_flag"
@@ -1540,13 +1391,11 @@ tables:
     "@id": "#Object.i_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35FluxErr
     "@id": "#Object.i_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35Flux_flag
     "@id": "#Object.i_ap35Flux_flag"
@@ -1558,13 +1407,11 @@ tables:
     "@id": "#Object.i_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50FluxErr
     "@id": "#Object.i_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50Flux_flag
     "@id": "#Object.i_ap50Flux_flag"
@@ -1576,13 +1423,11 @@ tables:
     "@id": "#Object.i_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70FluxErr
     "@id": "#Object.i_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70Flux_flag
     "@id": "#Object.i_ap70Flux_flag"
@@ -1612,61 +1457,51 @@ tables:
     "@id": "#Object.i_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_bdE1
     "@id": "#Object.i_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxBErr
     "@id": "#Object.i_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxD
     "@id": "#Object.i_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxDErr
     "@id": "#Object.i_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdReB
     "@id": "#Object.i_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_blendedness_flag
     "@id": "#Object.i_blendedness_flag"
@@ -1678,19 +1513,16 @@ tables:
     "@id": "#Object.i_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFluxErr
     "@id": "#Object.i_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFlux_inner
     "@id": "#Object.i_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModel_flag
     "@id": "#Object.i_cModel_flag"
@@ -1708,13 +1540,11 @@ tables:
     "@id": "#Object.i_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFluxErr
     "@id": "#Object.i_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFlux_flag
     "@id": "#Object.i_calibFlux_flag"
@@ -1780,50 +1610,42 @@ tables:
     "@id": "#Object.i_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_xErr
     "@id": "#Object.i_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_centroid_y
     "@id": "#Object.i_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_yErr
     "@id": "#Object.i_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_dec
     "@id": "#Object.i_dec"
     datatype: double
     description: Position in declination, measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: i_decErr
     "@id": "#Object.i_decErr"
     datatype: float
     description: Error in declination, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: i_decl
     "@id": "#Object.i_decl"
     datatype: double
     description: Deprecated duplicate of i_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: i_extendedness
     "@id": "#Object.i_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_extendedness_flag
     "@id": "#Object.i_extendedness_flag"
@@ -1835,7 +1657,6 @@ tables:
     "@id": "#Object.i_sizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_sizeExtendedness_flag
     "@id": "#Object.i_sizeExtendedness_flag"
@@ -1847,13 +1668,11 @@ tables:
     "@id": "#Object.i_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFluxErr
     "@id": "#Object.i_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFlux_flag
     "@id": "#Object.i_free_cModelFlux_flag"
@@ -1865,19 +1684,16 @@ tables:
     "@id": "#Object.i_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux
     "@id": "#Object.i_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFluxErr
     "@id": "#Object.i_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux_flag
     "@id": "#Object.i_free_psfFlux_flag"
@@ -1889,61 +1705,51 @@ tables:
     "@id": "#Object.i_fwhm"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_gaap0p7FluxErr
     "@id": "#Object.i_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0FluxErr
     "@id": "#Object.i_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5FluxErr
     "@id": "#Object.i_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5FluxErr
     "@id": "#Object.i_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0FluxErr
     "@id": "#Object.i_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFluxErr
     "@id": "#Object.i_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapPsfFluxErr
     "@id": "#Object.i_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapPsfFlux
     "@id": "#Object.i_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFlux
     "@id": "#Object.i_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
@@ -1955,7 +1761,6 @@ tables:
     "@id": "#Object.i_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
@@ -1967,7 +1772,6 @@ tables:
     "@id": "#Object.i_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
@@ -1979,7 +1783,6 @@ tables:
     "@id": "#Object.i_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
@@ -1991,7 +1794,6 @@ tables:
     "@id": "#Object.i_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
@@ -2003,7 +1805,6 @@ tables:
     "@id": "#Object.i_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
@@ -2033,13 +1834,11 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_e2
     "@id": "#Object.i_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_flag
     "@id": "#Object.i_hsmShapeRegauss_flag"
@@ -2051,7 +1850,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_iDebiasedPSF_flag
     "@id": "#Object.i_iDebiasedPSF_flag"
@@ -2069,7 +1867,6 @@ tables:
     "@id": "#Object.i_iRound_flag"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
@@ -2081,7 +1878,6 @@ tables:
     "@id": "#Object.i_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on i-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: i_inputCount_flag
     "@id": "#Object.i_inputCount_flag"
@@ -2099,181 +1895,151 @@ tables:
     "@id": "#Object.i_ixx"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_hsm_moments_30
     "@id": "#Object.i_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_30
     "@id": "#Object.i_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_21
     "@id": "#Object.i_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_21
     "@id": "#Object.i_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_12
     "@id": "#Object.i_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_12
     "@id": "#Object.i_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_03
     "@id": "#Object.i_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_03
     "@id": "#Object.i_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_40
     "@id": "#Object.i_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_40
     "@id": "#Object.i_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_31
     "@id": "#Object.i_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_31
     "@id": "#Object.i_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_22
     "@id": "#Object.i_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_22
     "@id": "#Object.i_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_13
     "@id": "#Object.i_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_13
     "@id": "#Object.i_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_04
     "@id": "#Object.i_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_04
     "@id": "#Object.i_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_flag
     "@id": "#Object.i_hsm_moments_flag"
@@ -2291,13 +2057,11 @@ tables:
     "@id": "#Object.i_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFluxErr
     "@id": "#Object.i_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFlux_flag
     "@id": "#Object.i_kronFlux_flag"
@@ -2363,7 +2127,6 @@ tables:
     "@id": "#Object.i_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_pixelFlags_bad
     "@id": "#Object.i_pixelFlags_bad"
@@ -2483,19 +2246,16 @@ tables:
     "@id": "#Object.i_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFluxErr
     "@id": "#Object.i_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFlux_area
     "@id": "#Object.i_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_psfFlux_flag
     "@id": "#Object.i_psfFlux_flag"
@@ -2525,43 +2285,36 @@ tables:
     "@id": "#Object.i_ra"
     datatype: double
     description: Position in right ascension, measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: i_raErr
     "@id": "#Object.i_raErr"
     datatype: float
     description: Error in right ascension, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: i_ra_dec_Cov
     "@id": "#Object.i_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: i_deblend_dataCoverage
     "@id": "#Object.i_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the i-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_blendedness
     "@id": "#Object.i_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_fluxOverlap
     "@id": "#Object.i_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_fluxOverlapFraction
     "@id": "#Object.i_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_zeroFlux
     "@id": "#Object.i_deblend_zeroFlux"
@@ -2573,13 +2326,11 @@ tables:
     "@id": "#Object.r_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03FluxErr
     "@id": "#Object.r_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03Flux_flag
     "@id": "#Object.r_ap03Flux_flag"
@@ -2591,13 +2342,11 @@ tables:
     "@id": "#Object.r_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06FluxErr
     "@id": "#Object.r_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06Flux_flag
     "@id": "#Object.r_ap06Flux_flag"
@@ -2609,13 +2358,11 @@ tables:
     "@id": "#Object.r_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09FluxErr
     "@id": "#Object.r_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09Flux_flag
     "@id": "#Object.r_ap09Flux_flag"
@@ -2627,13 +2374,11 @@ tables:
     "@id": "#Object.r_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12FluxErr
     "@id": "#Object.r_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12Flux_flag
     "@id": "#Object.r_ap12Flux_flag"
@@ -2645,13 +2390,11 @@ tables:
     "@id": "#Object.r_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17FluxErr
     "@id": "#Object.r_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17Flux_flag
     "@id": "#Object.r_ap17Flux_flag"
@@ -2663,13 +2406,11 @@ tables:
     "@id": "#Object.r_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25FluxErr
     "@id": "#Object.r_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25Flux_flag
     "@id": "#Object.r_ap25Flux_flag"
@@ -2681,13 +2422,11 @@ tables:
     "@id": "#Object.r_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35FluxErr
     "@id": "#Object.r_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35Flux_flag
     "@id": "#Object.r_ap35Flux_flag"
@@ -2699,13 +2438,11 @@ tables:
     "@id": "#Object.r_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50FluxErr
     "@id": "#Object.r_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50Flux_flag
     "@id": "#Object.r_ap50Flux_flag"
@@ -2717,13 +2454,11 @@ tables:
     "@id": "#Object.r_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70FluxErr
     "@id": "#Object.r_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70Flux_flag
     "@id": "#Object.r_ap70Flux_flag"
@@ -2753,61 +2488,51 @@ tables:
     "@id": "#Object.r_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_bdE1
     "@id": "#Object.r_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxBErr
     "@id": "#Object.r_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxD
     "@id": "#Object.r_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxDErr
     "@id": "#Object.r_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdReB
     "@id": "#Object.r_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_blendedness_flag
     "@id": "#Object.r_blendedness_flag"
@@ -2819,19 +2544,16 @@ tables:
     "@id": "#Object.r_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFluxErr
     "@id": "#Object.r_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFlux_inner
     "@id": "#Object.r_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModel_flag
     "@id": "#Object.r_cModel_flag"
@@ -2849,13 +2571,11 @@ tables:
     "@id": "#Object.r_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFluxErr
     "@id": "#Object.r_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFlux_flag
     "@id": "#Object.r_calibFlux_flag"
@@ -2921,50 +2641,42 @@ tables:
     "@id": "#Object.r_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_xErr
     "@id": "#Object.r_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_centroid_y
     "@id": "#Object.r_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_yErr
     "@id": "#Object.r_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_dec
     "@id": "#Object.r_dec"
     datatype: double
     description: Position in declination, measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: r_decErr
     "@id": "#Object.r_decErr"
     datatype: float
     description: Error in declination, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: r_decl
     "@id": "#Object.r_decl"
     datatype: double
     description: Deprecated duplicate of r_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: r_extendedness
     "@id": "#Object.r_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_extendedness_flag
     "@id": "#Object.r_extendedness_flag"
@@ -2976,7 +2688,6 @@ tables:
     "@id": "#Object.r_sizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_sizeExtendedness_flag
     "@id": "#Object.r_sizeExtendedness_flag"
@@ -2988,13 +2699,11 @@ tables:
     "@id": "#Object.r_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFluxErr
     "@id": "#Object.r_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFlux_flag
     "@id": "#Object.r_free_cModelFlux_flag"
@@ -3006,19 +2715,16 @@ tables:
     "@id": "#Object.r_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux
     "@id": "#Object.r_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFluxErr
     "@id": "#Object.r_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux_flag
     "@id": "#Object.r_free_psfFlux_flag"
@@ -3030,61 +2736,51 @@ tables:
     "@id": "#Object.r_fwhm"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_gaap0p7FluxErr
     "@id": "#Object.r_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0FluxErr
     "@id": "#Object.r_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5FluxErr
     "@id": "#Object.r_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5FluxErr
     "@id": "#Object.r_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0FluxErr
     "@id": "#Object.r_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFluxErr
     "@id": "#Object.r_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapPsfFluxErr
     "@id": "#Object.r_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapPsfFlux
     "@id": "#Object.r_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFlux
     "@id": "#Object.r_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
@@ -3096,7 +2792,6 @@ tables:
     "@id": "#Object.r_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
@@ -3108,7 +2803,6 @@ tables:
     "@id": "#Object.r_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
@@ -3120,7 +2814,6 @@ tables:
     "@id": "#Object.r_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
@@ -3132,7 +2825,6 @@ tables:
     "@id": "#Object.r_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
@@ -3144,7 +2836,6 @@ tables:
     "@id": "#Object.r_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
@@ -3174,13 +2865,11 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_e2
     "@id": "#Object.r_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_flag
     "@id": "#Object.r_hsmShapeRegauss_flag"
@@ -3192,7 +2881,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_iDebiasedPSF_flag
     "@id": "#Object.r_iDebiasedPSF_flag"
@@ -3210,7 +2898,6 @@ tables:
     "@id": "#Object.r_iRound_flag"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
@@ -3222,7 +2909,6 @@ tables:
     "@id": "#Object.r_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on r-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: r_inputCount_flag
     "@id": "#Object.r_inputCount_flag"
@@ -3240,181 +2926,151 @@ tables:
     "@id": "#Object.r_ixx"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_hsm_moments_30
     "@id": "#Object.r_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_30
     "@id": "#Object.r_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_21
     "@id": "#Object.r_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_21
     "@id": "#Object.r_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_12
     "@id": "#Object.r_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_12
     "@id": "#Object.r_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_03
     "@id": "#Object.r_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_03
     "@id": "#Object.r_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_40
     "@id": "#Object.r_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_40
     "@id": "#Object.r_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_31
     "@id": "#Object.r_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_31
     "@id": "#Object.r_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_22
     "@id": "#Object.r_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_22
     "@id": "#Object.r_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_13
     "@id": "#Object.r_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_13
     "@id": "#Object.r_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_04
     "@id": "#Object.r_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_04
     "@id": "#Object.r_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_flag
     "@id": "#Object.r_hsm_moments_flag"
@@ -3432,13 +3088,11 @@ tables:
     "@id": "#Object.r_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFluxErr
     "@id": "#Object.r_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFlux_flag
     "@id": "#Object.r_kronFlux_flag"
@@ -3504,7 +3158,6 @@ tables:
     "@id": "#Object.r_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_pixelFlags_bad
     "@id": "#Object.r_pixelFlags_bad"
@@ -3624,19 +3277,16 @@ tables:
     "@id": "#Object.r_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFluxErr
     "@id": "#Object.r_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFlux_area
     "@id": "#Object.r_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_psfFlux_flag
     "@id": "#Object.r_psfFlux_flag"
@@ -3666,43 +3316,36 @@ tables:
     "@id": "#Object.r_ra"
     datatype: double
     description: Position in right ascension, measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: r_raErr
     "@id": "#Object.r_raErr"
     datatype: float
     description: Error in right ascension, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: r_ra_dec_Cov
     "@id": "#Object.r_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: r_deblend_dataCoverage
     "@id": "#Object.r_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the r-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_blendedness
     "@id": "#Object.r_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_fluxOverlap
     "@id": "#Object.r_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_fluxOverlapFraction
     "@id": "#Object.r_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_zeroFlux
     "@id": "#Object.r_deblend_zeroFlux"
@@ -3714,13 +3357,11 @@ tables:
     "@id": "#Object.y_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03FluxErr
     "@id": "#Object.y_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03Flux_flag
     "@id": "#Object.y_ap03Flux_flag"
@@ -3732,13 +3373,11 @@ tables:
     "@id": "#Object.y_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06FluxErr
     "@id": "#Object.y_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06Flux_flag
     "@id": "#Object.y_ap06Flux_flag"
@@ -3750,13 +3389,11 @@ tables:
     "@id": "#Object.y_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09FluxErr
     "@id": "#Object.y_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09Flux_flag
     "@id": "#Object.y_ap09Flux_flag"
@@ -3768,13 +3405,11 @@ tables:
     "@id": "#Object.y_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12FluxErr
     "@id": "#Object.y_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12Flux_flag
     "@id": "#Object.y_ap12Flux_flag"
@@ -3786,13 +3421,11 @@ tables:
     "@id": "#Object.y_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17FluxErr
     "@id": "#Object.y_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17Flux_flag
     "@id": "#Object.y_ap17Flux_flag"
@@ -3804,13 +3437,11 @@ tables:
     "@id": "#Object.y_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25FluxErr
     "@id": "#Object.y_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25Flux_flag
     "@id": "#Object.y_ap25Flux_flag"
@@ -3822,13 +3453,11 @@ tables:
     "@id": "#Object.y_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35FluxErr
     "@id": "#Object.y_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35Flux_flag
     "@id": "#Object.y_ap35Flux_flag"
@@ -3840,13 +3469,11 @@ tables:
     "@id": "#Object.y_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50FluxErr
     "@id": "#Object.y_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50Flux_flag
     "@id": "#Object.y_ap50Flux_flag"
@@ -3858,13 +3485,11 @@ tables:
     "@id": "#Object.y_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70FluxErr
     "@id": "#Object.y_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70Flux_flag
     "@id": "#Object.y_ap70Flux_flag"
@@ -3894,61 +3519,51 @@ tables:
     "@id": "#Object.y_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_bdE1
     "@id": "#Object.y_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxBErr
     "@id": "#Object.y_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxD
     "@id": "#Object.y_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxDErr
     "@id": "#Object.y_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdReB
     "@id": "#Object.y_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_blendedness_flag
     "@id": "#Object.y_blendedness_flag"
@@ -3960,19 +3575,16 @@ tables:
     "@id": "#Object.y_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFluxErr
     "@id": "#Object.y_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFlux_inner
     "@id": "#Object.y_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModel_flag
     "@id": "#Object.y_cModel_flag"
@@ -3990,13 +3602,11 @@ tables:
     "@id": "#Object.y_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFluxErr
     "@id": "#Object.y_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFlux_flag
     "@id": "#Object.y_calibFlux_flag"
@@ -4062,50 +3672,42 @@ tables:
     "@id": "#Object.y_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_xErr
     "@id": "#Object.y_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_centroid_y
     "@id": "#Object.y_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_yErr
     "@id": "#Object.y_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_dec
     "@id": "#Object.y_dec"
     datatype: double
     description: Position in declination, measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: y_decErr
     "@id": "#Object.y_decErr"
     datatype: float
     description: Error in declination, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: y_decl
     "@id": "#Object.y_decl"
     datatype: double
     description: Deprecated duplicate of y_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: y_extendedness
     "@id": "#Object.y_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_extendedness_flag
     "@id": "#Object.y_extendedness_flag"
@@ -4117,7 +3719,6 @@ tables:
     "@id": "#Object.y_sizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_sizeExtendedness_flag
     "@id": "#Object.y_sizeExtendedness_flag"
@@ -4129,13 +3730,11 @@ tables:
     "@id": "#Object.y_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFluxErr
     "@id": "#Object.y_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFlux_flag
     "@id": "#Object.y_free_cModelFlux_flag"
@@ -4147,19 +3746,16 @@ tables:
     "@id": "#Object.y_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux
     "@id": "#Object.y_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFluxErr
     "@id": "#Object.y_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux_flag
     "@id": "#Object.y_free_psfFlux_flag"
@@ -4171,61 +3767,51 @@ tables:
     "@id": "#Object.y_fwhm"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_gaap0p7FluxErr
     "@id": "#Object.y_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0FluxErr
     "@id": "#Object.y_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5FluxErr
     "@id": "#Object.y_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5FluxErr
     "@id": "#Object.y_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0FluxErr
     "@id": "#Object.y_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFluxErr
     "@id": "#Object.y_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapPsfFluxErr
     "@id": "#Object.y_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapPsfFlux
     "@id": "#Object.y_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFlux
     "@id": "#Object.y_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
@@ -4237,7 +3823,6 @@ tables:
     "@id": "#Object.y_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
@@ -4249,7 +3834,6 @@ tables:
     "@id": "#Object.y_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
@@ -4261,7 +3845,6 @@ tables:
     "@id": "#Object.y_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
@@ -4273,7 +3856,6 @@ tables:
     "@id": "#Object.y_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
@@ -4285,7 +3867,6 @@ tables:
     "@id": "#Object.y_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
@@ -4315,13 +3896,11 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_e2
     "@id": "#Object.y_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_flag
     "@id": "#Object.y_hsmShapeRegauss_flag"
@@ -4333,7 +3912,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_iDebiasedPSF_flag
     "@id": "#Object.y_iDebiasedPSF_flag"
@@ -4351,7 +3929,6 @@ tables:
     "@id": "#Object.y_iRound_flag"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
@@ -4363,7 +3940,6 @@ tables:
     "@id": "#Object.y_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on y-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: y_inputCount_flag
     "@id": "#Object.y_inputCount_flag"
@@ -4381,181 +3957,151 @@ tables:
     "@id": "#Object.y_ixx"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_hsm_moments_30
     "@id": "#Object.y_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_30
     "@id": "#Object.y_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_21
     "@id": "#Object.y_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_21
     "@id": "#Object.y_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_12
     "@id": "#Object.y_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_12
     "@id": "#Object.y_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_03
     "@id": "#Object.y_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_03
     "@id": "#Object.y_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_40
     "@id": "#Object.y_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_40
     "@id": "#Object.y_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_31
     "@id": "#Object.y_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_31
     "@id": "#Object.y_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_22
     "@id": "#Object.y_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_22
     "@id": "#Object.y_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_13
     "@id": "#Object.y_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_13
     "@id": "#Object.y_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_04
     "@id": "#Object.y_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_04
     "@id": "#Object.y_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_flag
     "@id": "#Object.y_hsm_moments_flag"
@@ -4573,13 +4119,11 @@ tables:
     "@id": "#Object.y_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFluxErr
     "@id": "#Object.y_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFlux_flag
     "@id": "#Object.y_kronFlux_flag"
@@ -4645,7 +4189,6 @@ tables:
     "@id": "#Object.y_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_pixelFlags_bad
     "@id": "#Object.y_pixelFlags_bad"
@@ -4765,19 +4308,16 @@ tables:
     "@id": "#Object.y_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFluxErr
     "@id": "#Object.y_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFlux_area
     "@id": "#Object.y_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_psfFlux_flag
     "@id": "#Object.y_psfFlux_flag"
@@ -4807,43 +4347,36 @@ tables:
     "@id": "#Object.y_ra"
     datatype: double
     description: Position in right ascension, measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: y_raErr
     "@id": "#Object.y_raErr"
     datatype: float
     description: Error in right ascension, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: y_ra_dec_Cov
     "@id": "#Object.y_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: y_deblend_dataCoverage
     "@id": "#Object.y_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the y-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_blendedness
     "@id": "#Object.y_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_fluxOverlap
     "@id": "#Object.y_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_fluxOverlapFraction
     "@id": "#Object.y_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_zeroFlux
     "@id": "#Object.y_deblend_zeroFlux"
@@ -4855,13 +4388,11 @@ tables:
     "@id": "#Object.z_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03FluxErr
     "@id": "#Object.z_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03Flux_flag
     "@id": "#Object.z_ap03Flux_flag"
@@ -4873,13 +4404,11 @@ tables:
     "@id": "#Object.z_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06FluxErr
     "@id": "#Object.z_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06Flux_flag
     "@id": "#Object.z_ap06Flux_flag"
@@ -4891,13 +4420,11 @@ tables:
     "@id": "#Object.z_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09FluxErr
     "@id": "#Object.z_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09Flux_flag
     "@id": "#Object.z_ap09Flux_flag"
@@ -4909,13 +4436,11 @@ tables:
     "@id": "#Object.z_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12FluxErr
     "@id": "#Object.z_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12Flux_flag
     "@id": "#Object.z_ap12Flux_flag"
@@ -4927,13 +4452,11 @@ tables:
     "@id": "#Object.z_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17FluxErr
     "@id": "#Object.z_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17Flux_flag
     "@id": "#Object.z_ap17Flux_flag"
@@ -4945,13 +4468,11 @@ tables:
     "@id": "#Object.z_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25FluxErr
     "@id": "#Object.z_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25Flux_flag
     "@id": "#Object.z_ap25Flux_flag"
@@ -4963,13 +4484,11 @@ tables:
     "@id": "#Object.z_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35FluxErr
     "@id": "#Object.z_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35Flux_flag
     "@id": "#Object.z_ap35Flux_flag"
@@ -4981,13 +4500,11 @@ tables:
     "@id": "#Object.z_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50FluxErr
     "@id": "#Object.z_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50Flux_flag
     "@id": "#Object.z_ap50Flux_flag"
@@ -4999,13 +4516,11 @@ tables:
     "@id": "#Object.z_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70FluxErr
     "@id": "#Object.z_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70Flux_flag
     "@id": "#Object.z_ap70Flux_flag"
@@ -5035,61 +4550,51 @@ tables:
     "@id": "#Object.z_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_bdE1
     "@id": "#Object.z_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxBErr
     "@id": "#Object.z_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxD
     "@id": "#Object.z_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxDErr
     "@id": "#Object.z_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdReB
     "@id": "#Object.z_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_blendedness_flag
     "@id": "#Object.z_blendedness_flag"
@@ -5101,19 +4606,16 @@ tables:
     "@id": "#Object.z_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFluxErr
     "@id": "#Object.z_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFlux_inner
     "@id": "#Object.z_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModel_flag
     "@id": "#Object.z_cModel_flag"
@@ -5131,13 +4633,11 @@ tables:
     "@id": "#Object.z_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFluxErr
     "@id": "#Object.z_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFlux_flag
     "@id": "#Object.z_calibFlux_flag"
@@ -5203,50 +4703,42 @@ tables:
     "@id": "#Object.z_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_xErr
     "@id": "#Object.z_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_centroid_y
     "@id": "#Object.z_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_yErr
     "@id": "#Object.z_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_dec
     "@id": "#Object.z_dec"
     datatype: double
     description: Position in declination, measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: z_decErr
     "@id": "#Object.z_decErr"
     datatype: float
     description: Error in declination, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: z_decl
     "@id": "#Object.z_decl"
     datatype: double
     description: Deprecated duplicate of z_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: z_extendedness
     "@id": "#Object.z_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_extendedness_flag
     "@id": "#Object.z_extendedness_flag"
@@ -5258,7 +4750,6 @@ tables:
     "@id": "#Object.z_sizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_sizeExtendedness_flag
     "@id": "#Object.z_sizeExtendedness_flag"
@@ -5270,13 +4761,11 @@ tables:
     "@id": "#Object.z_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFluxErr
     "@id": "#Object.z_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFlux_flag
     "@id": "#Object.z_free_cModelFlux_flag"
@@ -5288,19 +4777,16 @@ tables:
     "@id": "#Object.z_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux
     "@id": "#Object.z_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFluxErr
     "@id": "#Object.z_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux_flag
     "@id": "#Object.z_free_psfFlux_flag"
@@ -5312,61 +4798,51 @@ tables:
     "@id": "#Object.z_fwhm"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_gaap0p7FluxErr
     "@id": "#Object.z_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0FluxErr
     "@id": "#Object.z_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5FluxErr
     "@id": "#Object.z_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5FluxErr
     "@id": "#Object.z_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0FluxErr
     "@id": "#Object.z_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFluxErr
     "@id": "#Object.z_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapPsfFluxErr
     "@id": "#Object.z_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapPsfFlux
     "@id": "#Object.z_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFlux
     "@id": "#Object.z_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
@@ -5378,7 +4854,6 @@ tables:
     "@id": "#Object.z_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
@@ -5390,7 +4865,6 @@ tables:
     "@id": "#Object.z_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
@@ -5402,7 +4876,6 @@ tables:
     "@id": "#Object.z_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
@@ -5414,7 +4887,6 @@ tables:
     "@id": "#Object.z_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
@@ -5426,7 +4898,6 @@ tables:
     "@id": "#Object.z_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
@@ -5456,13 +4927,11 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_e2
     "@id": "#Object.z_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_flag
     "@id": "#Object.z_hsmShapeRegauss_flag"
@@ -5474,7 +4943,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_iDebiasedPSF_flag
     "@id": "#Object.z_iDebiasedPSF_flag"
@@ -5492,7 +4960,6 @@ tables:
     "@id": "#Object.z_iRound_flag"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
@@ -5504,7 +4971,6 @@ tables:
     "@id": "#Object.z_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on z-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: z_inputCount_flag
     "@id": "#Object.z_inputCount_flag"
@@ -5522,181 +4988,151 @@ tables:
     "@id": "#Object.z_ixx"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_hsm_moments_30
     "@id": "#Object.z_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_30
     "@id": "#Object.z_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_21
     "@id": "#Object.z_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_21
     "@id": "#Object.z_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_12
     "@id": "#Object.z_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_12
     "@id": "#Object.z_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_03
     "@id": "#Object.z_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_03
     "@id": "#Object.z_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_40
     "@id": "#Object.z_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_40
     "@id": "#Object.z_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_31
     "@id": "#Object.z_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_31
     "@id": "#Object.z_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_22
     "@id": "#Object.z_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_22
     "@id": "#Object.z_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_13
     "@id": "#Object.z_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_13
     "@id": "#Object.z_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_04
     "@id": "#Object.z_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_04
     "@id": "#Object.z_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_flag
     "@id": "#Object.z_hsm_moments_flag"
@@ -5714,13 +5150,11 @@ tables:
     "@id": "#Object.z_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFluxErr
     "@id": "#Object.z_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFlux_flag
     "@id": "#Object.z_kronFlux_flag"
@@ -5786,7 +5220,6 @@ tables:
     "@id": "#Object.z_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_pixelFlags_bad
     "@id": "#Object.z_pixelFlags_bad"
@@ -5906,19 +5339,16 @@ tables:
     "@id": "#Object.z_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFluxErr
     "@id": "#Object.z_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFlux_area
     "@id": "#Object.z_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_psfFlux_flag
     "@id": "#Object.z_psfFlux_flag"
@@ -5948,43 +5378,36 @@ tables:
     "@id": "#Object.z_ra"
     datatype: double
     description: Position in right ascension, measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: z_raErr
     "@id": "#Object.z_raErr"
     datatype: float
     description: Error in right ascension, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: z_ra_dec_Cov
     "@id": "#Object.z_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: z_deblend_dataCoverage
     "@id": "#Object.z_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the z-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_blendedness
     "@id": "#Object.z_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_fluxOverlap
     "@id": "#Object.z_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_fluxOverlapFraction
     "@id": "#Object.z_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_zeroFlux
     "@id": "#Object.z_deblend_zeroFlux"
@@ -6004,115 +5427,96 @@ tables:
     datatype: long
     nullable: false
     description: Unique id. Unique Source ID. Primary Key.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: coord_ra
     "@id": "#Source.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: coord_dec
     "@id": "#Source.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ccdVisitId
     "@id": "#Source.ccdVisitId"
     datatype: long
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: parentSourceId
     "@id": "#Source.parentSourceId"
     datatype: long
     description: Unique ID of parent source
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: x
     "@id": "#Source.x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y
     "@id": "#Source.y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Source.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: yErr
     "@id": "#Source.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: ra
     "@id": "#Source.ra"
     datatype: double
     description: Position in right ascension.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     "@id": "#Source.dec"
     datatype: double
     description: Position in declination.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: decl
     "@id": "#Source.decl"
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: raErr
     "@id": "#Source.raErr"
     datatype: float
     description: Error in right ascension.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: decErr
     "@id": "#Source.decErr"
     datatype: float
     description: Error in declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: ra_dec_Cov
     "@id": "#Source.ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
   - name: calibFlux
     "@id": "#Source.calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: calibFluxErr
     "@id": "#Source.calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux
     "@id": "#Source.ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03FluxErr
     "@id": "#Source.ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux_flag
     "@id": "#Source.ap03Flux_flag"
@@ -6124,13 +5528,11 @@ tables:
     "@id": "#Source.ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06FluxErr
     "@id": "#Source.ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06Flux_flag
     "@id": "#Source.ap06Flux_flag"
@@ -6142,13 +5544,11 @@ tables:
     "@id": "#Source.ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09FluxErr
     "@id": "#Source.ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09Flux_flag
     "@id": "#Source.ap09Flux_flag"
@@ -6160,13 +5560,11 @@ tables:
     "@id": "#Source.ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12FluxErr
     "@id": "#Source.ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12Flux_flag
     "@id": "#Source.ap12Flux_flag"
@@ -6178,13 +5576,11 @@ tables:
     "@id": "#Source.ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17FluxErr
     "@id": "#Source.ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17Flux_flag
     "@id": "#Source.ap17Flux_flag"
@@ -6196,13 +5592,11 @@ tables:
     "@id": "#Source.ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25FluxErr
     "@id": "#Source.ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25Flux_flag
     "@id": "#Source.ap25Flux_flag"
@@ -6214,13 +5608,11 @@ tables:
     "@id": "#Source.ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35FluxErr
     "@id": "#Source.ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35Flux_flag
     "@id": "#Source.ap35Flux_flag"
@@ -6232,13 +5624,11 @@ tables:
     "@id": "#Source.ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50FluxErr
     "@id": "#Source.ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50Flux_flag
     "@id": "#Source.ap50Flux_flag"
@@ -6250,13 +5640,11 @@ tables:
     "@id": "#Source.ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70FluxErr
     "@id": "#Source.ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70Flux_flag
     "@id": "#Source.ap70Flux_flag"
@@ -6268,109 +5656,91 @@ tables:
     "@id": "#Source.sky"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: skyErr
     "@id": "#Source.skyErr"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFlux
     "@id": "#Source.psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#Source.psfFluxErr"
     datatype: double
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ixx
     "@id": "#Source.ixx"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixxDebiasedPSF
     "@id": "#Source.ixxDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: iyyDebiasedPSF
     "@id": "#Source.iyyDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: ixyDebiasedPSF
     "@id": "#Source.ixyDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double
     description: Flux from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: gaussianFluxErr
     "@id": "#Source.gaussianFluxErr"
     datatype: double
     description: Flux uncertainty from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: sizeExtendedness
     "@id": "#Source.sizeExtendedness"
     datatype: double
     description: Moments-based measure of a source to be a galaxy.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib
     "@id": "#Source.localPhotoCalib"
     datatype: double
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib_flag
     "@id": "#Source.localPhotoCalib_flag"
@@ -6382,7 +5752,6 @@ tables:
     "@id": "#Source.localPhotoCalibErr"
     datatype: double
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_flag
     "@id": "#Source.localWcs_flag"
@@ -6394,31 +5763,26 @@ tables:
     "@id": "#Source.localWcs_CDMatrix_2_1"
     datatype: double
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_1
     "@id": "#Source.localWcs_CDMatrix_1_1"
     datatype: double
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_2
     "@id": "#Source.localWcs_CDMatrix_1_2"
     datatype: double
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_2_2
     "@id": "#Source.localWcs_CDMatrix_2_2"
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_abs
     "@id": "#Source.blendedness_abs"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_flag
     "@id": "#Source.blendedness_flag"
@@ -6460,13 +5824,11 @@ tables:
     "@id": "#Source.apFlux_12_0_instFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_12_0_instFluxErr
     "@id": "#Source.apFlux_12_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_flag
     "@id": "#Source.apFlux_17_0_flag"
@@ -6478,13 +5840,11 @@ tables:
     "@id": "#Source.apFlux_17_0_instFlux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_instFluxErr
     "@id": "#Source.apFlux_17_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_35_0_flag
     "@id": "#Source.apFlux_35_0_flag"
@@ -6496,13 +5856,11 @@ tables:
     "@id": "#Source.apFlux_35_0_instFlux"
     datatype: double
     description: Flux within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_35_0_instFluxErr
     "@id": "#Source.apFlux_35_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_50_0_flag
     "@id": "#Source.apFlux_50_0_flag"
@@ -6514,13 +5872,11 @@ tables:
     "@id": "#Source.apFlux_50_0_instFlux"
     datatype: double
     description: Flux within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_50_0_instFluxErr
     "@id": "#Source.apFlux_50_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: extendedness_flag
     "@id": "#Source.extendedness_flag"
@@ -6538,7 +5894,6 @@ tables:
     "@id": "#Source.footprintArea_value"
     datatype: int
     description: Number of pixels in the sources detection footprint.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: jacobian_flag
     "@id": "#Source.jacobian_flag"
@@ -6550,19 +5905,16 @@ tables:
     "@id": "#Source.jacobian_value"
     datatype: double
     description: Jacobian correction
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localBackground_instFlux
     "@id": "#Source.localBackground_instFlux"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_instFluxErr
     "@id": "#Source.localBackground_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_flag
     "@id": "#Source.localBackground_flag"
@@ -6664,19 +6016,16 @@ tables:
     "@id": "#Source.psfFlux_apCorr"
     datatype: double
     description: Aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_apCorrErr
     "@id": "#Source.psfFlux_apCorrErr"
     datatype: double
     description: Standard deviation of aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_area
     "@id": "#Source.psfFlux_area"
     datatype: float
     description: Effective area of PSF
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: psfFlux_flag
     "@id": "#Source.psfFlux_flag"
@@ -6766,7 +6115,6 @@ tables:
     "@id": "#Source.variance_value"
     datatype: double
     description: Variance at object position
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: calib_astrometry_used
     "@id": "#Source.calib_astrometry_used"
@@ -6832,7 +6180,6 @@ tables:
     "@id": "#Source.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_parentTooBig
     "@id": "#Source.deblend_parentTooBig"
@@ -6977,7 +6324,6 @@ tables:
     "@id": "#Source.detector"
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: physical_filter
     "@id": "#Source.physical_filter"
@@ -6990,7 +6336,6 @@ tables:
     "@id": "#Source.visit"
     datatype: long
     description: ID of visit, the identifier for an observation within a sequence of observations.
-    mysql:datatype: BIGINT
     fits:tunit:
 - name: Visit
   '@id': '#Visit'
@@ -7023,37 +6368,31 @@ tables:
     '@id': '#Visit.ra'
     datatype: double
     description: RA of focal plane center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     '@id': '#Visit.dec'
     datatype: double
     description: Declination of focal plane center
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: decl
     '@id': '#Visit.decl'
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: skyRotation
     '@id': '#Visit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: azimuth
     '@id': '#Visit.azimuth'
     datatype: double
     description: Azimuth of focal plane center at the middle of the visit.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: altitude
     '@id': '#Visit.altitude'
     datatype: double
     description: Altitude of focal plane center at the middle of the visit.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: zenithDistance
     '@id': '#Visit.zenithDistance'
@@ -7071,7 +6410,6 @@ tables:
     '@id': '#Visit.expTime'
     datatype: double
     description: Spatially-averaged duration of visit, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: midpoint
     '@id': '#Visit.midpoint'
@@ -7086,7 +6424,6 @@ tables:
     datatype: double
     description: Midpoint time of the visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: obsStart
     '@id': '#Visit.obsStart'
@@ -7100,7 +6437,6 @@ tables:
     datatype: double
     description: Start of the visit, expressed as Modified
       Julian Date, International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
 - name: CcdVisit
   '@id': '#CcdVisit'
   description: Defines a single detector of a visit
@@ -7109,7 +6445,6 @@ tables:
     '@id': '#CcdVisit.ccdVisitId'
     datatype: long
     description: Primary key (unique identifier).
-    mysql:datatype: BIGINT
   - name: visitId
     '@id': '#CcdVisit.visitId'
     datatype: long
@@ -7136,55 +6471,46 @@ tables:
     '@id': '#CcdVisit.ra'
     datatype: double
     description: RA of Ccd center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     '@id': '#CcdVisit.dec'
     datatype: double
     description: Declination of Ccd center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: decl
     '@id': '#CcdVisit.decl'
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: zenithDistance
     '@id': '#CcdVisit.zenithDistance'
     datatype: float
     description: Zenith distance at observation mid-point.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: zeroPoint
     '@id': '#CcdVisit.zeroPoint'
     datatype: float
     description: Zero-point for the Ccd, estimated at Ccd center.
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: psfSigma
     '@id': '#CcdVisit.psfSigma'
     datatype: float
     description: PSF model second-moments determinant radius (center of chip)
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: skyBg
     '@id': '#CcdVisit.skyBg'
     datatype: float
     description: Average sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: skyNoise
     '@id': '#CcdVisit.skyNoise'
     datatype: float
     description: RMS noise of the sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: detector
     '@id': '#CcdVisit.detector'
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
   - name: seeing
     '@id': '#CcdVisit.seeing'
     datatype: double
@@ -7195,7 +6521,6 @@ tables:
     '@id': '#CcdVisit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: midpoint
     '@id': '#CcdVisit.midpoint'
@@ -7208,13 +6533,11 @@ tables:
     datatype: double
     description: Midpoint of this visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: expTime
     '@id': '#CcdVisit.expTime'
     datatype: double
     description: Spatially-averaged duration of visit, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
@@ -7227,12 +6550,10 @@ tables:
     datatype: double
     description: Start of the visit, expressed as Modified
       Julian Date, International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
   - name: darkTime
     '@id': '#CcdVisit.darkTime'
     datatype: double
     description: Average dark current accumulation time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: xSize
     '@id': '#CcdVisit.xSize'
@@ -7250,49 +6571,41 @@ tables:
     '@id': '#CcdVisit.llcra'
     datatype: double
     description: RA of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: llcdec
     '@id': '#CcdVisit.llcdec'
     datatype: double
     description: Declination of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcra
     '@id': '#CcdVisit.ulcra'
     datatype: double
     description: RA of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcdec
     '@id': '#CcdVisit.ulcdec'
     datatype: double
     description: Declination of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcra
     '@id': '#CcdVisit.urcra'
     datatype: double
     description: RA of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcdec
     '@id': '#CcdVisit.urcdec'
     datatype: double
     description: Declination of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcra
     '@id': '#CcdVisit.lrcra'
     datatype: double
     description: RA of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcdec
     '@id': '#CcdVisit.lrcdec'
     datatype: double
     description: Declination of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: astromOffsetMean
     '@id': '#CcdVisit.astromOffsetMean'

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -17,54 +17,46 @@ tables:
     "@id": "#Object.objectId"
     datatype: long
     description: Unique id. Unique ObjectID
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: coord_dec
     "@id": "#Object.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: coord_decErr
     "@id": "#Object.coord_decErr"
     datatype: float
     description: Error in fiducial ICRS Declination of centroid
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec;meta.main
   - name: coord_ra
     "@id": "#Object.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: coord_raErr
     "@id": "#Object.coord_raErr"
     datatype: float
     description: Error in fiducial ICRS Right Ascension of centroid
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra;meta.main
   - name: coord_ra_dec_Cov
     "@id": "#Object.coord_ra_dec_Cov"
     datatype: float
     description: Covariance between fiducial ICRS Right Ascension and Declination of centroid
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec;meta.main
   - name: deblend_nChild
     "@id": "#Object.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_nPeaks
     "@id": "#Object.deblend_nPeaks"
     datatype: int
     description: Number of peaks this parent footprint has (even if the deblender failed or skipped this blend)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_failed
     "@id": "#Object.deblend_failed"
@@ -112,25 +104,21 @@ tables:
     "@id": "#Object.deblend_iterations"
     datatype: int
     description: Number of iterations during deblending
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_peak_center_x
     "@id": "#Object.deblend_peak_center_x"
     datatype: int
     description: x-coordinate of the peak after source detection
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: deblend_peak_center_y
     "@id": "#Object.deblend_peak_center_y"
     datatype: int
     description: y-coordinate of the peak after source detection
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: deblend_logL
     "@id": "#Object.deblend_logL"
     datatype: float
     description: Log likelihood of the entire blend in scarlet_lite.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: detect_fromBlend
     "@id": "#Object.detect_fromBlend"
@@ -178,13 +166,11 @@ tables:
     "@id": "#Object.ebv"
     datatype: double
     description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
-    mysql:datatype: DOUBLE
     fits:tunit: mag
   - name: footprintArea
     "@id": "#Object.footprintArea"
     datatype: int
     description: Number of pixels in the sources detection footprint. Reference band.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: merge_peak_sky
     "@id": "#Object.merge_peak_sky"
@@ -196,13 +182,11 @@ tables:
     "@id": "#Object.parentObjectId"
     datatype: long
     description: Unique ID of parent source. Reference band.
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: patch
     "@id": "#Object.patch"
     datatype: long
     description: Skymap patch ID
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: refBand
     "@id": "#Object.refBand"
@@ -215,19 +199,16 @@ tables:
     "@id": "#Object.refExtendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: refSizeExtendedness
     "@id": "#Object.refSizeExtendedness"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: refFwhm
     "@id": "#Object.refFwhm"
     datatype: double
     description: Estimated FWHM on the reference band at source center assuming a Gaussian profile
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: shape_flag
     "@id": "#Object.shape_flag"
@@ -239,19 +220,16 @@ tables:
     "@id": "#Object.shape_xx"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_xy
     "@id": "#Object.shape_xy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: shape_yy
     "@id": "#Object.shape_yy"
     datatype: double
     description: HSM moments. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: sky_object
     "@id": "#Object.sky_object"
@@ -263,19 +241,16 @@ tables:
     "@id": "#Object.tract"
     datatype: long
     description: Skymap tract ID
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: x
     "@id": "#Object.x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Object.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: xy_flag
     "@id": "#Object.xy_flag"
@@ -287,25 +262,21 @@ tables:
     "@id": "#Object.y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Reference band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: yErr
     "@id": "#Object.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Reference band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_ap03Flux
     "@id": "#Object.g_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03FluxErr
     "@id": "#Object.g_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap03Flux_flag
     "@id": "#Object.g_ap03Flux_flag"
@@ -317,13 +288,11 @@ tables:
     "@id": "#Object.g_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06FluxErr
     "@id": "#Object.g_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap06Flux_flag
     "@id": "#Object.g_ap06Flux_flag"
@@ -335,13 +304,11 @@ tables:
     "@id": "#Object.g_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09FluxErr
     "@id": "#Object.g_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap09Flux_flag
     "@id": "#Object.g_ap09Flux_flag"
@@ -353,13 +320,11 @@ tables:
     "@id": "#Object.g_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12FluxErr
     "@id": "#Object.g_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap12Flux_flag
     "@id": "#Object.g_ap12Flux_flag"
@@ -371,13 +336,11 @@ tables:
     "@id": "#Object.g_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17FluxErr
     "@id": "#Object.g_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap17Flux_flag
     "@id": "#Object.g_ap17Flux_flag"
@@ -389,13 +352,11 @@ tables:
     "@id": "#Object.g_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25FluxErr
     "@id": "#Object.g_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap25Flux_flag
     "@id": "#Object.g_ap25Flux_flag"
@@ -407,13 +368,11 @@ tables:
     "@id": "#Object.g_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35FluxErr
     "@id": "#Object.g_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap35Flux_flag
     "@id": "#Object.g_ap35Flux_flag"
@@ -425,13 +384,11 @@ tables:
     "@id": "#Object.g_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50FluxErr
     "@id": "#Object.g_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap50Flux_flag
     "@id": "#Object.g_ap50Flux_flag"
@@ -443,13 +400,11 @@ tables:
     "@id": "#Object.g_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70FluxErr
     "@id": "#Object.g_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_ap70Flux_flag
     "@id": "#Object.g_ap70Flux_flag"
@@ -479,61 +434,51 @@ tables:
     "@id": "#Object.g_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_bdE1
     "@id": "#Object.g_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdE2
     "@id": "#Object.g_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdFluxB
     "@id": "#Object.g_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxBErr
     "@id": "#Object.g_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxD
     "@id": "#Object.g_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdFluxDErr
     "@id": "#Object.g_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_bdReB
     "@id": "#Object.g_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_bdReD
     "@id": "#Object.g_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_blendedness
     "@id": "#Object.g_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_blendedness_flag
     "@id": "#Object.g_blendedness_flag"
@@ -545,19 +490,16 @@ tables:
     "@id": "#Object.g_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFluxErr
     "@id": "#Object.g_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModelFlux_inner
     "@id": "#Object.g_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_cModel_flag
     "@id": "#Object.g_cModel_flag"
@@ -575,13 +517,11 @@ tables:
     "@id": "#Object.g_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFluxErr
     "@id": "#Object.g_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_calibFlux_flag
     "@id": "#Object.g_calibFlux_flag"
@@ -647,52 +587,44 @@ tables:
     "@id": "#Object.g_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_xErr
     "@id": "#Object.g_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_centroid_y
     "@id": "#Object.g_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: g_centroid_yErr
     "@id": "#Object.g_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_dec
     "@id": "#Object.g_dec"
     datatype: double
     description: Position in declination, measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: g_decErr
     "@id": "#Object.g_decErr"
     datatype: float
     description: Error in declination, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: g_decl
     "@id": "#Object.g_decl"
     datatype: double
     description: Deprecated duplicate of g_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: g_extendedness
     "@id": "#Object.g_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_extendedness_flag
     "@id": "#Object.g_extendedness_flag"
@@ -704,7 +636,6 @@ tables:
     "@id": "#Object.g_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_sizeExtendedness_flag
     "@id": "#Object.g_sizeExtendedness_flag"
@@ -716,13 +647,11 @@ tables:
     "@id": "#Object.g_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFluxErr
     "@id": "#Object.g_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_cModelFlux_flag
     "@id": "#Object.g_free_cModelFlux_flag"
@@ -734,19 +663,16 @@ tables:
     "@id": "#Object.g_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux
     "@id": "#Object.g_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFluxErr
     "@id": "#Object.g_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_free_psfFlux_flag
     "@id": "#Object.g_free_psfFlux_flag"
@@ -758,19 +684,16 @@ tables:
     "@id": "#Object.g_fwhm"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_gaap0p7Flux
     "@id": "#Object.g_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p7FluxErr
     "@id": "#Object.g_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
@@ -782,13 +705,11 @@ tables:
     "@id": "#Object.g_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0FluxErr
     "@id": "#Object.g_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
@@ -800,13 +721,11 @@ tables:
     "@id": "#Object.g_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5FluxErr
     "@id": "#Object.g_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
@@ -818,13 +737,11 @@ tables:
     "@id": "#Object.g_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5FluxErr
     "@id": "#Object.g_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
@@ -836,13 +753,11 @@ tables:
     "@id": "#Object.g_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0FluxErr
     "@id": "#Object.g_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
@@ -872,13 +787,11 @@ tables:
     "@id": "#Object.g_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFluxErr
     "@id": "#Object.g_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
@@ -890,25 +803,21 @@ tables:
     "@id": "#Object.g_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_gaapPsfFluxErr
     "@id": "#Object.g_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_hsmShapeRegauss_e1
     "@id": "#Object.g_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_e2
     "@id": "#Object.g_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsmShapeRegauss_flag
     "@id": "#Object.g_hsmShapeRegauss_flag"
@@ -920,7 +829,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_iDebiasedPSF_flag
     "@id": "#Object.g_iDebiasedPSF_flag"
@@ -938,7 +846,6 @@ tables:
     "@id": "#Object.g_iRound_flag"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
@@ -950,7 +857,6 @@ tables:
     "@id": "#Object.g_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on g-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: g_inputCount_flag
     "@id": "#Object.g_inputCount_flag"
@@ -968,181 +874,151 @@ tables:
     "@id": "#Object.g_ixx"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxDebiasedPSF
     "@id": "#Object.g_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxPSF
     "@id": "#Object.g_ixxPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixxRound
     "@id": "#Object.g_ixxRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixy
     "@id": "#Object.g_ixy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyDebiasedPSF
     "@id": "#Object.g_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyPSF
     "@id": "#Object.g_ixyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_ixyRound
     "@id": "#Object.g_ixyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyy
     "@id": "#Object.g_iyy"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyDebiasedPSF
     "@id": "#Object.g_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyPSF
     "@id": "#Object.g_iyyPSF"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_iyyRound
     "@id": "#Object.g_iyyRound"
     datatype: double
     description: HSM moments. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: g_hsm_moments_30
     "@id": "#Object.g_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_30
     "@id": "#Object.g_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_21
     "@id": "#Object.g_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_21
     "@id": "#Object.g_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_12
     "@id": "#Object.g_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_12
     "@id": "#Object.g_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_03
     "@id": "#Object.g_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_03
     "@id": "#Object.g_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_40
     "@id": "#Object.g_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_40
     "@id": "#Object.g_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_31
     "@id": "#Object.g_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_31
     "@id": "#Object.g_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_22
     "@id": "#Object.g_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_22
     "@id": "#Object.g_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_13
     "@id": "#Object.g_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_13
     "@id": "#Object.g_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_04
     "@id": "#Object.g_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_momentsPsf_04
     "@id": "#Object.g_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: g_hsm_moments_flag
     "@id": "#Object.g_hsm_moments_flag"
@@ -1160,13 +1036,11 @@ tables:
     "@id": "#Object.g_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFluxErr
     "@id": "#Object.g_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_kronFlux_flag
     "@id": "#Object.g_kronFlux_flag"
@@ -1232,7 +1106,6 @@ tables:
     "@id": "#Object.g_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_pixelFlags_bad
     "@id": "#Object.g_pixelFlags_bad"
@@ -1352,19 +1225,16 @@ tables:
     "@id": "#Object.g_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFluxErr
     "@id": "#Object.g_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: g_psfFlux_area
     "@id": "#Object.g_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: g_psfFlux_flag
     "@id": "#Object.g_psfFlux_flag"
@@ -1394,46 +1264,39 @@ tables:
     "@id": "#Object.g_ra"
     datatype: double
     description: Position in right ascension, measured on g-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: g_raErr
     "@id": "#Object.g_raErr"
     datatype: float
     description: Error in right ascension, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: g_ra_dec_Cov
     "@id": "#Object.g_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on g-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: g_deblend_dataCoverage
     "@id": "#Object.g_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the g-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_blendedness
     "@id": "#Object.g_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_fluxOverlap
     "@id": "#Object.g_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_fluxOverlapFraction
     "@id": "#Object.g_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: g_deblend_zeroFlux
     "@id": "#Object.g_deblend_zeroFlux"
@@ -1445,13 +1308,11 @@ tables:
     "@id": "#Object.i_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03FluxErr
     "@id": "#Object.i_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap03Flux_flag
     "@id": "#Object.i_ap03Flux_flag"
@@ -1463,13 +1324,11 @@ tables:
     "@id": "#Object.i_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06FluxErr
     "@id": "#Object.i_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap06Flux_flag
     "@id": "#Object.i_ap06Flux_flag"
@@ -1481,13 +1340,11 @@ tables:
     "@id": "#Object.i_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09FluxErr
     "@id": "#Object.i_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap09Flux_flag
     "@id": "#Object.i_ap09Flux_flag"
@@ -1499,13 +1356,11 @@ tables:
     "@id": "#Object.i_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12FluxErr
     "@id": "#Object.i_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap12Flux_flag
     "@id": "#Object.i_ap12Flux_flag"
@@ -1517,13 +1372,11 @@ tables:
     "@id": "#Object.i_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17FluxErr
     "@id": "#Object.i_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap17Flux_flag
     "@id": "#Object.i_ap17Flux_flag"
@@ -1535,13 +1388,11 @@ tables:
     "@id": "#Object.i_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25FluxErr
     "@id": "#Object.i_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap25Flux_flag
     "@id": "#Object.i_ap25Flux_flag"
@@ -1553,13 +1404,11 @@ tables:
     "@id": "#Object.i_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35FluxErr
     "@id": "#Object.i_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap35Flux_flag
     "@id": "#Object.i_ap35Flux_flag"
@@ -1571,13 +1420,11 @@ tables:
     "@id": "#Object.i_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50FluxErr
     "@id": "#Object.i_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap50Flux_flag
     "@id": "#Object.i_ap50Flux_flag"
@@ -1589,13 +1436,11 @@ tables:
     "@id": "#Object.i_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70FluxErr
     "@id": "#Object.i_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_ap70Flux_flag
     "@id": "#Object.i_ap70Flux_flag"
@@ -1625,61 +1470,51 @@ tables:
     "@id": "#Object.i_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_bdE1
     "@id": "#Object.i_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdE2
     "@id": "#Object.i_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdFluxB
     "@id": "#Object.i_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxBErr
     "@id": "#Object.i_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxD
     "@id": "#Object.i_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdFluxDErr
     "@id": "#Object.i_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_bdReB
     "@id": "#Object.i_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_bdReD
     "@id": "#Object.i_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_blendedness
     "@id": "#Object.i_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_blendedness_flag
     "@id": "#Object.i_blendedness_flag"
@@ -1691,19 +1526,16 @@ tables:
     "@id": "#Object.i_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFluxErr
     "@id": "#Object.i_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModelFlux_inner
     "@id": "#Object.i_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_cModel_flag
     "@id": "#Object.i_cModel_flag"
@@ -1721,13 +1553,11 @@ tables:
     "@id": "#Object.i_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFluxErr
     "@id": "#Object.i_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_calibFlux_flag
     "@id": "#Object.i_calibFlux_flag"
@@ -1793,52 +1623,44 @@ tables:
     "@id": "#Object.i_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_xErr
     "@id": "#Object.i_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_centroid_y
     "@id": "#Object.i_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: i_centroid_yErr
     "@id": "#Object.i_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_dec
     "@id": "#Object.i_dec"
     datatype: double
     description: Position in declination, measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: i_decErr
     "@id": "#Object.i_decErr"
     datatype: float
     description: Error in declination, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: i_decl
     "@id": "#Object.i_decl"
     datatype: double
     description: Deprecated duplicate of i_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: i_extendedness
     "@id": "#Object.i_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_extendedness_flag
     "@id": "#Object.i_extendedness_flag"
@@ -1850,7 +1672,6 @@ tables:
     "@id": "#Object.i_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_sizeExtendedness_flag
     "@id": "#Object.i_sizeExtendedness_flag"
@@ -1862,13 +1683,11 @@ tables:
     "@id": "#Object.i_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFluxErr
     "@id": "#Object.i_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_cModelFlux_flag
     "@id": "#Object.i_free_cModelFlux_flag"
@@ -1880,19 +1699,16 @@ tables:
     "@id": "#Object.i_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux
     "@id": "#Object.i_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFluxErr
     "@id": "#Object.i_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_free_psfFlux_flag
     "@id": "#Object.i_free_psfFlux_flag"
@@ -1904,19 +1720,16 @@ tables:
     "@id": "#Object.i_fwhm"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_gaap0p7Flux
     "@id": "#Object.i_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p7FluxErr
     "@id": "#Object.i_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
@@ -1928,13 +1741,11 @@ tables:
     "@id": "#Object.i_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0FluxErr
     "@id": "#Object.i_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
@@ -1946,13 +1757,11 @@ tables:
     "@id": "#Object.i_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5FluxErr
     "@id": "#Object.i_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
@@ -1964,13 +1773,11 @@ tables:
     "@id": "#Object.i_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5FluxErr
     "@id": "#Object.i_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
@@ -1982,13 +1789,11 @@ tables:
     "@id": "#Object.i_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0FluxErr
     "@id": "#Object.i_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
@@ -2018,13 +1823,11 @@ tables:
     "@id": "#Object.i_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFluxErr
     "@id": "#Object.i_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
@@ -2036,25 +1839,21 @@ tables:
     "@id": "#Object.i_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_gaapPsfFluxErr
     "@id": "#Object.i_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_hsmShapeRegauss_e1
     "@id": "#Object.i_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_e2
     "@id": "#Object.i_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsmShapeRegauss_flag
     "@id": "#Object.i_hsmShapeRegauss_flag"
@@ -2066,7 +1865,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_iDebiasedPSF_flag
     "@id": "#Object.i_iDebiasedPSF_flag"
@@ -2084,7 +1882,6 @@ tables:
     "@id": "#Object.i_iRound_flag"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_i_flag
     "@id": "#Object.i_i_flag"
@@ -2096,7 +1893,6 @@ tables:
     "@id": "#Object.i_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on i-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: i_inputCount_flag
     "@id": "#Object.i_inputCount_flag"
@@ -2114,181 +1910,151 @@ tables:
     "@id": "#Object.i_ixx"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxDebiasedPSF
     "@id": "#Object.i_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxPSF
     "@id": "#Object.i_ixxPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixxRound
     "@id": "#Object.i_ixxRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixy
     "@id": "#Object.i_ixy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyDebiasedPSF
     "@id": "#Object.i_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyPSF
     "@id": "#Object.i_ixyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_ixyRound
     "@id": "#Object.i_ixyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyy
     "@id": "#Object.i_iyy"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyDebiasedPSF
     "@id": "#Object.i_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyPSF
     "@id": "#Object.i_iyyPSF"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_iyyRound
     "@id": "#Object.i_iyyRound"
     datatype: double
     description: HSM moments. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: i_hsm_moments_30
     "@id": "#Object.i_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_30
     "@id": "#Object.i_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_21
     "@id": "#Object.i_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_21
     "@id": "#Object.i_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_12
     "@id": "#Object.i_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_12
     "@id": "#Object.i_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_03
     "@id": "#Object.i_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_03
     "@id": "#Object.i_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_40
     "@id": "#Object.i_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_40
     "@id": "#Object.i_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_31
     "@id": "#Object.i_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_31
     "@id": "#Object.i_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_22
     "@id": "#Object.i_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_22
     "@id": "#Object.i_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_13
     "@id": "#Object.i_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_13
     "@id": "#Object.i_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_04
     "@id": "#Object.i_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_momentsPsf_04
     "@id": "#Object.i_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: i_hsm_moments_flag
     "@id": "#Object.i_hsm_moments_flag"
@@ -2306,13 +2072,11 @@ tables:
     "@id": "#Object.i_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFluxErr
     "@id": "#Object.i_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_kronFlux_flag
     "@id": "#Object.i_kronFlux_flag"
@@ -2378,7 +2142,6 @@ tables:
     "@id": "#Object.i_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_pixelFlags_bad
     "@id": "#Object.i_pixelFlags_bad"
@@ -2498,19 +2261,16 @@ tables:
     "@id": "#Object.i_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFluxErr
     "@id": "#Object.i_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: i_psfFlux_area
     "@id": "#Object.i_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: i_psfFlux_flag
     "@id": "#Object.i_psfFlux_flag"
@@ -2540,46 +2300,39 @@ tables:
     "@id": "#Object.i_ra"
     datatype: double
     description: Position in right ascension, measured on i-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: i_raErr
     "@id": "#Object.i_raErr"
     datatype: float
     description: Error in right ascension, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: i_ra_dec_Cov
     "@id": "#Object.i_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on i-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: i_deblend_dataCoverage
     "@id": "#Object.i_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the i-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_blendedness
     "@id": "#Object.i_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_fluxOverlap
     "@id": "#Object.i_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_fluxOverlapFraction
     "@id": "#Object.i_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: i_deblend_zeroFlux
     "@id": "#Object.i_deblend_zeroFlux"
@@ -2591,13 +2344,11 @@ tables:
     "@id": "#Object.r_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03FluxErr
     "@id": "#Object.r_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap03Flux_flag
     "@id": "#Object.r_ap03Flux_flag"
@@ -2609,13 +2360,11 @@ tables:
     "@id": "#Object.r_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06FluxErr
     "@id": "#Object.r_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap06Flux_flag
     "@id": "#Object.r_ap06Flux_flag"
@@ -2627,13 +2376,11 @@ tables:
     "@id": "#Object.r_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09FluxErr
     "@id": "#Object.r_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap09Flux_flag
     "@id": "#Object.r_ap09Flux_flag"
@@ -2645,13 +2392,11 @@ tables:
     "@id": "#Object.r_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12FluxErr
     "@id": "#Object.r_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap12Flux_flag
     "@id": "#Object.r_ap12Flux_flag"
@@ -2663,13 +2408,11 @@ tables:
     "@id": "#Object.r_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17FluxErr
     "@id": "#Object.r_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap17Flux_flag
     "@id": "#Object.r_ap17Flux_flag"
@@ -2681,13 +2424,11 @@ tables:
     "@id": "#Object.r_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25FluxErr
     "@id": "#Object.r_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap25Flux_flag
     "@id": "#Object.r_ap25Flux_flag"
@@ -2699,13 +2440,11 @@ tables:
     "@id": "#Object.r_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35FluxErr
     "@id": "#Object.r_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap35Flux_flag
     "@id": "#Object.r_ap35Flux_flag"
@@ -2717,13 +2456,11 @@ tables:
     "@id": "#Object.r_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50FluxErr
     "@id": "#Object.r_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap50Flux_flag
     "@id": "#Object.r_ap50Flux_flag"
@@ -2735,13 +2472,11 @@ tables:
     "@id": "#Object.r_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70FluxErr
     "@id": "#Object.r_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_ap70Flux_flag
     "@id": "#Object.r_ap70Flux_flag"
@@ -2771,61 +2506,51 @@ tables:
     "@id": "#Object.r_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_bdE1
     "@id": "#Object.r_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdE2
     "@id": "#Object.r_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdFluxB
     "@id": "#Object.r_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxBErr
     "@id": "#Object.r_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxD
     "@id": "#Object.r_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdFluxDErr
     "@id": "#Object.r_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_bdReB
     "@id": "#Object.r_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_bdReD
     "@id": "#Object.r_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_blendedness
     "@id": "#Object.r_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_blendedness_flag
     "@id": "#Object.r_blendedness_flag"
@@ -2837,19 +2562,16 @@ tables:
     "@id": "#Object.r_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFluxErr
     "@id": "#Object.r_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModelFlux_inner
     "@id": "#Object.r_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_cModel_flag
     "@id": "#Object.r_cModel_flag"
@@ -2867,13 +2589,11 @@ tables:
     "@id": "#Object.r_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFluxErr
     "@id": "#Object.r_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_calibFlux_flag
     "@id": "#Object.r_calibFlux_flag"
@@ -2939,52 +2659,44 @@ tables:
     "@id": "#Object.r_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_xErr
     "@id": "#Object.r_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_centroid_y
     "@id": "#Object.r_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: r_centroid_yErr
     "@id": "#Object.r_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_dec
     "@id": "#Object.r_dec"
     datatype: double
     description: Position in declination, measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: r_decErr
     "@id": "#Object.r_decErr"
     datatype: float
     description: Error in declination, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: r_decl
     "@id": "#Object.r_decl"
     datatype: double
     description: Deprecated duplicate of r_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: r_extendedness
     "@id": "#Object.r_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_extendedness_flag
     "@id": "#Object.r_extendedness_flag"
@@ -2996,7 +2708,6 @@ tables:
     "@id": "#Object.r_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_sizeExtendedness_flag
     "@id": "#Object.r_sizeExtendedness_flag"
@@ -3008,13 +2719,11 @@ tables:
     "@id": "#Object.r_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFluxErr
     "@id": "#Object.r_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_cModelFlux_flag
     "@id": "#Object.r_free_cModelFlux_flag"
@@ -3026,19 +2735,16 @@ tables:
     "@id": "#Object.r_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux
     "@id": "#Object.r_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFluxErr
     "@id": "#Object.r_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_free_psfFlux_flag
     "@id": "#Object.r_free_psfFlux_flag"
@@ -3050,19 +2756,16 @@ tables:
     "@id": "#Object.r_fwhm"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_gaap0p7Flux
     "@id": "#Object.r_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p7FluxErr
     "@id": "#Object.r_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
@@ -3074,13 +2777,11 @@ tables:
     "@id": "#Object.r_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0FluxErr
     "@id": "#Object.r_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
@@ -3092,13 +2793,11 @@ tables:
     "@id": "#Object.r_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5FluxErr
     "@id": "#Object.r_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
@@ -3110,13 +2809,11 @@ tables:
     "@id": "#Object.r_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5FluxErr
     "@id": "#Object.r_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
@@ -3128,13 +2825,11 @@ tables:
     "@id": "#Object.r_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0FluxErr
     "@id": "#Object.r_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
@@ -3164,13 +2859,11 @@ tables:
     "@id": "#Object.r_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFluxErr
     "@id": "#Object.r_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
@@ -3182,25 +2875,21 @@ tables:
     "@id": "#Object.r_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_gaapPsfFluxErr
     "@id": "#Object.r_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_hsmShapeRegauss_e1
     "@id": "#Object.r_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_e2
     "@id": "#Object.r_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsmShapeRegauss_flag
     "@id": "#Object.r_hsmShapeRegauss_flag"
@@ -3212,7 +2901,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_iDebiasedPSF_flag
     "@id": "#Object.r_iDebiasedPSF_flag"
@@ -3230,7 +2918,6 @@ tables:
     "@id": "#Object.r_iRound_flag"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_i_flag
     "@id": "#Object.r_i_flag"
@@ -3242,7 +2929,6 @@ tables:
     "@id": "#Object.r_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on r-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: r_inputCount_flag
     "@id": "#Object.r_inputCount_flag"
@@ -3260,181 +2946,151 @@ tables:
     "@id": "#Object.r_ixx"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxDebiasedPSF
     "@id": "#Object.r_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxPSF
     "@id": "#Object.r_ixxPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixxRound
     "@id": "#Object.r_ixxRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixy
     "@id": "#Object.r_ixy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyDebiasedPSF
     "@id": "#Object.r_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyPSF
     "@id": "#Object.r_ixyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_ixyRound
     "@id": "#Object.r_ixyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyy
     "@id": "#Object.r_iyy"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyDebiasedPSF
     "@id": "#Object.r_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyPSF
     "@id": "#Object.r_iyyPSF"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_iyyRound
     "@id": "#Object.r_iyyRound"
     datatype: double
     description: HSM moments. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: r_hsm_moments_30
     "@id": "#Object.r_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_30
     "@id": "#Object.r_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_21
     "@id": "#Object.r_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_21
     "@id": "#Object.r_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_12
     "@id": "#Object.r_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_12
     "@id": "#Object.r_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_03
     "@id": "#Object.r_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_03
     "@id": "#Object.r_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_40
     "@id": "#Object.r_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_40
     "@id": "#Object.r_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_31
     "@id": "#Object.r_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_31
     "@id": "#Object.r_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_22
     "@id": "#Object.r_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_22
     "@id": "#Object.r_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_13
     "@id": "#Object.r_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_13
     "@id": "#Object.r_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_04
     "@id": "#Object.r_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_momentsPsf_04
     "@id": "#Object.r_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: r_hsm_moments_flag
     "@id": "#Object.r_hsm_moments_flag"
@@ -3452,13 +3108,11 @@ tables:
     "@id": "#Object.r_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFluxErr
     "@id": "#Object.r_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_kronFlux_flag
     "@id": "#Object.r_kronFlux_flag"
@@ -3524,7 +3178,6 @@ tables:
     "@id": "#Object.r_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_pixelFlags_bad
     "@id": "#Object.r_pixelFlags_bad"
@@ -3644,19 +3297,16 @@ tables:
     "@id": "#Object.r_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFluxErr
     "@id": "#Object.r_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: r_psfFlux_area
     "@id": "#Object.r_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: r_psfFlux_flag
     "@id": "#Object.r_psfFlux_flag"
@@ -3686,46 +3336,39 @@ tables:
     "@id": "#Object.r_ra"
     datatype: double
     description: Position in right ascension, measured on r-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: r_raErr
     "@id": "#Object.r_raErr"
     datatype: float
     description: Error in right ascension, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: r_ra_dec_Cov
     "@id": "#Object.r_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on r-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: r_deblend_dataCoverage
     "@id": "#Object.r_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the r-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_blendedness
     "@id": "#Object.r_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_fluxOverlap
     "@id": "#Object.r_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_fluxOverlapFraction
     "@id": "#Object.r_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: r_deblend_zeroFlux
     "@id": "#Object.r_deblend_zeroFlux"
@@ -3737,13 +3380,11 @@ tables:
     "@id": "#Object.u_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap03FluxErr
     "@id": "#Object.u_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap03Flux_flag
     "@id": "#Object.u_ap03Flux_flag"
@@ -3755,13 +3396,11 @@ tables:
     "@id": "#Object.u_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap06FluxErr
     "@id": "#Object.u_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap06Flux_flag
     "@id": "#Object.u_ap06Flux_flag"
@@ -3773,13 +3412,11 @@ tables:
     "@id": "#Object.u_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap09FluxErr
     "@id": "#Object.u_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap09Flux_flag
     "@id": "#Object.u_ap09Flux_flag"
@@ -3791,13 +3428,11 @@ tables:
     "@id": "#Object.u_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap12FluxErr
     "@id": "#Object.u_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap12Flux_flag
     "@id": "#Object.u_ap12Flux_flag"
@@ -3809,13 +3444,11 @@ tables:
     "@id": "#Object.u_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap17FluxErr
     "@id": "#Object.u_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap17Flux_flag
     "@id": "#Object.u_ap17Flux_flag"
@@ -3827,13 +3460,11 @@ tables:
     "@id": "#Object.u_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap25FluxErr
     "@id": "#Object.u_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap25Flux_flag
     "@id": "#Object.u_ap25Flux_flag"
@@ -3845,13 +3476,11 @@ tables:
     "@id": "#Object.u_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap35FluxErr
     "@id": "#Object.u_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap35Flux_flag
     "@id": "#Object.u_ap35Flux_flag"
@@ -3863,13 +3492,11 @@ tables:
     "@id": "#Object.u_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap50FluxErr
     "@id": "#Object.u_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap50Flux_flag
     "@id": "#Object.u_ap50Flux_flag"
@@ -3881,13 +3508,11 @@ tables:
     "@id": "#Object.u_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap70FluxErr
     "@id": "#Object.u_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_ap70Flux_flag
     "@id": "#Object.u_ap70Flux_flag"
@@ -3917,61 +3542,51 @@ tables:
     "@id": "#Object.u_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_bdE1
     "@id": "#Object.u_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdE2
     "@id": "#Object.u_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdFluxB
     "@id": "#Object.u_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxBErr
     "@id": "#Object.u_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxD
     "@id": "#Object.u_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdFluxDErr
     "@id": "#Object.u_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_bdReB
     "@id": "#Object.u_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_bdReD
     "@id": "#Object.u_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_blendedness
     "@id": "#Object.u_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_blendedness_flag
     "@id": "#Object.u_blendedness_flag"
@@ -3983,19 +3598,16 @@ tables:
     "@id": "#Object.u_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModelFluxErr
     "@id": "#Object.u_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModelFlux_inner
     "@id": "#Object.u_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_cModel_flag
     "@id": "#Object.u_cModel_flag"
@@ -4013,13 +3625,11 @@ tables:
     "@id": "#Object.u_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_calibFluxErr
     "@id": "#Object.u_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_calibFlux_flag
     "@id": "#Object.u_calibFlux_flag"
@@ -4085,52 +3695,44 @@ tables:
     "@id": "#Object.u_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: u_centroid_xErr
     "@id": "#Object.u_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_centroid_y
     "@id": "#Object.u_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: u_centroid_yErr
     "@id": "#Object.u_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_dec
     "@id": "#Object.u_dec"
     datatype: double
     description: Position in declination, measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: u_decErr
     "@id": "#Object.u_decErr"
     datatype: float
     description: Error in declination, measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: u_decl
     "@id": "#Object.u_decl"
     datatype: double
     description: Deprecated duplicate of u_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: u_extendedness
     "@id": "#Object.u_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_extendedness_flag
     "@id": "#Object.u_extendedness_flag"
@@ -4142,7 +3744,6 @@ tables:
     "@id": "#Object.u_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_sizeExtendedness_flag
     "@id": "#Object.u_sizeExtendedness_flag"
@@ -4154,13 +3755,11 @@ tables:
     "@id": "#Object.u_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_cModelFluxErr
     "@id": "#Object.u_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_cModelFlux_flag
     "@id": "#Object.u_free_cModelFlux_flag"
@@ -4172,19 +3771,16 @@ tables:
     "@id": "#Object.u_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFlux
     "@id": "#Object.u_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFluxErr
     "@id": "#Object.u_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_free_psfFlux_flag
     "@id": "#Object.u_free_psfFlux_flag"
@@ -4196,19 +3792,16 @@ tables:
     "@id": "#Object.u_fwhm"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_gaap0p7Flux
     "@id": "#Object.u_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p7FluxErr
     "@id": "#Object.u_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.u_gaap0p7Flux_flag_bigPsf"
@@ -4220,13 +3813,11 @@ tables:
     "@id": "#Object.u_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p0FluxErr
     "@id": "#Object.u_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.u_gaap1p0Flux_flag_bigPsf"
@@ -4238,13 +3829,11 @@ tables:
     "@id": "#Object.u_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p5FluxErr
     "@id": "#Object.u_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.u_gaap1p5Flux_flag_bigPsf"
@@ -4256,13 +3845,11 @@ tables:
     "@id": "#Object.u_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap2p5FluxErr
     "@id": "#Object.u_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.u_gaap2p5Flux_flag_bigPsf"
@@ -4274,13 +3861,11 @@ tables:
     "@id": "#Object.u_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap3p0FluxErr
     "@id": "#Object.u_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.u_gaap3p0Flux_flag_bigPsf"
@@ -4310,13 +3895,11 @@ tables:
     "@id": "#Object.u_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapOptimalFluxErr
     "@id": "#Object.u_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.u_gaapOptimalFlux_flag_bigPsf"
@@ -4328,25 +3911,21 @@ tables:
     "@id": "#Object.u_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_gaapPsfFluxErr
     "@id": "#Object.u_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_hsmShapeRegauss_e1
     "@id": "#Object.u_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsmShapeRegauss_e2
     "@id": "#Object.u_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsmShapeRegauss_flag
     "@id": "#Object.u_hsmShapeRegauss_flag"
@@ -4358,7 +3937,6 @@ tables:
     "@id": "#Object.u_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_iDebiasedPSF_flag
     "@id": "#Object.u_iDebiasedPSF_flag"
@@ -4376,7 +3954,6 @@ tables:
     "@id": "#Object.u_iRound_flag"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_i_flag
     "@id": "#Object.u_i_flag"
@@ -4388,7 +3965,6 @@ tables:
     "@id": "#Object.u_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on u-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: u_inputCount_flag
     "@id": "#Object.u_inputCount_flag"
@@ -4406,181 +3982,151 @@ tables:
     "@id": "#Object.u_ixx"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxDebiasedPSF
     "@id": "#Object.u_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxPSF
     "@id": "#Object.u_ixxPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixxRound
     "@id": "#Object.u_ixxRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixy
     "@id": "#Object.u_ixy"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyDebiasedPSF
     "@id": "#Object.u_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyPSF
     "@id": "#Object.u_ixyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_ixyRound
     "@id": "#Object.u_ixyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyy
     "@id": "#Object.u_iyy"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyDebiasedPSF
     "@id": "#Object.u_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyPSF
     "@id": "#Object.u_iyyPSF"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_iyyRound
     "@id": "#Object.u_iyyRound"
     datatype: double
     description: HSM moments. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: u_hsm_moments_30
     "@id": "#Object.u_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_30
     "@id": "#Object.u_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_21
     "@id": "#Object.u_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_21
     "@id": "#Object.u_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_12
     "@id": "#Object.u_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_12
     "@id": "#Object.u_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_03
     "@id": "#Object.u_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_03
     "@id": "#Object.u_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_40
     "@id": "#Object.u_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_40
     "@id": "#Object.u_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_31
     "@id": "#Object.u_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_31
     "@id": "#Object.u_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_22
     "@id": "#Object.u_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_22
     "@id": "#Object.u_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_13
     "@id": "#Object.u_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_13
     "@id": "#Object.u_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_04
     "@id": "#Object.u_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_momentsPsf_04
     "@id": "#Object.u_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: u_hsm_moments_flag
     "@id": "#Object.u_hsm_moments_flag"
@@ -4598,13 +4144,11 @@ tables:
     "@id": "#Object.u_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_kronFluxErr
     "@id": "#Object.u_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_kronFlux_flag
     "@id": "#Object.u_kronFlux_flag"
@@ -4670,7 +4214,6 @@ tables:
     "@id": "#Object.u_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_pixelFlags_bad
     "@id": "#Object.u_pixelFlags_bad"
@@ -4790,19 +4333,16 @@ tables:
     "@id": "#Object.u_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_psfFluxErr
     "@id": "#Object.u_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: u_psfFlux_area
     "@id": "#Object.u_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: u_psfFlux_flag
     "@id": "#Object.u_psfFlux_flag"
@@ -4832,46 +4372,39 @@ tables:
     "@id": "#Object.u_ra"
     datatype: double
     description: Position in right ascension, measured on u-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: u_raErr
     "@id": "#Object.u_raErr"
     datatype: float
     description: Error in right ascension, measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: u_ra_dec_Cov
     "@id": "#Object.u_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on u-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: u_deblend_dataCoverage
     "@id": "#Object.u_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the u-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_deblend_blendedness
     "@id": "#Object.u_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_deblend_fluxOverlap
     "@id": "#Object.u_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_deblend_fluxOverlapFraction
     "@id": "#Object.u_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: u_deblend_zeroFlux
     "@id": "#Object.u_deblend_zeroFlux"
@@ -4883,13 +4416,11 @@ tables:
     "@id": "#Object.y_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03FluxErr
     "@id": "#Object.y_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap03Flux_flag
     "@id": "#Object.y_ap03Flux_flag"
@@ -4901,13 +4432,11 @@ tables:
     "@id": "#Object.y_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06FluxErr
     "@id": "#Object.y_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap06Flux_flag
     "@id": "#Object.y_ap06Flux_flag"
@@ -4919,13 +4448,11 @@ tables:
     "@id": "#Object.y_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09FluxErr
     "@id": "#Object.y_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap09Flux_flag
     "@id": "#Object.y_ap09Flux_flag"
@@ -4937,13 +4464,11 @@ tables:
     "@id": "#Object.y_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12FluxErr
     "@id": "#Object.y_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap12Flux_flag
     "@id": "#Object.y_ap12Flux_flag"
@@ -4955,13 +4480,11 @@ tables:
     "@id": "#Object.y_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17FluxErr
     "@id": "#Object.y_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap17Flux_flag
     "@id": "#Object.y_ap17Flux_flag"
@@ -4973,13 +4496,11 @@ tables:
     "@id": "#Object.y_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25FluxErr
     "@id": "#Object.y_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap25Flux_flag
     "@id": "#Object.y_ap25Flux_flag"
@@ -4991,13 +4512,11 @@ tables:
     "@id": "#Object.y_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35FluxErr
     "@id": "#Object.y_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap35Flux_flag
     "@id": "#Object.y_ap35Flux_flag"
@@ -5009,13 +4528,11 @@ tables:
     "@id": "#Object.y_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50FluxErr
     "@id": "#Object.y_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap50Flux_flag
     "@id": "#Object.y_ap50Flux_flag"
@@ -5027,13 +4544,11 @@ tables:
     "@id": "#Object.y_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70FluxErr
     "@id": "#Object.y_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_ap70Flux_flag
     "@id": "#Object.y_ap70Flux_flag"
@@ -5063,61 +4578,51 @@ tables:
     "@id": "#Object.y_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_bdE1
     "@id": "#Object.y_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdE2
     "@id": "#Object.y_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdFluxB
     "@id": "#Object.y_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxBErr
     "@id": "#Object.y_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxD
     "@id": "#Object.y_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdFluxDErr
     "@id": "#Object.y_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_bdReB
     "@id": "#Object.y_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_bdReD
     "@id": "#Object.y_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_blendedness
     "@id": "#Object.y_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_blendedness_flag
     "@id": "#Object.y_blendedness_flag"
@@ -5129,19 +4634,16 @@ tables:
     "@id": "#Object.y_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFluxErr
     "@id": "#Object.y_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModelFlux_inner
     "@id": "#Object.y_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_cModel_flag
     "@id": "#Object.y_cModel_flag"
@@ -5159,13 +4661,11 @@ tables:
     "@id": "#Object.y_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFluxErr
     "@id": "#Object.y_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_calibFlux_flag
     "@id": "#Object.y_calibFlux_flag"
@@ -5231,52 +4731,44 @@ tables:
     "@id": "#Object.y_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_xErr
     "@id": "#Object.y_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_centroid_y
     "@id": "#Object.y_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y_centroid_yErr
     "@id": "#Object.y_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_dec
     "@id": "#Object.y_dec"
     datatype: double
     description: Position in declination, measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: y_decErr
     "@id": "#Object.y_decErr"
     datatype: float
     description: Error in declination, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: y_decl
     "@id": "#Object.y_decl"
     datatype: double
     description: Deprecated duplicate of y_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: y_extendedness
     "@id": "#Object.y_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_extendedness_flag
     "@id": "#Object.y_extendedness_flag"
@@ -5288,7 +4780,6 @@ tables:
     "@id": "#Object.y_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_sizeExtendedness_flag
     "@id": "#Object.y_sizeExtendedness_flag"
@@ -5300,13 +4791,11 @@ tables:
     "@id": "#Object.y_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFluxErr
     "@id": "#Object.y_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_cModelFlux_flag
     "@id": "#Object.y_free_cModelFlux_flag"
@@ -5318,19 +4807,16 @@ tables:
     "@id": "#Object.y_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux
     "@id": "#Object.y_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFluxErr
     "@id": "#Object.y_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_free_psfFlux_flag
     "@id": "#Object.y_free_psfFlux_flag"
@@ -5342,19 +4828,16 @@ tables:
     "@id": "#Object.y_fwhm"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_gaap0p7Flux
     "@id": "#Object.y_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p7FluxErr
     "@id": "#Object.y_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
@@ -5366,13 +4849,11 @@ tables:
     "@id": "#Object.y_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0FluxErr
     "@id": "#Object.y_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
@@ -5384,13 +4865,11 @@ tables:
     "@id": "#Object.y_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5FluxErr
     "@id": "#Object.y_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
@@ -5402,13 +4881,11 @@ tables:
     "@id": "#Object.y_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5FluxErr
     "@id": "#Object.y_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
@@ -5420,13 +4897,11 @@ tables:
     "@id": "#Object.y_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0FluxErr
     "@id": "#Object.y_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
@@ -5456,13 +4931,11 @@ tables:
     "@id": "#Object.y_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFluxErr
     "@id": "#Object.y_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
@@ -5474,25 +4947,21 @@ tables:
     "@id": "#Object.y_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_gaapPsfFluxErr
     "@id": "#Object.y_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_hsmShapeRegauss_e1
     "@id": "#Object.y_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_e2
     "@id": "#Object.y_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsmShapeRegauss_flag
     "@id": "#Object.y_hsmShapeRegauss_flag"
@@ -5504,7 +4973,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_iDebiasedPSF_flag
     "@id": "#Object.y_iDebiasedPSF_flag"
@@ -5522,7 +4990,6 @@ tables:
     "@id": "#Object.y_iRound_flag"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_i_flag
     "@id": "#Object.y_i_flag"
@@ -5534,7 +5001,6 @@ tables:
     "@id": "#Object.y_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on y-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: y_inputCount_flag
     "@id": "#Object.y_inputCount_flag"
@@ -5552,181 +5018,151 @@ tables:
     "@id": "#Object.y_ixx"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxDebiasedPSF
     "@id": "#Object.y_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxPSF
     "@id": "#Object.y_ixxPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixxRound
     "@id": "#Object.y_ixxRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixy
     "@id": "#Object.y_ixy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyDebiasedPSF
     "@id": "#Object.y_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyPSF
     "@id": "#Object.y_ixyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_ixyRound
     "@id": "#Object.y_ixyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyy
     "@id": "#Object.y_iyy"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyDebiasedPSF
     "@id": "#Object.y_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyPSF
     "@id": "#Object.y_iyyPSF"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_iyyRound
     "@id": "#Object.y_iyyRound"
     datatype: double
     description: HSM moments. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: y_hsm_moments_30
     "@id": "#Object.y_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_30
     "@id": "#Object.y_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_21
     "@id": "#Object.y_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_21
     "@id": "#Object.y_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_12
     "@id": "#Object.y_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_12
     "@id": "#Object.y_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_03
     "@id": "#Object.y_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_03
     "@id": "#Object.y_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_40
     "@id": "#Object.y_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_40
     "@id": "#Object.y_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_31
     "@id": "#Object.y_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_31
     "@id": "#Object.y_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_22
     "@id": "#Object.y_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_22
     "@id": "#Object.y_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_13
     "@id": "#Object.y_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_13
     "@id": "#Object.y_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_04
     "@id": "#Object.y_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_momentsPsf_04
     "@id": "#Object.y_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: y_hsm_moments_flag
     "@id": "#Object.y_hsm_moments_flag"
@@ -5744,13 +5180,11 @@ tables:
     "@id": "#Object.y_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFluxErr
     "@id": "#Object.y_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_kronFlux_flag
     "@id": "#Object.y_kronFlux_flag"
@@ -5816,7 +5250,6 @@ tables:
     "@id": "#Object.y_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_pixelFlags_bad
     "@id": "#Object.y_pixelFlags_bad"
@@ -5936,19 +5369,16 @@ tables:
     "@id": "#Object.y_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFluxErr
     "@id": "#Object.y_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: y_psfFlux_area
     "@id": "#Object.y_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: y_psfFlux_flag
     "@id": "#Object.y_psfFlux_flag"
@@ -5978,46 +5408,39 @@ tables:
     "@id": "#Object.y_ra"
     datatype: double
     description: Position in right ascension, measured on y-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: y_raErr
     "@id": "#Object.y_raErr"
     datatype: float
     description: Error in right ascension, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: y_ra_dec_Cov
     "@id": "#Object.y_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on y-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: y_deblend_dataCoverage
     "@id": "#Object.y_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the y-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_blendedness
     "@id": "#Object.y_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_fluxOverlap
     "@id": "#Object.y_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_fluxOverlapFraction
     "@id": "#Object.y_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: y_deblend_zeroFlux
     "@id": "#Object.y_deblend_zeroFlux"
@@ -6029,13 +5452,11 @@ tables:
     "@id": "#Object.z_ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03FluxErr
     "@id": "#Object.z_ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap03Flux_flag
     "@id": "#Object.z_ap03Flux_flag"
@@ -6047,13 +5468,11 @@ tables:
     "@id": "#Object.z_ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06FluxErr
     "@id": "#Object.z_ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap06Flux_flag
     "@id": "#Object.z_ap06Flux_flag"
@@ -6065,13 +5484,11 @@ tables:
     "@id": "#Object.z_ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09FluxErr
     "@id": "#Object.z_ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap09Flux_flag
     "@id": "#Object.z_ap09Flux_flag"
@@ -6083,13 +5500,11 @@ tables:
     "@id": "#Object.z_ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12FluxErr
     "@id": "#Object.z_ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap12Flux_flag
     "@id": "#Object.z_ap12Flux_flag"
@@ -6101,13 +5516,11 @@ tables:
     "@id": "#Object.z_ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17FluxErr
     "@id": "#Object.z_ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap17Flux_flag
     "@id": "#Object.z_ap17Flux_flag"
@@ -6119,13 +5532,11 @@ tables:
     "@id": "#Object.z_ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25FluxErr
     "@id": "#Object.z_ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap25Flux_flag
     "@id": "#Object.z_ap25Flux_flag"
@@ -6137,13 +5548,11 @@ tables:
     "@id": "#Object.z_ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35FluxErr
     "@id": "#Object.z_ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap35Flux_flag
     "@id": "#Object.z_ap35Flux_flag"
@@ -6155,13 +5564,11 @@ tables:
     "@id": "#Object.z_ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50FluxErr
     "@id": "#Object.z_ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap50Flux_flag
     "@id": "#Object.z_ap50Flux_flag"
@@ -6173,13 +5580,11 @@ tables:
     "@id": "#Object.z_ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70FluxErr
     "@id": "#Object.z_ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_ap70Flux_flag
     "@id": "#Object.z_ap70Flux_flag"
@@ -6209,61 +5614,51 @@ tables:
     "@id": "#Object.z_bdChi2"
     datatype: double
     description: -ln(likelihood) (chi^2) in cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_bdE1
     "@id": "#Object.z_bdE1"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdE2
     "@id": "#Object.z_bdE2"
     datatype: double
     description: FracDev-weighted average of exp.ellipse and dev.ellipse. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdFluxB
     "@id": "#Object.z_bdFluxB"
     datatype: double
     description: Flux from the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxBErr
     "@id": "#Object.z_bdFluxBErr"
     datatype: double
     description: Flux uncertainty from the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxD
     "@id": "#Object.z_bdFluxD"
     datatype: double
     description: Flux from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdFluxDErr
     "@id": "#Object.z_bdFluxDErr"
     datatype: double
     description: Flux uncertainty from the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_bdReB
     "@id": "#Object.z_bdReB"
     datatype: double
     description: Half-light ellipse of the de Vaucouleur fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_bdReD
     "@id": "#Object.z_bdReD"
     datatype: double
     description: Half-light ellipse of the exponential fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_blendedness
     "@id": "#Object.z_blendedness"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_blendedness_flag
     "@id": "#Object.z_blendedness_flag"
@@ -6275,19 +5670,16 @@ tables:
     "@id": "#Object.z_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFluxErr
     "@id": "#Object.z_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModelFlux_inner
     "@id": "#Object.z_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_cModel_flag
     "@id": "#Object.z_cModel_flag"
@@ -6305,13 +5697,11 @@ tables:
     "@id": "#Object.z_calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFluxErr
     "@id": "#Object.z_calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_calibFlux_flag
     "@id": "#Object.z_calibFlux_flag"
@@ -6377,52 +5767,44 @@ tables:
     "@id": "#Object.z_centroid_x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_xErr
     "@id": "#Object.z_centroid_xErr"
     datatype: float
     description: 1-sigma uncertainty on x position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_centroid_y
     "@id": "#Object.z_centroid_y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: z_centroid_yErr
     "@id": "#Object.z_centroid_yErr"
     datatype: float
     description: 1-sigma uncertainty on y position. Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_dec
     "@id": "#Object.z_dec"
     datatype: double
     description: Position in declination, measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: z_decErr
     "@id": "#Object.z_decErr"
     datatype: float
     description: Error in declination, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: z_decl
     "@id": "#Object.z_decl"
     datatype: double
     description: Deprecated duplicate of z_dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: z_extendedness
     "@id": "#Object.z_extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_extendedness_flag
     "@id": "#Object.z_extendedness_flag"
@@ -6434,7 +5816,6 @@ tables:
     "@id": "#Object.z_extendedLikehood"
     datatype: double
     description: Moments-based measure of an object to be a galaxy. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_sizeExtendedness_flag
     "@id": "#Object.z_sizeExtendedness_flag"
@@ -6446,13 +5827,11 @@ tables:
     "@id": "#Object.z_free_cModelFlux"
     datatype: double
     description: Flux from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFluxErr
     "@id": "#Object.z_free_cModelFluxErr"
     datatype: double
     description: Flux uncertainty from the final cmodel fit. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_cModelFlux_flag
     "@id": "#Object.z_free_cModelFlux_flag"
@@ -6464,19 +5843,16 @@ tables:
     "@id": "#Object.z_free_cModelFlux_inner"
     datatype: double
     description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux
     "@id": "#Object.z_free_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFluxErr
     "@id": "#Object.z_free_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_free_psfFlux_flag
     "@id": "#Object.z_free_psfFlux_flag"
@@ -6488,19 +5864,16 @@ tables:
     "@id": "#Object.z_fwhm"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_gaap0p7Flux
     "@id": "#Object.z_gaap0p7Flux"
     datatype: double
     description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p7FluxErr
     "@id": "#Object.z_gaap0p7FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap0p7Flux_flag_bigPsf
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
@@ -6512,13 +5885,11 @@ tables:
     "@id": "#Object.z_gaap1p0Flux"
     datatype: double
     description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0FluxErr
     "@id": "#Object.z_gaap1p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
@@ -6530,13 +5901,11 @@ tables:
     "@id": "#Object.z_gaap1p5Flux"
     datatype: double
     description: GAaP Flux with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5FluxErr
     "@id": "#Object.z_gaap1p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 1.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap1p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
@@ -6548,13 +5917,11 @@ tables:
     "@id": "#Object.z_gaap2p5Flux"
     datatype: double
     description: GAaP Flux with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5FluxErr
     "@id": "#Object.z_gaap2p5FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 2.5 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap2p5Flux_flag_bigPsf
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
@@ -6566,13 +5933,11 @@ tables:
     "@id": "#Object.z_gaap3p0Flux"
     datatype: double
     description: GAaP Flux with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0FluxErr
     "@id": "#Object.z_gaap3p0FluxErr"
     datatype: double
     description: GAaP Flux uncertainty with 3.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaap3p0Flux_flag_bigPsf
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
@@ -6602,13 +5967,11 @@ tables:
     "@id": "#Object.z_gaapOptimalFlux"
     datatype: double
     description: GAaP Flux with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFluxErr
     "@id": "#Object.z_gaapOptimalFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with optimal aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapOptimalFlux_flag_bigPsf
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
@@ -6620,25 +5983,21 @@ tables:
     "@id": "#Object.z_gaapPsfFlux"
     datatype: double
     description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_gaapPsfFluxErr
     "@id": "#Object.z_gaapPsfFluxErr"
     datatype: double
     description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_hsmShapeRegauss_e1
     "@id": "#Object.z_hsmShapeRegauss_e1"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_e2
     "@id": "#Object.z_hsmShapeRegauss_e2"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsmShapeRegauss_flag
     "@id": "#Object.z_hsmShapeRegauss_flag"
@@ -6650,7 +6009,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_sigma"
     datatype: double
     description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_iDebiasedPSF_flag
     "@id": "#Object.z_iDebiasedPSF_flag"
@@ -6668,7 +6026,6 @@ tables:
     "@id": "#Object.z_iRound_flag"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_i_flag
     "@id": "#Object.z_i_flag"
@@ -6680,7 +6037,6 @@ tables:
     "@id": "#Object.z_inputCount"
     datatype: int
     description: Number of images contributing at center, not including anyclipping. Forced on z-band.
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: z_inputCount_flag
     "@id": "#Object.z_inputCount_flag"
@@ -6698,181 +6054,151 @@ tables:
     "@id": "#Object.z_ixx"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxDebiasedPSF
     "@id": "#Object.z_ixxDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxPSF
     "@id": "#Object.z_ixxPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixxRound
     "@id": "#Object.z_ixxRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixy
     "@id": "#Object.z_ixy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyDebiasedPSF
     "@id": "#Object.z_ixyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyPSF
     "@id": "#Object.z_ixyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_ixyRound
     "@id": "#Object.z_ixyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyy
     "@id": "#Object.z_iyy"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyDebiasedPSF
     "@id": "#Object.z_iyyDebiasedPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyPSF
     "@id": "#Object.z_iyyPSF"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_iyyRound
     "@id": "#Object.z_iyyRound"
     datatype: double
     description: HSM moments. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: z_hsm_moments_30
     "@id": "#Object.z_hsm_moments_30"
     datatype: double
     description: HSM higher order moments 30. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_30
     "@id": "#Object.z_hsm_momentsPsf_30"
     datatype: double
     description: HSM higher order PSF moments 30. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_21
     "@id": "#Object.z_hsm_moments_21"
     datatype: double
     description: HSM higher order moments 21. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_21
     "@id": "#Object.z_hsm_momentsPsf_21"
     datatype: double
     description: HSM higher order PSF moments 21. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_12
     "@id": "#Object.z_hsm_moments_12"
     datatype: double
     description: HSM higher order moments 12. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_12
     "@id": "#Object.z_hsm_momentsPsf_12"
     datatype: double
     description: HSM higher order PSF moments 12. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_03
     "@id": "#Object.z_hsm_moments_03"
     datatype: double
     description: HSM higher order moments 03. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_03
     "@id": "#Object.z_hsm_momentsPsf_03"
     datatype: double
     description: HSM higher order PSF moments 03. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_40
     "@id": "#Object.z_hsm_moments_40"
     datatype: double
     description: HSM higher order moments 40. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_40
     "@id": "#Object.z_hsm_momentsPsf_40"
     datatype: double
     description: HSM higher order PSF moments 40. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_31
     "@id": "#Object.z_hsm_moments_31"
     datatype: double
     description: HSM higher order moments 31. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_31
     "@id": "#Object.z_hsm_momentsPsf_31"
     datatype: double
     description: HSM higher order PSF moments 31. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_22
     "@id": "#Object.z_hsm_moments_22"
     datatype: double
     description: HSM higher order moments 22. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_22
     "@id": "#Object.z_hsm_momentsPsf_22"
     datatype: double
     description: HSM higher order PSF moments 22. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_13
     "@id": "#Object.z_hsm_moments_13"
     datatype: double
     description: HSM higher order moments 13. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_13
     "@id": "#Object.z_hsm_momentsPsf_13"
     datatype: double
     description: HSM higher order PSF moments 13. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_04
     "@id": "#Object.z_hsm_moments_04"
     datatype: double
     description: HSM higher order moments 04. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_momentsPsf_04
     "@id": "#Object.z_hsm_momentsPsf_04"
     datatype: double
     description: HSM higher order PSF moments 04. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: z_hsm_moments_flag
     "@id": "#Object.z_hsm_moments_flag"
@@ -6890,13 +6216,11 @@ tables:
     "@id": "#Object.z_kronFlux"
     datatype: double
     description: Flux from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFluxErr
     "@id": "#Object.z_kronFluxErr"
     datatype: double
     description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_kronFlux_flag
     "@id": "#Object.z_kronFlux_flag"
@@ -6962,7 +6286,6 @@ tables:
     "@id": "#Object.z_kronRad"
     datatype: float
     description: Kron radius (sqrt(a*b)). Measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_pixelFlags_bad
     "@id": "#Object.z_pixelFlags_bad"
@@ -7082,19 +6405,16 @@ tables:
     "@id": "#Object.z_psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFluxErr
     "@id": "#Object.z_psfFluxErr"
     datatype: double
     description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: z_psfFlux_area
     "@id": "#Object.z_psfFlux_area"
     datatype: float
     description: Effective area of PSF. Forced on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: z_psfFlux_flag
     "@id": "#Object.z_psfFlux_flag"
@@ -7124,46 +6444,39 @@ tables:
     "@id": "#Object.z_ra"
     datatype: double
     description: Position in right ascension, measured on z-band.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: z_raErr
     "@id": "#Object.z_raErr"
     datatype: float
     description: Error in right ascension, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: z_ra_dec_Cov
     "@id": "#Object.z_ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination, measured on z-band.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: z_deblend_dataCoverage
     "@id": "#Object.z_deblend_dataCoverage"
     datatype: float
     description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the z-band.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_blendedness
     "@id": "#Object.z_deblend_blendedness"
     datatype: float
     description: Blendedness in the deconvolved scarlet space
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_fluxOverlap
     "@id": "#Object.z_deblend_fluxOverlap"
     datatype: float
     description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_fluxOverlapFraction
     "@id": "#Object.z_deblend_fluxOverlapFraction"
     datatype: float
     description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    mysql:datatype: FLOAT
     fits:tunit:
   - name: z_deblend_zeroFlux
     "@id": "#Object.z_deblend_zeroFlux"
@@ -7184,123 +6497,104 @@ tables:
     datatype: long
     nullable: false
     description: Unique id. Unique Source ID. Primary Key.
-    mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
   - name: coord_ra
     "@id": "#Source.coord_ra"
     datatype: double
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: coord_dec
     "@id": "#Source.coord_dec"
     datatype: double
     description: Fiducial ICRS Declination of centroid used for database indexing
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: ccdVisitId
     "@id": "#Source.ccdVisitId"
     datatype: long
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: parentSourceId
     "@id": "#Source.parentSourceId"
     datatype: long
     description: Unique ID of parent source
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: x
     "@id": "#Source.x"
     datatype: double
     description: Centroid from Sdss Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: y
     "@id": "#Source.y"
     datatype: double
     description: Centroid from Sdss Centroid algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: pixel
   - name: xErr
     "@id": "#Source.xErr"
     datatype: float
     description: 1-sigma uncertainty on x position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: yErr
     "@id": "#Source.yErr"
     datatype: float
     description: 1-sigma uncertainty on y position
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: ra
     "@id": "#Source.ra"
     datatype: double
     description: Position in right ascension.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
   - name: dec
     "@id": "#Source.dec"
     datatype: double
     description: Position in declination.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: raErr
     "@id": "#Source.raErr"
     datatype: float
     description: Error in right ascension.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: decErr
     "@id": "#Source.decErr"
     datatype: float
     description: Error in declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: ra_dec_Cov
     "@id": "#Source.ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: decl
     "@id": "#Source.decl"
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: calibFlux
     "@id": "#Source.calibFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: calibFluxErr
     "@id": "#Source.calibFluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux
     "@id": "#Source.ap03Flux"
     datatype: double
     description: Flux within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03FluxErr
     "@id": "#Source.ap03FluxErr"
     datatype: double
     description: Flux uncertainty within 3.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap03Flux_flag
     "@id": "#Source.ap03Flux_flag"
@@ -7312,13 +6606,11 @@ tables:
     "@id": "#Source.ap06Flux"
     datatype: double
     description: Flux within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06FluxErr
     "@id": "#Source.ap06FluxErr"
     datatype: double
     description: Flux uncertainty within 6.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap06Flux_flag
     "@id": "#Source.ap06Flux_flag"
@@ -7330,13 +6622,11 @@ tables:
     "@id": "#Source.ap09Flux"
     datatype: double
     description: Flux within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09FluxErr
     "@id": "#Source.ap09FluxErr"
     datatype: double
     description: Flux uncertainty within 9.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap09Flux_flag
     "@id": "#Source.ap09Flux_flag"
@@ -7348,13 +6638,11 @@ tables:
     "@id": "#Source.ap12Flux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12FluxErr
     "@id": "#Source.ap12FluxErr"
     datatype: double
     description: Flux uncertainty within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap12Flux_flag
     "@id": "#Source.ap12Flux_flag"
@@ -7366,13 +6654,11 @@ tables:
     "@id": "#Source.ap17Flux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17FluxErr
     "@id": "#Source.ap17FluxErr"
     datatype: double
     description: Flux uncertainty within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap17Flux_flag
     "@id": "#Source.ap17Flux_flag"
@@ -7384,13 +6670,11 @@ tables:
     "@id": "#Source.ap25Flux"
     datatype: double
     description: Flux within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25FluxErr
     "@id": "#Source.ap25FluxErr"
     datatype: double
     description: Flux uncertainty within 25.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap25Flux_flag
     "@id": "#Source.ap25Flux_flag"
@@ -7402,13 +6686,11 @@ tables:
     "@id": "#Source.ap35Flux"
     datatype: double
     description: Flux within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35FluxErr
     "@id": "#Source.ap35FluxErr"
     datatype: double
     description: Flux uncertainty within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap35Flux_flag
     "@id": "#Source.ap35Flux_flag"
@@ -7420,13 +6702,11 @@ tables:
     "@id": "#Source.ap50Flux"
     datatype: double
     description: Flux within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50FluxErr
     "@id": "#Source.ap50FluxErr"
     datatype: double
     description: Flux uncertainty within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap50Flux_flag
     "@id": "#Source.ap50Flux_flag"
@@ -7438,13 +6718,11 @@ tables:
     "@id": "#Source.ap70Flux"
     datatype: double
     description: Flux within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70FluxErr
     "@id": "#Source.ap70FluxErr"
     datatype: double
     description: Flux uncertainty within 70.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ap70Flux_flag
     "@id": "#Source.ap70Flux_flag"
@@ -7456,109 +6734,91 @@ tables:
     "@id": "#Source.sky"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: skyErr
     "@id": "#Source.skyErr"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFlux
     "@id": "#Source.psfFlux"
     datatype: double
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#Source.psfFluxErr"
     datatype: double
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: ixx
     "@id": "#Source.ixx"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyy
     "@id": "#Source.iyy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixy
     "@id": "#Source.ixy"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixxPSF
     "@id": "#Source.ixxPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyyPSF
     "@id": "#Source.iyyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixyPSF
     "@id": "#Source.ixyPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixxDebiasedPSF
     "@id": "#Source.ixxDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: iyyDebiasedPSF
     "@id": "#Source.iyyDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: ixyDebiasedPSF
     "@id": "#Source.ixyDebiasedPSF"
     datatype: double
     description: HSM moments
-    mysql:datatype: DOUBLE
     fits:tunit: pixel**2
   - name: gaussianFlux
     "@id": "#Source.gaussianFlux"
     datatype: double
     description: Flux from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: gaussianFluxErr
     "@id": "#Source.gaussianFluxErr"
     datatype: double
     description: Flux uncertainty from Gaussian Flux algorithm
-    mysql:datatype: DOUBLE
     fits:tunit: nJy
   - name: extendedness
     "@id": "#Source.extendedness"
     datatype: double
     description: Set to 1 for extended sources, 0 for point sources.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: sizeExtendedness
     "@id": "#Source.sizeExtendedness"
     datatype: double
     description: Moments-based measure of a source to be a galaxy.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib
     "@id": "#Source.localPhotoCalib"
     datatype: double
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localPhotoCalib_flag
     "@id": "#Source.localPhotoCalib_flag"
@@ -7570,7 +6830,6 @@ tables:
     "@id": "#Source.localPhotoCalibErr"
     datatype: double
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_flag
     "@id": "#Source.localWcs_flag"
@@ -7582,31 +6841,26 @@ tables:
     "@id": "#Source.localWcs_CDMatrix_2_1"
     datatype: double
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_1
     "@id": "#Source.localWcs_CDMatrix_1_1"
     datatype: double
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_1_2
     "@id": "#Source.localWcs_CDMatrix_1_2"
     datatype: double
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localWcs_CDMatrix_2_2
     "@id": "#Source.localWcs_CDMatrix_2_2"
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_abs
     "@id": "#Source.blendedness_abs"
     datatype: double
     description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: blendedness_flag
     "@id": "#Source.blendedness_flag"
@@ -7648,13 +6902,11 @@ tables:
     "@id": "#Source.apFlux_12_0_instFlux"
     datatype: double
     description: Flux within 12.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_12_0_instFluxErr
     "@id": "#Source.apFlux_12_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_flag
     "@id": "#Source.apFlux_17_0_flag"
@@ -7666,13 +6918,11 @@ tables:
     "@id": "#Source.apFlux_17_0_instFlux"
     datatype: double
     description: Flux within 17.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_17_0_instFluxErr
     "@id": "#Source.apFlux_17_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_35_0_flag
     "@id": "#Source.apFlux_35_0_flag"
@@ -7684,13 +6934,11 @@ tables:
     "@id": "#Source.apFlux_35_0_instFlux"
     datatype: double
     description: Flux within 35.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_35_0_instFluxErr
     "@id": "#Source.apFlux_35_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_50_0_flag
     "@id": "#Source.apFlux_50_0_flag"
@@ -7702,13 +6950,11 @@ tables:
     "@id": "#Source.apFlux_50_0_instFlux"
     datatype: double
     description: Flux within 50.0-pixel aperture
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: apFlux_50_0_instFluxErr
     "@id": "#Source.apFlux_50_0_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: extendedness_flag
     "@id": "#Source.extendedness_flag"
@@ -7726,7 +6972,6 @@ tables:
     "@id": "#Source.footprintArea_value"
     datatype: int
     description: Number of pixels in the sources detection footprint.
-    mysql:datatype: INTEGER
     fits:tunit: pixel
   - name: jacobian_flag
     "@id": "#Source.jacobian_flag"
@@ -7738,19 +6983,16 @@ tables:
     "@id": "#Source.jacobian_value"
     datatype: double
     description: Jacobian correction
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: localBackground_instFlux
     "@id": "#Source.localBackground_instFlux"
     datatype: double
     description: Background in annulus around source
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_instFluxErr
     "@id": "#Source.localBackground_instFluxErr"
     datatype: double
     description: 1-sigma flux uncertainty
-    mysql:datatype: DOUBLE
     fits:tunit: count
   - name: localBackground_flag
     "@id": "#Source.localBackground_flag"
@@ -7852,19 +7094,16 @@ tables:
     "@id": "#Source.psfFlux_apCorr"
     datatype: double
     description: Aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_apCorrErr
     "@id": "#Source.psfFlux_apCorrErr"
     datatype: double
     description: Standard deviation of aperture correction applied to base_PsfFlux
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: psfFlux_area
     "@id": "#Source.psfFlux_area"
     datatype: float
     description: Effective area of PSF
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: psfFlux_flag
     "@id": "#Source.psfFlux_flag"
@@ -7954,7 +7193,6 @@ tables:
     "@id": "#Source.variance_value"
     datatype: double
     description: Variance at object position
-    mysql:datatype: DOUBLE
     fits:tunit:
   - name: calib_astrometry_used
     "@id": "#Source.calib_astrometry_used"
@@ -8020,7 +7258,6 @@ tables:
     "@id": "#Source.deblend_nChild"
     datatype: int
     description: Number of children this object has (defaults to 0)
-    mysql:datatype: INTEGER
     fits:tunit:
   - name: deblend_parentTooBig
     "@id": "#Source.deblend_parentTooBig"
@@ -8165,7 +7402,6 @@ tables:
     "@id": "#Source.detector"
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
     fits:tunit:
   - name: physical_filter
     "@id": "#Source.physical_filter"
@@ -8178,7 +7414,6 @@ tables:
     "@id": "#Source.visit"
     datatype: long
     description: ID of visit, the identifier for an observation within a sequence of observations.
-    mysql:datatype: BIGINT
     fits:tunit:
 - name: ForcedSource
   "@id": "#ForcedSource"
@@ -8189,45 +7424,38 @@ tables:
   - name: forcedSourceId
     "@id": "#ForcedSource.forcedSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of forced source. Primary Key.
     fits:tunit:
   - name: objectId
     "@id": "#ForcedSource.objectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique Object ID. Primary Key of the Object Table
     fits:tunit:
   - name: parentObjectId
     "@id": "#ForcedSource.parentObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
     fits:tunit:
   - name: coord_ra
     "@id": "#ForcedSource.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: coord_dec
     "@id": "#ForcedSource.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: tract
     "@id": "#ForcedSource.tract"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
   - name: patch
     "@id": "#ForcedSource.patch"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap patch ID
     fits:tunit:
   - name: band
@@ -8240,7 +7468,6 @@ tables:
   - name: ccdVisitId
     "@id": "#ForcedSource.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
     fits:tunit:
   - name: detect_isPatchInner
@@ -8264,19 +7491,16 @@ tables:
   - name: localBackground_instFluxErr
     "@id": "#ForcedSource.localBackground_instFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 1-sigma flux uncertainty
     fits:tunit: count
   - name: localBackground_instFlux
     "@id": "#ForcedSource.localBackground_instFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Background in annulus around source
     fits:tunit: count
   - name: localPhotoCalibErr
     "@id": "#ForcedSource.localPhotoCalibErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
   - name: localPhotoCalib_flag
@@ -8288,31 +7512,26 @@ tables:
   - name: localPhotoCalib
     "@id": "#ForcedSource.localPhotoCalib"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
   - name: localWcs_CDMatrix_1_1
     "@id": "#ForcedSource.localWcs_CDMatrix_1_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_1_2
     "@id": "#ForcedSource.localWcs_CDMatrix_1_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_2_1
     "@id": "#ForcedSource.localWcs_CDMatrix_2_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_2_2
     "@id": "#ForcedSource.localWcs_CDMatrix_2_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_flag
@@ -8396,7 +7615,6 @@ tables:
   - name: psfDiffFluxErr
     "@id": "#ForcedSource.psfDiffFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
   - name: psfDiffFlux_flag
@@ -8408,13 +7626,11 @@ tables:
   - name: psfDiffFlux
     "@id": "#ForcedSource.psfDiffFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#ForcedSource.psfFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
   - name: psfFlux_flag
@@ -8426,7 +7642,6 @@ tables:
   - name: psfFlux
     "@id": "#ForcedSource.psfFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
 - name: DiaObject
@@ -8436,692 +7651,555 @@ tables:
   - name: diaObjectId
     "@id": "#DiaObject.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique identifier of this DiaObject.
   - name: ra
     "@id": "#DiaObject.ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Right Ascension coordinate of the position of the diaObject at time radecMjdTai.
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: dec
     "@id": "#DiaObject.dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Declination coordinate of the position of the diaObject at time radecMjdTai.
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: radecMjdTai
     "@id": "#DiaObject.radecMjdTai"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Time at which the object was at a position ra/dec, expressed
       as Modified Julian Date, International Atomic Time.
   - name: nDiaSources
     "@id": "#DiaObject.nDiaSources"
     datatype: long
-    mysql:datatype: BIGINT
     description: Number of diaSources associated with this diaObject.
   - name: g_psfFluxChi2
     "@id": "#DiaObject.g_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of g_psfFlux around g_psfFluxMean
   - name: g_psfFluxErrMean
     "@id": "#DiaObject.g_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: g_psfFluxLinearIntercept
     "@id": "#DiaObject.g_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: g_psfFluxLinearSlope
     "@id": "#DiaObject.g_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: g_psfFluxMAD
     "@id": "#DiaObject.g_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: g_psfFluxMax
     "@id": "#DiaObject.g_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: g_psfFluxMaxSlope
     "@id": "#DiaObject.g_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: g_psfFluxMean
     "@id": "#DiaObject.g_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: g_psfFluxMeanErr
     "@id": "#DiaObject.g_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: g_psfFluxMin
     "@id": "#DiaObject.g_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: g_psfFluxNdata
     "@id": "#DiaObject.g_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute g_psfFluxChi2
   - name: g_psfFluxPercentile05
     "@id": "#DiaObject.g_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: g_psfFluxPercentile25
     "@id": "#DiaObject.g_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: g_psfFluxPercentile50
     "@id": "#DiaObject.g_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: g_psfFluxPercentile75
     "@id": "#DiaObject.g_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: g_psfFluxPercentile95
     "@id": "#DiaObject.g_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: g_psfFluxSigma
     "@id": "#DiaObject.g_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of g_psfFlux
   - name: g_psfFluxSkew
     "@id": "#DiaObject.g_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: g_psfFluxStetsonJ
     "@id": "#DiaObject.g_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: g_scienceFluxMean
     "@id": "#DiaObject.g_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: g_scienceFluxMeanErr
     "@id": "#DiaObject.g_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on g_scienceFluxMean
   - name: g_scienceFluxSigma
     "@id": "#DiaObject.g_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: i_psfFluxChi2
     "@id": "#DiaObject.i_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of i_psfFlux around i_psfFluxMean
   - name: i_psfFluxErrMean
     "@id": "#DiaObject.i_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: i_psfFluxLinearIntercept
     "@id": "#DiaObject.i_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: i_psfFluxLinearSlope
     "@id": "#DiaObject.i_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: i_psfFluxMAD
     "@id": "#DiaObject.i_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: i_psfFluxMax
     "@id": "#DiaObject.i_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: i_psfFluxMaxSlope
     "@id": "#DiaObject.i_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: i_psfFluxMean
     "@id": "#DiaObject.i_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: i_psfFluxMeanErr
     "@id": "#DiaObject.i_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: i_psfFluxMin
     "@id": "#DiaObject.i_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: i_psfFluxNdata
     "@id": "#DiaObject.i_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute i_psfFluxChi2
   - name: i_psfFluxPercentile05
     "@id": "#DiaObject.i_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: i_psfFluxPercentile25
     "@id": "#DiaObject.i_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: i_psfFluxPercentile50
     "@id": "#DiaObject.i_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: i_psfFluxPercentile75
     "@id": "#DiaObject.i_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: i_psfFluxPercentile95
     "@id": "#DiaObject.i_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: i_psfFluxSigma
     "@id": "#DiaObject.i_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of i_psfFlux
   - name: i_psfFluxSkew
     "@id": "#DiaObject.i_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: i_psfFluxStetsonJ
     "@id": "#DiaObject.i_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: i_scienceFluxMean
     "@id": "#DiaObject.i_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: i_scienceFluxMeanErr
     "@id": "#DiaObject.i_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on i_scienceFluxMean
   - name: i_scienceFluxSigma
     "@id": "#DiaObject.i_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: r_psfFluxChi2
     "@id": "#DiaObject.r_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of r_psfFlux around r_psfFluxMean
   - name: r_psfFluxErrMean
     "@id": "#DiaObject.r_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: r_psfFluxLinearIntercept
     "@id": "#DiaObject.r_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: r_psfFluxLinearSlope
     "@id": "#DiaObject.r_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: r_psfFluxMAD
     "@id": "#DiaObject.r_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: r_psfFluxMax
     "@id": "#DiaObject.r_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: r_psfFluxMaxSlope
     "@id": "#DiaObject.r_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: r_psfFluxMean
     "@id": "#DiaObject.r_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: r_psfFluxMeanErr
     "@id": "#DiaObject.r_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: r_psfFluxMin
     "@id": "#DiaObject.r_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: r_psfFluxNdata
     "@id": "#DiaObject.r_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute r_psfFluxChi2
   - name: r_psfFluxPercentile05
     "@id": "#DiaObject.r_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: r_psfFluxPercentile25
     "@id": "#DiaObject.r_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: r_psfFluxPercentile50
     "@id": "#DiaObject.r_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: r_psfFluxPercentile75
     "@id": "#DiaObject.r_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: r_psfFluxPercentile95
     "@id": "#DiaObject.r_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: r_psfFluxSigma
     "@id": "#DiaObject.r_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of r_psfFlux
   - name: r_psfFluxSkew
     "@id": "#DiaObject.r_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: r_psfFluxStetsonJ
     "@id": "#DiaObject.r_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: r_scienceFluxMean
     "@id": "#DiaObject.r_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: r_scienceFluxMeanErr
     "@id": "#DiaObject.r_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on r_scienceFluxMean
   - name: r_scienceFluxSigma
     "@id": "#DiaObject.r_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: u_psfFluxChi2
     "@id": "#DiaObject.u_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of u_psfFlux around u_psfFluxMean
   - name: u_psfFluxErrMean
     "@id": "#DiaObject.u_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: u_psfFluxLinearIntercept
     "@id": "#DiaObject.u_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: u_psfFluxLinearSlope
     "@id": "#DiaObject.u_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: u_psfFluxMAD
     "@id": "#DiaObject.u_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: u_psfFluxMax
     "@id": "#DiaObject.u_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: u_psfFluxMaxSlope
     "@id": "#DiaObject.u_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: u_psfFluxMean
     "@id": "#DiaObject.u_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: u_psfFluxMeanErr
     "@id": "#DiaObject.u_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: u_psfFluxMin
     "@id": "#DiaObject.u_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: u_psfFluxNdata
     "@id": "#DiaObject.u_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute u_psfFluxChi2
   - name: u_psfFluxPercentile05
     "@id": "#DiaObject.u_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: u_psfFluxPercentile25
     "@id": "#DiaObject.u_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: u_psfFluxPercentile50
     "@id": "#DiaObject.u_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: u_psfFluxPercentile75
     "@id": "#DiaObject.u_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: u_psfFluxPercentile95
     "@id": "#DiaObject.u_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: u_psfFluxSigma
     "@id": "#DiaObject.u_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of u_psfFlux
   - name: u_psfFluxSkew
     "@id": "#DiaObject.u_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: u_psfFluxStetsonJ
     "@id": "#DiaObject.u_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: u_scienceFluxMean
     "@id": "#DiaObject.u_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: u_scienceFluxMeanErr
     "@id": "#DiaObject.u_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on u_scienceFluxMean
   - name: u_scienceFluxSigma
     "@id": "#DiaObject.u_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: y_psfFluxChi2
     "@id": "#DiaObject.y_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of y_psfFlux around y_psfFluxMean
   - name: y_psfFluxErrMean
     "@id": "#DiaObject.y_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: y_psfFluxLinearIntercept
     "@id": "#DiaObject.y_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: y_psfFluxLinearSlope
     "@id": "#DiaObject.y_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: y_psfFluxMAD
     "@id": "#DiaObject.y_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: y_psfFluxMax
     "@id": "#DiaObject.y_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: y_psfFluxMaxSlope
     "@id": "#DiaObject.y_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: y_psfFluxMean
     "@id": "#DiaObject.y_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: y_psfFluxMeanErr
     "@id": "#DiaObject.y_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: y_psfFluxMin
     "@id": "#DiaObject.y_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: y_psfFluxNdata
     "@id": "#DiaObject.y_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute y_psfFluxChi2
   - name: y_psfFluxPercentile05
     "@id": "#DiaObject.y_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: y_psfFluxPercentile25
     "@id": "#DiaObject.y_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: y_psfFluxPercentile50
     "@id": "#DiaObject.y_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: y_psfFluxPercentile75
     "@id": "#DiaObject.y_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: y_psfFluxPercentile95
     "@id": "#DiaObject.y_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: y_psfFluxSigma
     "@id": "#DiaObject.y_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of y_psfFlux
   - name: y_psfFluxSkew
     "@id": "#DiaObject.y_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: y_psfFluxStetsonJ
     "@id": "#DiaObject.y_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: y_scienceFluxMean
     "@id": "#DiaObject.y_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: y_scienceFluxMeanErr
     "@id": "#DiaObject.y_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on y_scienceFluxMean
   - name: y_scienceFluxSigma
     "@id": "#DiaObject.y_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: z_psfFluxChi2
     "@id": "#DiaObject.z_psfFluxChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi^2 statistic for the scatter of z_psfFlux around z_psfFluxMean
   - name: z_psfFluxErrMean
     "@id": "#DiaObject.z_psfFluxErrMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Mean of the diaSource PSF flux errors
   - name: z_psfFluxLinearIntercept
     "@id": "#DiaObject.z_psfFluxLinearIntercept"
     datatype: double
-    mysql:datatype: DOUBLE
     description: y-intercept of a linear model fit to diaSource PSF flux vs time
   - name: z_psfFluxLinearSlope
     "@id": "#DiaObject.z_psfFluxLinearSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Slope of a linear model fit to diaSource PSF flux vs time
   - name: z_psfFluxMAD
     "@id": "#DiaObject.z_psfFluxMAD"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median absolute deviation of diaSource PSF flux. Does not include scale factor for comparison to sigma
   - name: z_psfFluxMax
     "@id": "#DiaObject.z_psfFluxMax"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum diaSource PSF flux
   - name: z_psfFluxMaxSlope
     "@id": "#DiaObject.z_psfFluxMaxSlope"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Maximum ratio of time ordered deltaFlux / deltaTime
   - name: z_psfFluxMean
     "@id": "#DiaObject.z_psfFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of diaSource PSF flux
   - name: z_psfFluxMeanErr
     "@id": "#DiaObject.z_psfFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on the weighted mean of diaSource PSF flux
   - name: z_psfFluxMin
     "@id": "#DiaObject.z_psfFluxMin"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Minimum diaSource PSF flux
   - name: z_psfFluxNdata
     "@id": "#DiaObject.z_psfFluxNdata"
     datatype: double
-    mysql:datatype: DOUBLE
     description: The number of data points used to compute z_psfFluxChi2
   - name: z_psfFluxPercentile05
     "@id": "#DiaObject.z_psfFluxPercentile05"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 5th percentile diaSource PSF flux
   - name: z_psfFluxPercentile25
     "@id": "#DiaObject.z_psfFluxPercentile25"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 10th percentile diaSource PSF flux
   - name: z_psfFluxPercentile50
     "@id": "#DiaObject.z_psfFluxPercentile50"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Median diaSource PSF flux
   - name: z_psfFluxPercentile75
     "@id": "#DiaObject.z_psfFluxPercentile75"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 75th percentile diaSource PSF flux
   - name: z_psfFluxPercentile95
     "@id": "#DiaObject.z_psfFluxPercentile95"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 95th percentile diaSource PSF flux
   - name: z_psfFluxSigma
     "@id": "#DiaObject.z_psfFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the distribution of z_psfFlux
   - name: z_psfFluxSkew
     "@id": "#DiaObject.z_psfFluxSkew"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Skew of diaSource PSF flux
   - name: z_psfFluxStetsonJ
     "@id": "#DiaObject.z_psfFluxStetsonJ"
     datatype: double
-    mysql:datatype: DOUBLE
     description: StetsonJ statistic of diaSource PSF flux
   - name: z_scienceFluxMean
     "@id": "#DiaObject.z_scienceFluxMean"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Weighted mean of the PSF flux forced photometered at the diaSource position on the calibrated image
   - name: z_scienceFluxMeanErr
     "@id": "#DiaObject.z_scienceFluxMeanErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard error on z_scienceFluxMean
   - name: z_scienceFluxSigma
     "@id": "#DiaObject.z_scienceFluxSigma"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Standard deviation of the PSF flux forced photometered at the diaSource position on the calibrated image
 - name: DiaSource
   "@id": "#DiaSource"
@@ -9130,13 +8208,11 @@ tables:
   - name: apFlux
     "@id": "#DiaSource.apFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux in a 12 pixel radius aperture on the difference image.
     fits:tunit: nJy
   - name: apFluxErr
     "@id": "#DiaSource.apFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Estimated uncertainty of apFlux.
     fits:tunit: nJy
   - name: apFlux_flag
@@ -9154,13 +8230,11 @@ tables:
   - name: bboxSize
     "@id": "#DiaSource.bboxSize"
     datatype: long
-    mysql:datatype: BIGINT
     description: Bounding box of diaSource footprint.
     fits:tunit:
   - name: ccdVisitId
     "@id": "#DiaSource.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
     fits:tunit:
   - name: centroid_flag
@@ -9172,21 +8246,18 @@ tables:
   - name: coord_dec
     "@id": "#DiaSource.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of centroid used for database indexing.
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: coord_ra
     "@id": "#DiaSource.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of centroid used for database indexing.
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: dec
     "@id": "#DiaSource.dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Position in declination.
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
@@ -9194,67 +8265,56 @@ tables:
     "@id": "#DiaSource.decErr"
     datatype: float
     description: Error in declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.dec
   - name: diaObjectId
     "@id": "#DiaSource.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Id of the DiaObject that this DiaSource was associated with.
     fits:tunit:
   - name: diaSourceId
     "@id": "#DiaSource.diaSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique identifier of this DiaSource.
     fits:tunit:
   - name: dipoleAngle
     "@id": "#DiaSource.dipoleAngle"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Dipole orientation
     fits:tunit: deg
   - name: dipoleChi2
     "@id": "#DiaSource.dipoleChi2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Chi2 per degree of freedom of dipole fit.
     fits:tunit:
   - name: dipoleNdata
     "@id": "#DiaSource.dipoleNdata"
     datatype: long
-    mysql:datatype: BIGINT
     description: Number of data points in the dipole fit
     fits:tunit:
   - name: dipoleFluxDiff
     "@id": "#DiaSource.dipoleFluxDiff"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux counts, positive lobe.
     fits:tunit: nJy
   - name: dipoleFluxDiffErr
     "@id": "#DiaSource.dipoleFluxDiffErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux uncertainty counts, positive lobe.
     fits:tunit: nJy
   - name: dipoleLength
     "@id": "#DiaSource.dipoleLength"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Pixel separation between positive and negative lobes of dipole.
     fits:tunit: pixel
   - name: dipoleMeanFlux
     "@id": "#DiaSource.dipoleMeanFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux counts, positive lobe.
     fits:tunit: count
   - name: dipoleMeanFluxErr
     "@id": "#DiaSource.dipoleMeanFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Raw flux uncertainty counts, positive lobe.
     fits:tunit: count
   - name: band
@@ -9298,50 +8358,42 @@ tables:
   - name: ixx
     "@id": "#DiaSource.ixx"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
     fits:tunit: arcsec**2
   - name: ixxPSF
     "@id": "#DiaSource.ixxPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
     fits:tunit: arcsec**2
   - name: ixy
     "@id": "#DiaSource.ixy"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
     fits:tunit: arcsec**2
   - name: ixyPSF
     "@id": "#DiaSource.ixyPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
     fits:tunit: arcsec**2
   - name: iyy
     "@id": "#DiaSource.iyy"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Elliptical Gaussian adaptive moments.
     fits:tunit: arcsec**2
   - name: iyyPSF
     "@id": "#DiaSource.iyyPSF"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Adaptive moments of the PSF model at the object position.
     fits:tunit: arcsec**2
   - name: midpointMjdTai
     "@id": "#DiaSource.midpointMjdTai"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Effective mid-exposure time for this diaSource, expressed as
       Modified Julian Date, International Atomic Time.
     fits:tunit:
   - name: parentDiaSourceId
     "@id": "#DiaSource.parentDiaSourceId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of parent source.
     fits:tunit:
   - name: pixelFlags
@@ -9455,13 +8507,11 @@ tables:
   - name: psfFlux
     "@id": "#DiaSource.psfFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of PSF model.
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#DiaSource.psfFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux uncertainty derived from linear least-squares fit of PSF model.
     fits:tunit: nJy
   - name: psfFlux_flag
@@ -9485,7 +8535,6 @@ tables:
   - name: ra
     "@id": "#DiaSource.ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Position in right ascension.
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
@@ -9493,14 +8542,12 @@ tables:
     "@id": "#DiaSource.raErr"
     datatype: float
     description: Error in right ascension.
-    mysql:datatype: FLOAT
     fits:tunit: deg
     ivoa:ucd: stat.error;pos.eq.ra
   - name: ra_dec_Cov
     "@id": "#DiaSource.ra_dec_Cov"
     datatype: float
     description: Covariance between right ascension and declination.
-    mysql:datatype: FLOAT
     fits:tunit: deg**2
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
   - name: shape_flag
@@ -9530,92 +8577,77 @@ tables:
   - name: snr
     "@id": "#DiaSource.snr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Ratio of apFlux/apFluxErr
     fits:tunit:
   - name: ssObjectId
     "@id": "#DiaSource.ssObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Id of the ssObject this source was associated with, if any. If not, it is set to 0
     fits:tunit:
   - name: scienceFlux
     "@id": "#DiaSource.scienceFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Forced PSF flux measured on the direct image.
     fits:tunit: nJy
   - name: scienceFluxErr
     "@id": "#DiaSource.scienceFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Forced PSF flux uncertainty measured on the direct image.
     fits:tunit: nJy
   - name: x
     "@id": "#DiaSource.x"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Unweighted first moment centroid, overall centroid
     fits:tunit: pixel
   - name: xErr
     "@id": "#DiaSource.xErr"
     datatype: float
-    mysql:datatype: FLOAT
     description: 1-sigma uncertainty on x position
     fits:tunit: pixel
   - name: y
     "@id": "#DiaSource.y"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Unweighted first moment centroid, overall centroid
     fits:tunit: pixel
   - name: yErr
     "@id": "#DiaSource.yErr"
     datatype: float
-    mysql:datatype: FLOAT
     description: 1-sigma uncertainty on y position
     fits:tunit: pixel
   - name: psfChi2
     "@id": "#DiaSource.psfChi2"
     datatype: float
-    mysql:datatype: FLOAT
     description: Chi^2 statistic of the point source model fit.
     fits:tunit:
   - name: psfNdata
     "@id": "#DiaSource.psfNdata"
     datatype: int
-    mysql:datatype: INTEGER
     description: Number of pixels that were included in the PSF fit.
     fits:tunit: pixel
   - name: trailAngle
     "@id": "#DiaSource.trailAngle"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Angle measured from +x-axis.
     fits:tunit:
   - name: trailDec
     "@id": "#DiaSource.trailDec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Trail centroid declination.
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec
   - name: trailFlux
     "@id": "#DiaSource.trailFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Trailed source flux.
     fits:tunit: nJy
   - name: trailLength
     "@id": "#DiaSource.trailLength"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Trail length.
     fits:tunit: pixel
   - name: trailRa
     "@id": "#DiaSource.trailRa"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Trail centroid right ascension.
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra
@@ -9626,7 +8658,6 @@ tables:
       and image characterization, as well as the information on the Telescope and
       Camera system (e.g., ghost maps, defect maps, etc.).
     fits:tunit:
-    mysql:datatype: FLOAT
   - name: ext_trailedSources_Naive_flag_edge
     "@id": "#DiaSource.ext_trailedSources_Naive_flag_edge"
     datatype: boolean
@@ -9646,57 +8677,48 @@ tables:
   - name: ccdVisitId
     "@id": "#ForcedSourceOnDiaObject.ccdVisitId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of CCD and visit where this source was detected and measured. Primary Key of the CcdVisit Table.
     fits:tunit:
   - name: coord_dec
     "@id": "#ForcedSourceOnDiaObject.coord_dec"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Declination of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.dec;meta.main
   - name: coord_ra
     "@id": "#ForcedSourceOnDiaObject.coord_ra"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
     fits:tunit: deg
     ivoa:ucd: pos.eq.ra;meta.main
   - name: diaObjectId
     "@id": "#ForcedSourceOnDiaObject.diaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Id of the DiaObject that this DiaForcedSource was associated with.
     fits:tunit:
   - name: forcedSourceOnDiaObjectId
     "@id": "#ForcedSourceOnDiaObject.forcedSourceOnDiaObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ID of forced source. Primary Key.
     fits:tunit:
   - name: localBackground_instFlux
     "@id": "#ForcedSourceOnDiaObject.localBackground_instFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Background in annulus around source
     fits:tunit: count
   - name: localBackground_instFluxErr
     "@id": "#ForcedSourceOnDiaObject.localBackground_instFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: 1-sigma flux uncertainty
     fits:tunit: count
   - name: localPhotoCalib
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalib"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
   - name: localPhotoCalibErr
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalibErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
     fits:tunit:
   - name: localPhotoCalib_flag
@@ -9708,25 +8730,21 @@ tables:
   - name: localWcs_CDMatrix_1_1
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_1_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_1_2
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_1_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_2_1
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_2_1"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_CDMatrix_2_2
     "@id": "#ForcedSourceOnDiaObject.localWcs_CDMatrix_2_2"
     datatype: double
-    mysql:datatype: DOUBLE
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
   - name: localWcs_flag
@@ -9738,13 +8756,11 @@ tables:
   - name: parentObjectId
     "@id": "#ForcedSourceOnDiaObject.parentObjectId"
     datatype: long
-    mysql:datatype: BIGINT
     description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
     fits:tunit:
   - name: patch
     "@id": "#ForcedSourceOnDiaObject.patch"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap patch ID
     fits:tunit:
   - name: pixelFlags_bad
@@ -9822,13 +8838,11 @@ tables:
   - name: psfDiffFlux
     "@id": "#ForcedSourceOnDiaObject.psfDiffFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
   - name: psfDiffFluxErr
     "@id": "#ForcedSourceOnDiaObject.psfDiffFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
     fits:tunit: nJy
   - name: psfDiffFlux_flag
@@ -9840,13 +8854,11 @@ tables:
   - name: psfFlux
     "@id": "#ForcedSourceOnDiaObject.psfFlux"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
   - name: psfFluxErr
     "@id": "#ForcedSourceOnDiaObject.psfFluxErr"
     datatype: double
-    mysql:datatype: DOUBLE
     description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
     fits:tunit: nJy
   - name: psfFlux_flag
@@ -9858,7 +8870,6 @@ tables:
   - name: tract
     "@id": "#ForcedSourceOnDiaObject.tract"
     datatype: long
-    mysql:datatype: BIGINT
     description: Skymap tract ID
     fits:tunit:
 - name: MatchesTruth
@@ -9868,7 +8879,6 @@ tables:
   - name: index
     '@id': '#MatchesTruth.index'
     datatype: long
-    mysql:datatype: BIGINT
     description: Incrementing (implicit) row index
   - name: match_candidate
     '@id': '#MatchesTruth.match_candidate'
@@ -9878,22 +8888,18 @@ tables:
   - name: match_row
     '@id': '#MatchesTruth.match_row'
     datatype: long
-    mysql:datatype: BIGINT
     description: Index of matched objectTable_tract table row, if any
   - name: match_count
     '@id': '#MatchesTruth.match_count'
     datatype: int
-    mysql:datatype: INTEGER
     description: Number of candidate object matches within match radius
   - name: match_chisq
     '@id': '#MatchesTruth.match_chisq'
     datatype: double
-    mysql:datatype: DOUBLE
     description: The chi-squared value of the (best) match
   - name: match_n_chisq_finite
     '@id': '#MatchesTruth.match_n_chisq_finite'
     datatype: int
-    mysql:datatype: INTEGER
     description: The number of finite columns used to compute the match chisq
   - name: id
     '@id': '#MatchesTruth.id'
@@ -9904,12 +8910,10 @@ tables:
   - name: truth_type
     '@id': '#MatchesTruth.truth_type'
     datatype: long
-    mysql:datatype: BIGINT
     description: Truth object type (1/2/3 = galaxy/star/SN)
   - name: match_objectId
     '@id': '#MatchesTruth.match_objectId'
     datatype: long
-    mysql:datatype: BIGINT
     description: objectId of matched objectTable_tract object, if any
 - name: MatchesObject
   '@id': '#MatchesObject'
@@ -9918,7 +8922,6 @@ tables:
   - name: index
     '@id': '#MatchesObject.index'
     datatype: long
-    mysql:datatype: BIGINT
     description: Incrementing (implicit) row index
   - name: match_candidate
     '@id': '#MatchesObject.match_candidate'
@@ -9928,7 +8931,6 @@ tables:
   - name: match_row
     '@id': '#MatchesObject.match_row'
     datatype: long
-    mysql:datatype: BIGINT
     description: Index of matched truth_summary table row, if any
   - name: match_id
     '@id': '#MatchesObject.match_id'
@@ -9939,12 +8941,10 @@ tables:
   - name: match_truth_type
     '@id': '#MatchesObject.match_truth_type'
     datatype: long
-    mysql:datatype: BIGINT
     description: Type of matched truth_summary source, if any (1/2/3 = galaxy/star/SN)
   - name: objectId
     '@id': '#MatchesObject.objectId'
     datatype: long
-    mysql:datatype: BIGINT
     description: objectId of object
 - name: Visit
   '@id': '#Visit'
@@ -9977,37 +8977,31 @@ tables:
     '@id': '#Visit.ra'
     datatype: double
     description: Right Ascension of focal plane center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     '@id': '#Visit.dec'
     datatype: double
     description: Declination of focal plane center
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: decl
     '@id': '#Visit.decl'
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: skyRotation
     '@id': '#Visit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: azimuth
     '@id': '#Visit.azimuth'
     datatype: double
     description: Azimuth of focal plane center at the middle of the visit.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: altitude
     '@id': '#Visit.altitude'
     datatype: double
     description: Altitude of focal plane center at the middle of the visit.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: zenithDistance
     '@id': '#Visit.zenithDistance'
@@ -10025,7 +9019,6 @@ tables:
     '@id': '#Visit.expTime'
     datatype: double
     description: Spatially-averaged duration of visit, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: midpoint
     '@id': '#Visit.midpoint'
@@ -10040,7 +9033,6 @@ tables:
     datatype: double
     description: Midpoint time for visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: obsStart
     '@id': '#Visit.obsStart'
@@ -10054,7 +9046,6 @@ tables:
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
 - name: CcdVisit
   '@id': '#CcdVisit'
   description: Defines a single detector of a visit
@@ -10063,7 +9054,6 @@ tables:
     '@id': '#CcdVisit.ccdVisitId'
     datatype: long
     description: Primary key (unique identifier).
-    mysql:datatype: BIGINT
   - name: visitId
     '@id': '#CcdVisit.visitId'
     datatype: long
@@ -10090,55 +9080,46 @@ tables:
     '@id': '#CcdVisit.ra'
     datatype: double
     description: Right Ascension of Ccd center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: dec
     '@id': '#CcdVisit.dec'
     datatype: double
     description: Declination of Ccd center.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: decl
     '@id': '#CcdVisit.decl'
     datatype: double
     description: Deprecated duplicate of dec.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: zenithDistance
     '@id': '#CcdVisit.zenithDistance'
     datatype: float
     description: Zenith distance at observation mid-point.
-    mysql:datatype: FLOAT
     fits:tunit: deg
   - name: zeroPoint
     '@id': '#CcdVisit.zeroPoint'
     datatype: float
     description: Zero-point for the Ccd, estimated at Ccd center.
-    mysql:datatype: FLOAT
     fits:tunit: mag
   - name: psfSigma
     '@id': '#CcdVisit.psfSigma'
     datatype: float
     description: PSF model second-moments determinant radius (center of chip)
-    mysql:datatype: FLOAT
     fits:tunit: pixel
   - name: skyBg
     '@id': '#CcdVisit.skyBg'
     datatype: float
     description: Average sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: skyNoise
     '@id': '#CcdVisit.skyNoise'
     datatype: float
     description: RMS noise of the sky background.
-    mysql:datatype: FLOAT
     fits:tunit: adu
   - name: detector
     '@id': '#CcdVisit.detector'
     datatype: long
     description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-    mysql:datatype: BIGINT
   - name: seeing
     '@id': '#CcdVisit.seeing'
     datatype: double
@@ -10149,7 +9130,6 @@ tables:
     '@id': '#CcdVisit.skyRotation'
     datatype: double
     description: Sky rotation angle.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: midpoint
     '@id': '#CcdVisit.midpoint'
@@ -10162,13 +9142,11 @@ tables:
     datatype: double
     description: Midpoint of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: d
   - name: expTime
     '@id': '#CcdVisit.expTime'
     datatype: double
     description: Spatially-averaged duration of visit, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
@@ -10181,12 +9159,10 @@ tables:
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    mysql:datatype: DOUBLE
   - name: darkTime
     '@id': '#CcdVisit.darkTime'
     datatype: double
     description: Average dark current accumulation time, accurate to 10ms.
-    mysql:datatype: DOUBLE
     fits:tunit: s
   - name: xSize
     '@id': '#CcdVisit.xSize'
@@ -10204,49 +9180,41 @@ tables:
     '@id': '#CcdVisit.llcra'
     datatype: double
     description: Right Ascension of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: llcdec
     '@id': '#CcdVisit.llcdec'
     datatype: double
     description: Declination of lower left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcra
     '@id': '#CcdVisit.ulcra'
     datatype: double
     description: Right Ascension of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: ulcdec
     '@id': '#CcdVisit.ulcdec'
     datatype: double
     description: Declination of upper left corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcra
     '@id': '#CcdVisit.urcra'
     datatype: double
     description: Right Ascension of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: urcdec
     '@id': '#CcdVisit.urcdec'
     datatype: double
     description: Declination of upper right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcra
     '@id': '#CcdVisit.lrcra'
     datatype: double
     description: Right Ascension of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: lrcdec
     '@id': '#CcdVisit.lrcdec'
     datatype: double
     description: Declination of lower right corner.
-    mysql:datatype: DOUBLE
     fits:tunit: deg
   - name: astromOffsetMean
     '@id': '#CcdVisit.astromOffsetMean'


### PR DESCRIPTION
This removes the redundant `mysql:datatype` definitions from all schemas for numeric types, including the Felis types `double`, `float`, `int` and `long`. These correspond to `DOUBLE`, `FLOAT`, `INTEGER` and `BIGINT` in MySQL, respectively.

[This script](https://github.com/JeremyMcCormick/rubin_scripts/blob/b45558e21c4c16ba16506afa86eae389c7efd3c7/sdm_schemas/remove-redundant-numerics.awk) from @gpdf was used to perform the cleanup.

These changes should have no practical effect on any schema workflows, since the resultant SQL output for each datatype was the same (a criteria for making this change) and we do not currently generate any DDL for creating live MySQL databases from any these schemas.

@ctslater Made some suggestions for verifying these changes:

- [x] Make sure generated DDL is bitwise identical between the old and new versions of the schemas for MySQL 
https://github.com/lsst/sdm_schemas/pull/205#issuecomment-2067367375
- [x] Run the validation and confirm that there are no remaining numeric overrides 
https://github.com/lsst/sdm_schemas/pull/205#issuecomment-2067376383