### PR TITLE
DM-42935: Set the schema index using Felis command line argument

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
         # required dependencies for the tap-schema build.
         run: |
           python -m pip install --upgrade pip
-          pip install lsst-felis
+          pip install 'lsst-felis @ git+https://github.com/lsst/felis@main'
         working-directory: ./tap-schema
 
       - name: Log in to Docker Hub

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install lsst-felis
+          pip install 'lsst-felis @ git+https://github.com/lsst/felis@main'
 
       - name: Validate YAML files
         run: felis validate ./yml/*.yaml

--- a/tap-schema/build
+++ b/tap-schema/build
@@ -3,14 +3,14 @@ ENVIRONMENT="$1"
 GIT_TAG=`echo $GITHUB_REF | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'`
 shift
 
-./set_schema_index $@
-
 # Generate SQL files from Felis yaml files
 # Place the SQL files in the sql directory, which gets
 # copied into the docker image.
+schema_index=0
 for file in $@
 do
-    felis load-tap --dry-run --engine-url=postgresql+psycopg2:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
+    felis load-tap --tap-schema-index $schema_index --dry-run --engine-url=postgresql+psycopg2:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
+    schema_index=$((schema_index+1))
 done
 
 # Build and push docker images


### PR DESCRIPTION
This is an update to the TAP_SCHEMA workflow based on changes to Felis in [DM-42935](https://rubinobs.atlassian.net/browse/DM-42935), which will need to be merged first before the checks will pass.

The `build` script is updated to use the `tap-schema-index` command line argument instead of modifying the YAML files.

The Git workflows have also been changed to install Felis from `main` rather than the latest version on PyPI.

[DM-42935]: https://rubinobs.atlassian.net/browse/DM-42935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ