### PR TITLE
DM-43958: Remove redundant boolean datatype overrides

### DIFF
--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -51,7 +51,6 @@ tables:
   - name: detect_isPrimary
     '@id': '#position.detect_isPrimary'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: true if source has no children and is in the inner region of a coadd
@@ -68,7 +67,6 @@ tables:
   - name: detect_isPatchInner
     '@id': '#position.detect_isPatchInner'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: true if source is in the inner region of a coadd patch
@@ -76,7 +74,6 @@ tables:
   - name: detect_isTractInner
     '@id': '#position.detect_isTractInner'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: true if source is in the inner region of a coadd tract
@@ -84,7 +81,6 @@ tables:
   - name: merge_footprint_i
     '@id': '#position.merge_footprint_i'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter i
@@ -92,7 +88,6 @@ tables:
   - name: merge_footprint_r
     '@id': '#position.merge_footprint_r'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter r
@@ -100,7 +95,6 @@ tables:
   - name: merge_footprint_z
     '@id': '#position.merge_footprint_z'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter z
@@ -108,7 +102,6 @@ tables:
   - name: merge_footprint_y
     '@id': '#position.merge_footprint_y'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter y
@@ -116,7 +109,6 @@ tables:
   - name: merge_footprint_g
     '@id': '#position.merge_footprint_g'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter g
@@ -124,7 +116,6 @@ tables:
   - name: merge_footprint_u
     '@id': '#position.merge_footprint_u'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter u
@@ -132,7 +123,6 @@ tables:
   - name: merge_footprint_sky
     '@id': '#position.merge_footprint_sky'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Detection footprint overlapped with a detection from filter sky
@@ -140,7 +130,6 @@ tables:
   - name: merge_peak_i
     '@id': '#position.merge_peak_i'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter i
@@ -148,7 +137,6 @@ tables:
   - name: merge_peak_r
     '@id': '#position.merge_peak_r'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter r
@@ -156,7 +144,6 @@ tables:
   - name: merge_peak_z
     '@id': '#position.merge_peak_z'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter z
@@ -164,7 +151,6 @@ tables:
   - name: merge_peak_y
     '@id': '#position.merge_peak_y'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter y
@@ -172,7 +158,6 @@ tables:
   - name: merge_peak_g
     '@id': '#position.merge_peak_g'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter g
@@ -180,7 +165,6 @@ tables:
   - name: merge_peak_u
     '@id': '#position.merge_peak_u'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter u
@@ -188,7 +172,6 @@ tables:
   - name: merge_peak_sky
     '@id': '#position.merge_peak_sky'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Peak detected in filter sky
@@ -196,7 +179,6 @@ tables:
   - name: merge_measurement_i
     '@id': '#position.merge_measurement_i'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the i filter
@@ -204,7 +186,6 @@ tables:
   - name: merge_measurement_r
     '@id': '#position.merge_measurement_r'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the r filter
@@ -212,7 +193,6 @@ tables:
   - name: merge_measurement_z
     '@id': '#position.merge_measurement_z'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the z filter
@@ -220,7 +200,6 @@ tables:
   - name: merge_measurement_y
     '@id': '#position.merge_measurement_y'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the y filter
@@ -228,7 +207,6 @@ tables:
   - name: merge_measurement_g
     '@id': '#position.merge_measurement_g'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the g filter
@@ -236,7 +214,6 @@ tables:
   - name: merge_measurement_u
     '@id': '#position.merge_measurement_u'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Flag field set if the measurements here are from the u filter
@@ -302,7 +279,6 @@ tables:
   - name: base_SdssCentroid_flag
     '@id': '#reference.base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -310,7 +286,6 @@ tables:
   - name: base_SdssCentroid_flag_edge
     '@id': '#reference.base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -318,7 +293,6 @@ tables:
   - name: base_SdssCentroid_flag_noSecondDerivative
     '@id': '#reference.base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -326,7 +300,6 @@ tables:
   - name: base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#reference.base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -334,7 +307,6 @@ tables:
   - name: base_SdssCentroid_flag_notAtMaximum
     '@id': '#reference.base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -342,7 +314,6 @@ tables:
   - name: base_SdssCentroid_flag_resetToPeak
     '@id': '#reference.base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -385,7 +356,6 @@ tables:
   - name: base_PsfFlux_flag
     '@id': '#reference.base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -393,7 +363,6 @@ tables:
   - name: base_PsfFlux_flag_noGoodPixels
     '@id': '#reference.base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -401,7 +370,6 @@ tables:
   - name: base_PsfFlux_flag_edge
     '@id': '#reference.base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -410,7 +378,6 @@ tables:
   - name: base_PsfFlux_flag_apCorr
     '@id': '#reference.base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -418,7 +385,6 @@ tables:
   - name: base_PsfFlux_flag_badCentroid
     '@id': '#reference.base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -581,7 +547,6 @@ tables:
   - name: base_ClassificationExtendedness_flag
     '@id': '#reference.base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to 1 for any fatal failure.
@@ -606,7 +571,6 @@ tables:
   - name: base_Blendedness_flag
     '@id': '#reference.base_Blendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -614,7 +578,6 @@ tables:
   - name: base_Blendedness_flag_noCentroid
     '@id': '#reference.base_Blendedness_flag_noCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object has no centroid
@@ -622,7 +585,6 @@ tables:
   - name: base_Blendedness_flag_noShape
     '@id': '#reference.base_Blendedness_flag_noShape'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object has no shape
@@ -630,7 +592,6 @@ tables:
   - name: base_PixelFlags_flag
     '@id': '#reference.base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -638,7 +599,6 @@ tables:
   - name: base_PixelFlags_flag_offimage
     '@id': '#reference.base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -646,7 +606,6 @@ tables:
   - name: base_PixelFlags_flag_edge
     '@id': '#reference.base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -654,7 +613,6 @@ tables:
   - name: base_PixelFlags_flag_interpolated
     '@id': '#reference.base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -662,7 +620,6 @@ tables:
   - name: base_PixelFlags_flag_saturated
     '@id': '#reference.base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -670,7 +627,6 @@ tables:
   - name: base_PixelFlags_flag_cr
     '@id': '#reference.base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -678,7 +634,6 @@ tables:
   - name: base_PixelFlags_flag_bad
     '@id': '#reference.base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -686,7 +641,6 @@ tables:
   - name: base_PixelFlags_flag_suspect
     '@id': '#reference.base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -694,7 +648,6 @@ tables:
   - name: base_PixelFlags_flag_interpolatedCenter
     '@id': '#reference.base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -702,7 +655,6 @@ tables:
   - name: base_PixelFlags_flag_saturatedCenter
     '@id': '#reference.base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -710,7 +662,6 @@ tables:
   - name: base_PixelFlags_flag_crCenter
     '@id': '#reference.base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -718,7 +669,6 @@ tables:
   - name: base_PixelFlags_flag_suspectCenter
     '@id': '#reference.base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -726,7 +676,6 @@ tables:
   - name: base_PixelFlags_flag_clippedCenter
     '@id': '#reference.base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -734,7 +683,6 @@ tables:
   - name: base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#reference.base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -742,7 +690,6 @@ tables:
   - name: base_PixelFlags_flag_inexact_psfCenter
     '@id': '#reference.base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -750,7 +697,6 @@ tables:
   - name: base_PixelFlags_flag_bright_objectCenter
     '@id': '#reference.base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -758,7 +704,6 @@ tables:
   - name: base_PixelFlags_flag_clipped
     '@id': '#reference.base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -766,7 +711,6 @@ tables:
   - name: base_PixelFlags_flag_sensor_edge
     '@id': '#reference.base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -774,7 +718,6 @@ tables:
   - name: base_PixelFlags_flag_inexact_psf
     '@id': '#reference.base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -782,7 +725,6 @@ tables:
   - name: base_PixelFlags_flag_bright_object
     '@id': '#reference.base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -790,7 +732,6 @@ tables:
   - name: good
     '@id': '#reference.good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -832,7 +773,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_flag
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: general failure flag, set if anything went wrong
@@ -840,7 +780,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_no_pixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no pixels to measure
@@ -848,7 +787,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_not_contained'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: center not contained in footprint bounding box
@@ -856,7 +794,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_parent_source'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: parent source, ignored
@@ -864,7 +801,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMoments_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmSourceMoments_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -977,7 +913,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_flag
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: general failure flag, set if anything went wrong
@@ -985,7 +920,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_no_pixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no pixels to measure
@@ -993,7 +927,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_not_contained'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: center not contained in footprint bounding box
@@ -1001,7 +934,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_parent_source'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: parent source, ignored
@@ -1009,7 +941,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: general failure flag, set if anything went wrong
@@ -1017,7 +948,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_no_pixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no pixels to measure
@@ -1025,7 +955,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_not_contained'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: center not contained in footprint bounding box
@@ -1033,7 +962,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_parent_source'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: parent source, ignored
@@ -1041,7 +969,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag_galsim
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_galsim'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: GalSim failure
@@ -1049,7 +976,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: general failure flag, set if anything went wrong
@@ -1057,7 +983,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_no_pixels
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_no_pixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no pixels to measure
@@ -1065,7 +990,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_not_contained
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_not_contained'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: center not contained in footprint bounding box
@@ -1073,7 +997,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_parent_source
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_parent_source'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: parent source, ignored
@@ -1081,7 +1004,6 @@ tables:
   - name: ext_shapeHSM_HsmPsfMoments_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmPsfMoments_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -1089,7 +1011,6 @@ tables:
   - name: ext_shapeHSM_HsmShapeRegauss_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmShapeRegauss_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -1097,7 +1018,6 @@ tables:
   - name: ext_shapeHSM_HsmSourceMomentsRound_flag_badCentroid
     '@id': '#reference.ext_shapeHSM_HsmSourceMomentsRound_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -1217,7 +1137,6 @@ tables:
   - name: base_SdssShape_flag
     '@id': '#reference.base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -1225,7 +1144,6 @@ tables:
   - name: base_SdssShape_flag_unweightedBad
     '@id': '#reference.base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -1233,7 +1151,6 @@ tables:
   - name: base_SdssShape_flag_unweighted
     '@id': '#reference.base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -1242,7 +1159,6 @@ tables:
   - name: base_SdssShape_flag_shift
     '@id': '#reference.base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -1250,7 +1166,6 @@ tables:
   - name: base_SdssShape_flag_maxIter
     '@id': '#reference.base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -1258,7 +1173,6 @@ tables:
   - name: base_SdssShape_flag_psf
     '@id': '#reference.base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -1266,7 +1180,6 @@ tables:
   - name: base_SdssShape_flag_badCentroid
     '@id': '#reference.base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -1295,7 +1208,6 @@ tables:
   - name: deblend_deblendedAsPsf
     '@id': '#reference.deblend_deblendedAsPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Deblender thought this source looked like a PSF
@@ -1303,7 +1215,6 @@ tables:
   - name: deblend_tooManyPeaks
     '@id': '#reference.deblend_tooManyPeaks'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source had too many peaks; only the brightest were included
@@ -1311,7 +1222,6 @@ tables:
   - name: deblend_parentTooBig
     '@id': '#reference.deblend_parentTooBig'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Parent footprint covered too many pixels
@@ -1319,7 +1229,6 @@ tables:
   - name: deblend_masked
     '@id': '#reference.deblend_masked'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Parent footprint was predominantly masked
@@ -1327,7 +1236,6 @@ tables:
   - name: deblend_skipped
     '@id': '#reference.deblend_skipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Deblender skipped this source
@@ -1335,7 +1243,6 @@ tables:
   - name: deblend_rampedTemplate
     '@id': '#reference.deblend_rampedTemplate'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: This source was near an image edge and the deblender used "ramp"
@@ -1344,7 +1251,6 @@ tables:
   - name: deblend_patchedTemplate
     '@id': '#reference.deblend_patchedTemplate'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: This source was near an image edge and the deblender used "patched"
@@ -1353,7 +1259,6 @@ tables:
   - name: deblend_hasStrayFlux
     '@id': '#reference.deblend_hasStrayFlux'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: This source was assigned some stray flux
@@ -1822,7 +1727,6 @@ tables:
   - name: modelfit_CModel_initial_flag
     '@id': '#reference.modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -1830,7 +1734,6 @@ tables:
   - name: modelfit_CModel_initial_flag_trSmall
     '@id': '#reference.modelfit_CModel_initial_flag_trSmall'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
@@ -1840,7 +1743,6 @@ tables:
   - name: modelfit_CModel_initial_flag_maxIter
     '@id': '#reference.modelfit_CModel_initial_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
@@ -1848,7 +1750,6 @@ tables:
   - name: modelfit_CModel_initial_flag_numericError
     '@id': '#reference.modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -1858,7 +1759,6 @@ tables:
   - name: modelfit_CModel_exp_flag
     '@id': '#reference.modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -1866,7 +1766,6 @@ tables:
   - name: modelfit_CModel_exp_flag_trSmall
     '@id': '#reference.modelfit_CModel_exp_flag_trSmall'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
@@ -1876,7 +1775,6 @@ tables:
   - name: modelfit_CModel_exp_flag_maxIter
     '@id': '#reference.modelfit_CModel_exp_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
@@ -1884,7 +1782,6 @@ tables:
   - name: modelfit_CModel_exp_flag_numericError
     '@id': '#reference.modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -1894,7 +1791,6 @@ tables:
   - name: modelfit_CModel_dev_flag
     '@id': '#reference.modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -1902,7 +1798,6 @@ tables:
   - name: modelfit_CModel_dev_flag_trSmall
     '@id': '#reference.modelfit_CModel_dev_flag_trSmall'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer converged because the trust radius became too small;
@@ -1912,7 +1807,6 @@ tables:
   - name: modelfit_CModel_dev_flag_maxIter
     '@id': '#reference.modelfit_CModel_dev_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the optimizer hit the maximum number of iterations and did not converge
@@ -1920,7 +1814,6 @@ tables:
   - name: modelfit_CModel_dev_flag_numericError
     '@id': '#reference.modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -1930,7 +1823,6 @@ tables:
   - name: modelfit_CModel_flag
     '@id': '#reference.modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -1938,7 +1830,6 @@ tables:
   - name: modelfit_CModel_flag_region_maxArea
     '@id': '#reference.modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -1946,7 +1837,6 @@ tables:
   - name: modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#reference.modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -1954,7 +1844,6 @@ tables:
   - name: modelfit_CModel_flags_region_usedFootprintArea
     '@id': '#reference.modelfit_CModel_flags_region_usedFootprintArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the pixel region for the initial fit was defined by the area of the
@@ -1963,7 +1852,6 @@ tables:
   - name: modelfit_CModel_flags_region_usedPsfArea
     '@id': '#reference.modelfit_CModel_flags_region_usedPsfArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the pixel region for the initial fit was set to a fixed factor of
@@ -1972,7 +1860,6 @@ tables:
   - name: modelfit_CModel_flags_region_usedInitialEllipseMin
     '@id': '#reference.modelfit_CModel_flags_region_usedInitialEllipseMin'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the pixel region for the final fit was set to the lower bound defined
@@ -1981,7 +1868,6 @@ tables:
   - name: modelfit_CModel_flags_region_usedInitialEllipseMax
     '@id': '#reference.modelfit_CModel_flags_region_usedInitialEllipseMax'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the pixel region for the final fit was set to the upper bound defined
@@ -1990,7 +1876,6 @@ tables:
   - name: modelfit_CModel_flag_noShape
     '@id': '#reference.modelfit_CModel_flag_noShape'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the shape slot needed to initialize the parameters failed or was
@@ -1999,7 +1884,6 @@ tables:
   - name: modelfit_CModel_flags_smallShape
     '@id': '#reference.modelfit_CModel_flags_smallShape'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: initial parameter guess resulted in negative radius; used minimum
@@ -2008,7 +1892,6 @@ tables:
   - name: modelfit_CModel_flag_noShapeletPsf
     '@id': '#reference.modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -2016,7 +1899,6 @@ tables:
   - name: modelfit_CModel_flag_badCentroid
     '@id': '#reference.modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -2025,7 +1907,6 @@ tables:
   - name: modelfit_CModel_exp_flag_apCorr
     '@id': '#reference.modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -2033,7 +1914,6 @@ tables:
   - name: modelfit_CModel_initial_flag_apCorr
     '@id': '#reference.modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -2041,7 +1921,6 @@ tables:
   - name: modelfit_CModel_dev_flag_apCorr
     '@id': '#reference.modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -2049,7 +1928,6 @@ tables:
   - name: modelfit_CModel_flag_apCorr
     '@id': '#reference.modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -2087,7 +1965,6 @@ tables:
   - name: g_base_PixelFlags_flag
     '@id': '#forced_photometry.g_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -2095,7 +1972,6 @@ tables:
   - name: g_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.g_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -2103,7 +1979,6 @@ tables:
   - name: g_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.g_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -2111,7 +1986,6 @@ tables:
   - name: g_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.g_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -2119,7 +1993,6 @@ tables:
   - name: g_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.g_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -2127,7 +2000,6 @@ tables:
   - name: g_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.g_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -2135,7 +2007,6 @@ tables:
   - name: g_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -2143,7 +2014,6 @@ tables:
   - name: g_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.g_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -2151,7 +2021,6 @@ tables:
   - name: g_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -2159,7 +2028,6 @@ tables:
   - name: g_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -2167,7 +2035,6 @@ tables:
   - name: g_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -2175,7 +2042,6 @@ tables:
   - name: g_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -2183,7 +2049,6 @@ tables:
   - name: g_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -2191,7 +2056,6 @@ tables:
   - name: g_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -2199,7 +2063,6 @@ tables:
   - name: g_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -2207,7 +2070,6 @@ tables:
   - name: g_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -2215,7 +2077,6 @@ tables:
   - name: g_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -2223,7 +2084,6 @@ tables:
   - name: g_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.g_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -2231,7 +2091,6 @@ tables:
   - name: g_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.g_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -2239,7 +2098,6 @@ tables:
   - name: g_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.g_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -2247,7 +2105,6 @@ tables:
   - name: g_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.g_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -2255,7 +2112,6 @@ tables:
   - name: g_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.g_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -2263,7 +2119,6 @@ tables:
   - name: g_good
     '@id': '#forced_photometry.g_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -2277,7 +2132,6 @@ tables:
   - name: g_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.g_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -2334,7 +2188,6 @@ tables:
   - name: g_modelfit_CModel_flag
     '@id': '#forced_photometry.g_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -2342,7 +2195,6 @@ tables:
   - name: g_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.g_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -2350,7 +2202,6 @@ tables:
   - name: g_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.g_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -2358,7 +2209,6 @@ tables:
   - name: g_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -2366,7 +2216,6 @@ tables:
   - name: g_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.g_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -2374,7 +2223,6 @@ tables:
   - name: g_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.g_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -2383,7 +2231,6 @@ tables:
   - name: g_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -2419,7 +2266,6 @@ tables:
   - name: g_base_SdssCentroid_flag
     '@id': '#forced_photometry.g_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2427,7 +2273,6 @@ tables:
   - name: g_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -2435,7 +2280,6 @@ tables:
   - name: g_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -2443,7 +2287,6 @@ tables:
   - name: g_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -2451,7 +2294,6 @@ tables:
   - name: g_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -2459,7 +2301,6 @@ tables:
   - name: g_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -2467,7 +2308,6 @@ tables:
   - name: g_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.g_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -2587,7 +2427,6 @@ tables:
   - name: g_base_SdssShape_flag
     '@id': '#forced_photometry.g_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2595,7 +2434,6 @@ tables:
   - name: g_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.g_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -2603,7 +2441,6 @@ tables:
   - name: g_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.g_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -2612,7 +2449,6 @@ tables:
   - name: g_base_SdssShape_flag_shift
     '@id': '#forced_photometry.g_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -2620,7 +2456,6 @@ tables:
   - name: g_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.g_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -2628,7 +2463,6 @@ tables:
   - name: g_base_SdssShape_flag_psf
     '@id': '#forced_photometry.g_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -2636,7 +2470,6 @@ tables:
   - name: g_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.g_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2679,7 +2512,6 @@ tables:
   - name: g_base_PsfFlux_flag
     '@id': '#forced_photometry.g_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2687,7 +2519,6 @@ tables:
   - name: g_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.g_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -2695,7 +2526,6 @@ tables:
   - name: g_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.g_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -2704,7 +2534,6 @@ tables:
   - name: g_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.g_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -2712,7 +2541,6 @@ tables:
   - name: g_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.g_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2727,7 +2555,6 @@ tables:
   - name: g_base_InputCount_flag
     '@id': '#forced_photometry.g_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -2735,7 +2562,6 @@ tables:
   - name: g_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.g_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -2743,7 +2569,6 @@ tables:
   - name: g_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.g_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2758,7 +2583,6 @@ tables:
   - name: g_base_Variance_flag
     '@id': '#forced_photometry.g_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -2766,7 +2590,6 @@ tables:
   - name: g_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.g_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -2774,7 +2597,6 @@ tables:
   - name: g_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.g_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2796,7 +2618,6 @@ tables:
   - name: g_base_LocalBackground_flag
     '@id': '#forced_photometry.g_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2804,7 +2625,6 @@ tables:
   - name: g_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.g_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -2812,7 +2632,6 @@ tables:
   - name: g_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.g_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -2820,7 +2639,6 @@ tables:
   - name: g_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.g_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -2933,7 +2751,6 @@ tables:
   - name: g_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -2941,7 +2758,6 @@ tables:
   - name: g_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -2949,7 +2765,6 @@ tables:
   - name: g_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -2959,7 +2774,6 @@ tables:
   - name: g_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -2967,7 +2781,6 @@ tables:
   - name: g_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -2975,7 +2788,6 @@ tables:
   - name: g_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -2985,7 +2797,6 @@ tables:
   - name: g_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -2993,7 +2804,6 @@ tables:
   - name: g_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -3001,7 +2811,6 @@ tables:
   - name: g_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -3011,7 +2820,6 @@ tables:
   - name: g_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -3019,7 +2827,6 @@ tables:
   - name: g_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -3027,7 +2834,6 @@ tables:
   - name: g_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.g_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -3035,7 +2841,6 @@ tables:
   - name: i_base_PixelFlags_flag
     '@id': '#forced_photometry.i_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -3043,7 +2848,6 @@ tables:
   - name: i_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.i_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -3051,7 +2855,6 @@ tables:
   - name: i_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.i_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -3059,7 +2862,6 @@ tables:
   - name: i_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.i_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -3067,7 +2869,6 @@ tables:
   - name: i_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.i_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -3075,7 +2876,6 @@ tables:
   - name: i_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.i_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -3083,7 +2883,6 @@ tables:
   - name: i_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -3091,7 +2890,6 @@ tables:
   - name: i_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.i_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -3099,7 +2897,6 @@ tables:
   - name: i_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -3107,7 +2904,6 @@ tables:
   - name: i_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -3115,7 +2911,6 @@ tables:
   - name: i_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -3123,7 +2918,6 @@ tables:
   - name: i_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -3131,7 +2925,6 @@ tables:
   - name: i_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -3139,7 +2932,6 @@ tables:
   - name: i_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -3147,7 +2939,6 @@ tables:
   - name: i_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -3155,7 +2946,6 @@ tables:
   - name: i_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -3163,7 +2953,6 @@ tables:
   - name: i_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -3171,7 +2960,6 @@ tables:
   - name: i_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.i_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -3179,7 +2967,6 @@ tables:
   - name: i_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.i_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -3187,7 +2974,6 @@ tables:
   - name: i_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.i_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -3195,7 +2981,6 @@ tables:
   - name: i_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.i_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -3203,7 +2988,6 @@ tables:
   - name: i_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.i_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -3211,7 +2995,6 @@ tables:
   - name: i_good
     '@id': '#forced_photometry.i_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -3225,7 +3008,6 @@ tables:
   - name: i_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.i_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -3282,7 +3064,6 @@ tables:
   - name: i_modelfit_CModel_flag
     '@id': '#forced_photometry.i_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -3290,7 +3071,6 @@ tables:
   - name: i_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.i_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -3298,7 +3078,6 @@ tables:
   - name: i_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.i_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -3306,7 +3085,6 @@ tables:
   - name: i_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -3314,7 +3092,6 @@ tables:
   - name: i_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.i_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -3322,7 +3099,6 @@ tables:
   - name: i_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.i_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -3331,7 +3107,6 @@ tables:
   - name: i_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -3367,7 +3142,6 @@ tables:
   - name: i_base_SdssCentroid_flag
     '@id': '#forced_photometry.i_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3375,7 +3149,6 @@ tables:
   - name: i_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -3383,7 +3156,6 @@ tables:
   - name: i_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -3391,7 +3163,6 @@ tables:
   - name: i_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -3399,7 +3170,6 @@ tables:
   - name: i_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -3407,7 +3177,6 @@ tables:
   - name: i_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -3415,7 +3184,6 @@ tables:
   - name: i_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.i_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -3535,7 +3303,6 @@ tables:
   - name: i_base_SdssShape_flag
     '@id': '#forced_photometry.i_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3543,7 +3310,6 @@ tables:
   - name: i_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.i_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -3551,7 +3317,6 @@ tables:
   - name: i_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.i_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -3560,7 +3325,6 @@ tables:
   - name: i_base_SdssShape_flag_shift
     '@id': '#forced_photometry.i_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -3568,7 +3332,6 @@ tables:
   - name: i_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.i_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -3576,7 +3339,6 @@ tables:
   - name: i_base_SdssShape_flag_psf
     '@id': '#forced_photometry.i_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -3584,7 +3346,6 @@ tables:
   - name: i_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.i_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3627,7 +3388,6 @@ tables:
   - name: i_base_PsfFlux_flag
     '@id': '#forced_photometry.i_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3635,7 +3395,6 @@ tables:
   - name: i_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.i_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -3643,7 +3402,6 @@ tables:
   - name: i_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.i_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -3652,7 +3410,6 @@ tables:
   - name: i_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.i_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -3660,7 +3417,6 @@ tables:
   - name: i_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.i_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3675,7 +3431,6 @@ tables:
   - name: i_base_InputCount_flag
     '@id': '#forced_photometry.i_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -3683,7 +3438,6 @@ tables:
   - name: i_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.i_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -3691,7 +3445,6 @@ tables:
   - name: i_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.i_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3706,7 +3459,6 @@ tables:
   - name: i_base_Variance_flag
     '@id': '#forced_photometry.i_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -3714,7 +3466,6 @@ tables:
   - name: i_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.i_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -3722,7 +3473,6 @@ tables:
   - name: i_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.i_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3744,7 +3494,6 @@ tables:
   - name: i_base_LocalBackground_flag
     '@id': '#forced_photometry.i_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3752,7 +3501,6 @@ tables:
   - name: i_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.i_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -3760,7 +3508,6 @@ tables:
   - name: i_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.i_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -3768,7 +3515,6 @@ tables:
   - name: i_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.i_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -3881,7 +3627,6 @@ tables:
   - name: i_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -3889,7 +3634,6 @@ tables:
   - name: i_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -3897,7 +3641,6 @@ tables:
   - name: i_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -3907,7 +3650,6 @@ tables:
   - name: i_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -3915,7 +3657,6 @@ tables:
   - name: i_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -3923,7 +3664,6 @@ tables:
   - name: i_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -3933,7 +3673,6 @@ tables:
   - name: i_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -3941,7 +3680,6 @@ tables:
   - name: i_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -3949,7 +3687,6 @@ tables:
   - name: i_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -3959,7 +3696,6 @@ tables:
   - name: i_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -3967,7 +3703,6 @@ tables:
   - name: i_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -3975,7 +3710,6 @@ tables:
   - name: i_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.i_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -3983,7 +3717,6 @@ tables:
   - name: r_base_PixelFlags_flag
     '@id': '#forced_photometry.r_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -3991,7 +3724,6 @@ tables:
   - name: r_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.r_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -3999,7 +3731,6 @@ tables:
   - name: r_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.r_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -4007,7 +3738,6 @@ tables:
   - name: r_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.r_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -4015,7 +3745,6 @@ tables:
   - name: r_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.r_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -4023,7 +3752,6 @@ tables:
   - name: r_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.r_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -4031,7 +3759,6 @@ tables:
   - name: r_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -4039,7 +3766,6 @@ tables:
   - name: r_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.r_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -4047,7 +3773,6 @@ tables:
   - name: r_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -4055,7 +3780,6 @@ tables:
   - name: r_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -4063,7 +3787,6 @@ tables:
   - name: r_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -4071,7 +3794,6 @@ tables:
   - name: r_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -4079,7 +3801,6 @@ tables:
   - name: r_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -4087,7 +3808,6 @@ tables:
   - name: r_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -4095,7 +3815,6 @@ tables:
   - name: r_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -4103,7 +3822,6 @@ tables:
   - name: r_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -4111,7 +3829,6 @@ tables:
   - name: r_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -4119,7 +3836,6 @@ tables:
   - name: r_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.r_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -4127,7 +3843,6 @@ tables:
   - name: r_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.r_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -4135,7 +3850,6 @@ tables:
   - name: r_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.r_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -4143,7 +3857,6 @@ tables:
   - name: r_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.r_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -4151,7 +3864,6 @@ tables:
   - name: r_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.r_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -4159,7 +3871,6 @@ tables:
   - name: r_good
     '@id': '#forced_photometry.r_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -4173,7 +3884,6 @@ tables:
   - name: r_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.r_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -4230,7 +3940,6 @@ tables:
   - name: r_modelfit_CModel_flag
     '@id': '#forced_photometry.r_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -4238,7 +3947,6 @@ tables:
   - name: r_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.r_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -4246,7 +3954,6 @@ tables:
   - name: r_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.r_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -4254,7 +3961,6 @@ tables:
   - name: r_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -4262,7 +3968,6 @@ tables:
   - name: r_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.r_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -4270,7 +3975,6 @@ tables:
   - name: r_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.r_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -4279,7 +3983,6 @@ tables:
   - name: r_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -4315,7 +4018,6 @@ tables:
   - name: r_base_SdssCentroid_flag
     '@id': '#forced_photometry.r_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4323,7 +4025,6 @@ tables:
   - name: r_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -4331,7 +4032,6 @@ tables:
   - name: r_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -4339,7 +4039,6 @@ tables:
   - name: r_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -4347,7 +4046,6 @@ tables:
   - name: r_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -4355,7 +4053,6 @@ tables:
   - name: r_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -4363,7 +4060,6 @@ tables:
   - name: r_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.r_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -4483,7 +4179,6 @@ tables:
   - name: r_base_SdssShape_flag
     '@id': '#forced_photometry.r_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4491,7 +4186,6 @@ tables:
   - name: r_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.r_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -4499,7 +4193,6 @@ tables:
   - name: r_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.r_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -4508,7 +4201,6 @@ tables:
   - name: r_base_SdssShape_flag_shift
     '@id': '#forced_photometry.r_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -4516,7 +4208,6 @@ tables:
   - name: r_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.r_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -4524,7 +4215,6 @@ tables:
   - name: r_base_SdssShape_flag_psf
     '@id': '#forced_photometry.r_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -4532,7 +4222,6 @@ tables:
   - name: r_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.r_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4575,7 +4264,6 @@ tables:
   - name: r_base_PsfFlux_flag
     '@id': '#forced_photometry.r_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4583,7 +4271,6 @@ tables:
   - name: r_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.r_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -4591,7 +4278,6 @@ tables:
   - name: r_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.r_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -4600,7 +4286,6 @@ tables:
   - name: r_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.r_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -4608,7 +4293,6 @@ tables:
   - name: r_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.r_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4623,7 +4307,6 @@ tables:
   - name: r_base_InputCount_flag
     '@id': '#forced_photometry.r_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -4631,7 +4314,6 @@ tables:
   - name: r_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.r_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -4639,7 +4321,6 @@ tables:
   - name: r_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.r_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4654,7 +4335,6 @@ tables:
   - name: r_base_Variance_flag
     '@id': '#forced_photometry.r_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -4662,7 +4342,6 @@ tables:
   - name: r_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.r_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -4670,7 +4349,6 @@ tables:
   - name: r_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.r_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4692,7 +4370,6 @@ tables:
   - name: r_base_LocalBackground_flag
     '@id': '#forced_photometry.r_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4700,7 +4377,6 @@ tables:
   - name: r_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.r_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -4708,7 +4384,6 @@ tables:
   - name: r_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.r_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -4716,7 +4391,6 @@ tables:
   - name: r_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.r_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -4829,7 +4503,6 @@ tables:
   - name: r_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -4837,7 +4510,6 @@ tables:
   - name: r_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -4845,7 +4517,6 @@ tables:
   - name: r_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -4855,7 +4526,6 @@ tables:
   - name: r_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -4863,7 +4533,6 @@ tables:
   - name: r_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -4871,7 +4540,6 @@ tables:
   - name: r_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -4881,7 +4549,6 @@ tables:
   - name: r_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -4889,7 +4556,6 @@ tables:
   - name: r_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -4897,7 +4563,6 @@ tables:
   - name: r_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -4907,7 +4572,6 @@ tables:
   - name: r_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -4915,7 +4579,6 @@ tables:
   - name: r_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -4923,7 +4586,6 @@ tables:
   - name: r_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.r_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -4931,7 +4593,6 @@ tables:
   - name: u_base_PixelFlags_flag
     '@id': '#forced_photometry.u_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -4939,7 +4600,6 @@ tables:
   - name: u_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.u_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -4947,7 +4607,6 @@ tables:
   - name: u_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.u_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -4955,7 +4614,6 @@ tables:
   - name: u_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.u_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -4963,7 +4621,6 @@ tables:
   - name: u_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.u_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -4971,7 +4628,6 @@ tables:
   - name: u_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.u_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -4979,7 +4635,6 @@ tables:
   - name: u_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -4987,7 +4642,6 @@ tables:
   - name: u_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.u_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -4995,7 +4649,6 @@ tables:
   - name: u_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -5003,7 +4656,6 @@ tables:
   - name: u_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -5011,7 +4663,6 @@ tables:
   - name: u_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -5019,7 +4670,6 @@ tables:
   - name: u_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -5027,7 +4677,6 @@ tables:
   - name: u_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -5035,7 +4684,6 @@ tables:
   - name: u_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -5043,7 +4691,6 @@ tables:
   - name: u_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -5051,7 +4698,6 @@ tables:
   - name: u_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -5059,7 +4705,6 @@ tables:
   - name: u_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -5067,7 +4712,6 @@ tables:
   - name: u_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.u_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -5075,7 +4719,6 @@ tables:
   - name: u_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.u_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -5083,7 +4726,6 @@ tables:
   - name: u_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.u_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -5091,7 +4733,6 @@ tables:
   - name: u_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.u_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -5099,7 +4740,6 @@ tables:
   - name: u_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.u_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -5107,7 +4747,6 @@ tables:
   - name: u_good
     '@id': '#forced_photometry.u_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -5121,7 +4760,6 @@ tables:
   - name: u_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.u_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -5178,7 +4816,6 @@ tables:
   - name: u_modelfit_CModel_flag
     '@id': '#forced_photometry.u_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -5186,7 +4823,6 @@ tables:
   - name: u_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.u_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -5194,7 +4830,6 @@ tables:
   - name: u_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.u_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -5202,7 +4837,6 @@ tables:
   - name: u_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -5210,7 +4844,6 @@ tables:
   - name: u_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.u_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -5218,7 +4851,6 @@ tables:
   - name: u_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.u_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -5227,7 +4859,6 @@ tables:
   - name: u_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -5263,7 +4894,6 @@ tables:
   - name: u_base_SdssCentroid_flag
     '@id': '#forced_photometry.u_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5271,7 +4901,6 @@ tables:
   - name: u_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -5279,7 +4908,6 @@ tables:
   - name: u_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -5287,7 +4915,6 @@ tables:
   - name: u_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -5295,7 +4922,6 @@ tables:
   - name: u_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -5303,7 +4929,6 @@ tables:
   - name: u_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -5311,7 +4936,6 @@ tables:
   - name: u_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.u_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -5431,7 +5055,6 @@ tables:
   - name: u_base_SdssShape_flag
     '@id': '#forced_photometry.u_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5439,7 +5062,6 @@ tables:
   - name: u_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.u_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -5447,7 +5069,6 @@ tables:
   - name: u_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.u_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -5456,7 +5077,6 @@ tables:
   - name: u_base_SdssShape_flag_shift
     '@id': '#forced_photometry.u_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -5464,7 +5084,6 @@ tables:
   - name: u_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.u_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -5472,7 +5091,6 @@ tables:
   - name: u_base_SdssShape_flag_psf
     '@id': '#forced_photometry.u_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -5480,7 +5098,6 @@ tables:
   - name: u_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.u_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5523,7 +5140,6 @@ tables:
   - name: u_base_PsfFlux_flag
     '@id': '#forced_photometry.u_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5531,7 +5147,6 @@ tables:
   - name: u_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.u_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -5539,7 +5154,6 @@ tables:
   - name: u_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.u_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -5548,7 +5162,6 @@ tables:
   - name: u_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.u_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -5556,7 +5169,6 @@ tables:
   - name: u_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.u_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5571,7 +5183,6 @@ tables:
   - name: u_base_InputCount_flag
     '@id': '#forced_photometry.u_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -5579,7 +5190,6 @@ tables:
   - name: u_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.u_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -5587,7 +5197,6 @@ tables:
   - name: u_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.u_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5602,7 +5211,6 @@ tables:
   - name: u_base_Variance_flag
     '@id': '#forced_photometry.u_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -5610,7 +5218,6 @@ tables:
   - name: u_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.u_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -5618,7 +5225,6 @@ tables:
   - name: u_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.u_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5640,7 +5246,6 @@ tables:
   - name: u_base_LocalBackground_flag
     '@id': '#forced_photometry.u_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5648,7 +5253,6 @@ tables:
   - name: u_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.u_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -5656,7 +5260,6 @@ tables:
   - name: u_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.u_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -5664,7 +5267,6 @@ tables:
   - name: u_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.u_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -5777,7 +5379,6 @@ tables:
   - name: u_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -5785,7 +5386,6 @@ tables:
   - name: u_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -5793,7 +5393,6 @@ tables:
   - name: u_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -5803,7 +5402,6 @@ tables:
   - name: u_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -5811,7 +5409,6 @@ tables:
   - name: u_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -5819,7 +5416,6 @@ tables:
   - name: u_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -5829,7 +5425,6 @@ tables:
   - name: u_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -5837,7 +5432,6 @@ tables:
   - name: u_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -5845,7 +5439,6 @@ tables:
   - name: u_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -5855,7 +5448,6 @@ tables:
   - name: u_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -5863,7 +5455,6 @@ tables:
   - name: u_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -5871,7 +5462,6 @@ tables:
   - name: u_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.u_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -5879,7 +5469,6 @@ tables:
   - name: y_base_PixelFlags_flag
     '@id': '#forced_photometry.y_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -5887,7 +5476,6 @@ tables:
   - name: y_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.y_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -5895,7 +5483,6 @@ tables:
   - name: y_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.y_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -5903,7 +5490,6 @@ tables:
   - name: y_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.y_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -5911,7 +5497,6 @@ tables:
   - name: y_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.y_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -5919,7 +5504,6 @@ tables:
   - name: y_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.y_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -5927,7 +5511,6 @@ tables:
   - name: y_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -5935,7 +5518,6 @@ tables:
   - name: y_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.y_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -5943,7 +5525,6 @@ tables:
   - name: y_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -5951,7 +5532,6 @@ tables:
   - name: y_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -5959,7 +5539,6 @@ tables:
   - name: y_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -5967,7 +5546,6 @@ tables:
   - name: y_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -5975,7 +5553,6 @@ tables:
   - name: y_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -5983,7 +5560,6 @@ tables:
   - name: y_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -5991,7 +5567,6 @@ tables:
   - name: y_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -5999,7 +5574,6 @@ tables:
   - name: y_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -6007,7 +5581,6 @@ tables:
   - name: y_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -6015,7 +5588,6 @@ tables:
   - name: y_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.y_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -6023,7 +5595,6 @@ tables:
   - name: y_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.y_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -6031,7 +5602,6 @@ tables:
   - name: y_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.y_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -6039,7 +5609,6 @@ tables:
   - name: y_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.y_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -6047,7 +5616,6 @@ tables:
   - name: y_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.y_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -6055,7 +5623,6 @@ tables:
   - name: y_good
     '@id': '#forced_photometry.y_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -6069,7 +5636,6 @@ tables:
   - name: y_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.y_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -6126,7 +5692,6 @@ tables:
   - name: y_modelfit_CModel_flag
     '@id': '#forced_photometry.y_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -6134,7 +5699,6 @@ tables:
   - name: y_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.y_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -6142,7 +5706,6 @@ tables:
   - name: y_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.y_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -6150,7 +5713,6 @@ tables:
   - name: y_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -6158,7 +5720,6 @@ tables:
   - name: y_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.y_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -6166,7 +5727,6 @@ tables:
   - name: y_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.y_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -6175,7 +5735,6 @@ tables:
   - name: y_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -6211,7 +5770,6 @@ tables:
   - name: y_base_SdssCentroid_flag
     '@id': '#forced_photometry.y_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6219,7 +5777,6 @@ tables:
   - name: y_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -6227,7 +5784,6 @@ tables:
   - name: y_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -6235,7 +5791,6 @@ tables:
   - name: y_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -6243,7 +5798,6 @@ tables:
   - name: y_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -6251,7 +5805,6 @@ tables:
   - name: y_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -6259,7 +5812,6 @@ tables:
   - name: y_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.y_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -6379,7 +5931,6 @@ tables:
   - name: y_base_SdssShape_flag
     '@id': '#forced_photometry.y_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6387,7 +5938,6 @@ tables:
   - name: y_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.y_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -6395,7 +5945,6 @@ tables:
   - name: y_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.y_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -6404,7 +5953,6 @@ tables:
   - name: y_base_SdssShape_flag_shift
     '@id': '#forced_photometry.y_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -6412,7 +5960,6 @@ tables:
   - name: y_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.y_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -6420,7 +5967,6 @@ tables:
   - name: y_base_SdssShape_flag_psf
     '@id': '#forced_photometry.y_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -6428,7 +5974,6 @@ tables:
   - name: y_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.y_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6471,7 +6016,6 @@ tables:
   - name: y_base_PsfFlux_flag
     '@id': '#forced_photometry.y_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6479,7 +6023,6 @@ tables:
   - name: y_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.y_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -6487,7 +6030,6 @@ tables:
   - name: y_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.y_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -6496,7 +6038,6 @@ tables:
   - name: y_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.y_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -6504,7 +6045,6 @@ tables:
   - name: y_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.y_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6519,7 +6059,6 @@ tables:
   - name: y_base_InputCount_flag
     '@id': '#forced_photometry.y_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -6527,7 +6066,6 @@ tables:
   - name: y_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.y_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -6535,7 +6073,6 @@ tables:
   - name: y_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.y_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6550,7 +6087,6 @@ tables:
   - name: y_base_Variance_flag
     '@id': '#forced_photometry.y_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -6558,7 +6094,6 @@ tables:
   - name: y_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.y_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -6566,7 +6101,6 @@ tables:
   - name: y_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.y_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6588,7 +6122,6 @@ tables:
   - name: y_base_LocalBackground_flag
     '@id': '#forced_photometry.y_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6596,7 +6129,6 @@ tables:
   - name: y_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.y_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -6604,7 +6136,6 @@ tables:
   - name: y_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.y_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -6612,7 +6143,6 @@ tables:
   - name: y_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.y_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -6725,7 +6255,6 @@ tables:
   - name: y_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -6733,7 +6262,6 @@ tables:
   - name: y_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -6741,7 +6269,6 @@ tables:
   - name: y_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -6751,7 +6278,6 @@ tables:
   - name: y_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -6759,7 +6285,6 @@ tables:
   - name: y_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -6767,7 +6292,6 @@ tables:
   - name: y_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -6777,7 +6301,6 @@ tables:
   - name: y_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -6785,7 +6308,6 @@ tables:
   - name: y_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -6793,7 +6315,6 @@ tables:
   - name: y_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -6803,7 +6324,6 @@ tables:
   - name: y_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -6811,7 +6331,6 @@ tables:
   - name: y_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -6819,7 +6338,6 @@ tables:
   - name: y_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.y_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -6827,7 +6345,6 @@ tables:
   - name: z_base_PixelFlags_flag
     '@id': '#forced_photometry.z_base_PixelFlags_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General failure flag, set if anything went wrong
@@ -6835,7 +6352,6 @@ tables:
   - name: z_base_PixelFlags_flag_offimage
     '@id': '#forced_photometry.z_base_PixelFlags_flag_offimage'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is off image
@@ -6843,7 +6359,6 @@ tables:
   - name: z_base_PixelFlags_flag_edge
     '@id': '#forced_photometry.z_base_PixelFlags_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
@@ -6851,7 +6366,6 @@ tables:
   - name: z_base_PixelFlags_flag_interpolated
     '@id': '#forced_photometry.z_base_PixelFlags_flag_interpolated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source footprint
@@ -6859,7 +6373,6 @@ tables:
   - name: z_base_PixelFlags_flag_saturated
     '@id': '#forced_photometry.z_base_PixelFlags_flag_saturated'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source footprint
@@ -6867,7 +6380,6 @@ tables:
   - name: z_base_PixelFlags_flag_cr
     '@id': '#forced_photometry.z_base_PixelFlags_flag_cr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source footprint
@@ -6875,7 +6387,6 @@ tables:
   - name: z_base_PixelFlags_flag_bad
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Bad pixel in the Source footprint
@@ -6883,7 +6394,6 @@ tables:
   - name: z_base_PixelFlags_flag_suspect
     '@id': '#forced_photometry.z_base_PixelFlags_flag_suspect'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's footprint includes suspect pixels"
@@ -6891,7 +6401,6 @@ tables:
   - name: z_base_PixelFlags_flag_interpolatedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_interpolatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Interpolated pixel in the Source center
@@ -6899,7 +6408,6 @@ tables:
   - name: z_base_PixelFlags_flag_saturatedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_saturatedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Saturated pixel in the Source center
@@ -6907,7 +6415,6 @@ tables:
   - name: z_base_PixelFlags_flag_crCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_crCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Cosmic ray in the Source center
@@ -6915,7 +6422,6 @@ tables:
   - name: z_base_PixelFlags_flag_suspectCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_suspectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: "Source's center is close to suspect pixels"
@@ -6923,7 +6429,6 @@ tables:
   - name: z_base_PixelFlags_flag_clippedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_clippedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to CLIPPED pixels
@@ -6931,7 +6436,6 @@ tables:
   - name: z_base_PixelFlags_flag_sensor_edgeCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_sensor_edgeCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to SENSOR_EDGE pixels
@@ -6939,7 +6443,6 @@ tables:
   - name: z_base_PixelFlags_flag_rejectedCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_rejectedCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to REJECTED pixels
@@ -6947,7 +6450,6 @@ tables:
   - name: z_base_PixelFlags_flag_inexact_psfCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_inexact_psfCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to INEXACT_PSF pixels
@@ -6955,7 +6457,6 @@ tables:
   - name: z_base_PixelFlags_flag_bright_objectCenter
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bright_objectCenter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source center is close to BRIGHT_OBJECT pixels
@@ -6963,7 +6464,6 @@ tables:
   - name: z_base_PixelFlags_flag_clipped
     '@id': '#forced_photometry.z_base_PixelFlags_flag_clipped'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes CLIPPED pixels
@@ -6971,7 +6471,6 @@ tables:
   - name: z_base_PixelFlags_flag_sensor_edge
     '@id': '#forced_photometry.z_base_PixelFlags_flag_sensor_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes SENSOR_EDGE pixels
@@ -6979,7 +6478,6 @@ tables:
   - name: z_base_PixelFlags_flag_rejected
     '@id': '#forced_photometry.z_base_PixelFlags_flag_rejected'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes REJECTED pixels
@@ -6987,7 +6485,6 @@ tables:
   - name: z_base_PixelFlags_flag_inexact_psf
     '@id': '#forced_photometry.z_base_PixelFlags_flag_inexact_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes INEXACT_PSF pixels
@@ -6995,7 +6492,6 @@ tables:
   - name: z_base_PixelFlags_flag_bright_object
     '@id': '#forced_photometry.z_base_PixelFlags_flag_bright_object'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Source footprint includes BRIGHT_OBJECT pixels
@@ -7003,7 +6499,6 @@ tables:
   - name: z_good
     '@id': '#forced_photometry.z_good'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if the source has no flagged pixels.
@@ -7017,7 +6512,6 @@ tables:
   - name: z_base_ClassificationExtendedness_flag
     '@id': '#forced_photometry.z_base_ClassificationExtendedness_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Set to 1 for any fatal failure.
@@ -7074,7 +6568,6 @@ tables:
   - name: z_modelfit_CModel_flag
     '@id': '#forced_photometry.z_modelfit_CModel_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set if the final cmodel fit (or any previous fit) failed
@@ -7082,7 +6575,6 @@ tables:
   - name: z_modelfit_CModel_flag_region_maxArea
     '@id': '#forced_photometry.z_modelfit_CModel_flag_region_maxArea'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: number of pixels in fit region exceeded the region.maxArea value
@@ -7090,7 +6582,6 @@ tables:
   - name: z_modelfit_CModel_flag_region_maxBadPixelFraction
     '@id': '#forced_photometry.z_modelfit_CModel_flag_region_maxBadPixelFraction'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the fraction of bad/clipped pixels in the fit region exceeded region.maxBadPixelFraction
@@ -7098,7 +6589,6 @@ tables:
   - name: z_modelfit_CModel_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -7106,7 +6596,6 @@ tables:
   - name: z_modelfit_CModel_flag_noShapeletPsf
     '@id': '#forced_photometry.z_modelfit_CModel_flag_noShapeletPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: the multishapelet fit to the PSF model did not succeed
@@ -7114,7 +6603,6 @@ tables:
   - name: z_modelfit_CModel_flag_badCentroid
     '@id': '#forced_photometry.z_modelfit_CModel_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: input centroid was not within the fit region (probably because it''s
@@ -7123,7 +6611,6 @@ tables:
   - name: z_modelfit_CModel_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel
@@ -7159,7 +6646,6 @@ tables:
   - name: z_base_SdssCentroid_flag
     '@id': '#forced_photometry.z_base_SdssCentroid_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7167,7 +6653,6 @@ tables:
   - name: z_base_SdssCentroid_flag_edge
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object too close to edge
@@ -7175,7 +6660,6 @@ tables:
   - name: z_base_SdssCentroid_flag_noSecondDerivative
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_noSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Vanishing second derivative
@@ -7183,7 +6667,6 @@ tables:
   - name: z_base_SdssCentroid_flag_almostNoSecondDerivative
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_almostNoSecondDerivative'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Almost vanishing second derivative
@@ -7191,7 +6674,6 @@ tables:
   - name: z_base_SdssCentroid_flag_notAtMaximum
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_notAtMaximum'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Object is not at a maximum
@@ -7199,7 +6681,6 @@ tables:
   - name: z_base_SdssCentroid_flag_resetToPeak
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_resetToPeak'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if CentroidChecker reset the centroid
@@ -7207,7 +6688,6 @@ tables:
   - name: z_base_SdssCentroid_flag_badInitialCentroid
     '@id': '#forced_photometry.z_base_SdssCentroid_flag_badInitialCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: whether the reference centroid is marked as bad
@@ -7327,7 +6807,6 @@ tables:
   - name: z_base_SdssShape_flag
     '@id': '#forced_photometry.z_base_SdssShape_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7335,7 +6814,6 @@ tables:
   - name: z_base_SdssShape_flag_unweightedBad
     '@id': '#forced_photometry.z_base_SdssShape_flag_unweightedBad'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Both weighted and unweighted moments were invalid
@@ -7343,7 +6821,6 @@ tables:
   - name: z_base_SdssShape_flag_unweighted
     '@id': '#forced_photometry.z_base_SdssShape_flag_unweighted'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Weighted moments converged to an invalid value; using unweighted
@@ -7352,7 +6829,6 @@ tables:
   - name: z_base_SdssShape_flag_shift
     '@id': '#forced_photometry.z_base_SdssShape_flag_shift'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: centroid shifted by more than the maximum allowed amount
@@ -7360,7 +6836,6 @@ tables:
   - name: z_base_SdssShape_flag_maxIter
     '@id': '#forced_photometry.z_base_SdssShape_flag_maxIter'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Too many iterations in adaptive moments
@@ -7368,7 +6843,6 @@ tables:
   - name: z_base_SdssShape_flag_psf
     '@id': '#forced_photometry.z_base_SdssShape_flag_psf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Failure in measuring PSF model shape
@@ -7376,7 +6850,6 @@ tables:
   - name: z_base_SdssShape_flag_badCentroid
     '@id': '#forced_photometry.z_base_SdssShape_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7419,7 +6892,6 @@ tables:
   - name: z_base_PsfFlux_flag
     '@id': '#forced_photometry.z_base_PsfFlux_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7427,7 +6899,6 @@ tables:
   - name: z_base_PsfFlux_flag_noGoodPixels
     '@id': '#forced_photometry.z_base_PsfFlux_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: not enough non-rejected pixels in data to attempt the fit
@@ -7435,7 +6906,6 @@ tables:
   - name: z_base_PsfFlux_flag_edge
     '@id': '#forced_photometry.z_base_PsfFlux_flag_edge'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: object was too close to the edge of the image to use the full PSF
@@ -7444,7 +6914,6 @@ tables:
   - name: z_base_PsfFlux_flag_apCorr
     '@id': '#forced_photometry.z_base_PsfFlux_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct base_PsfFlux
@@ -7452,7 +6921,6 @@ tables:
   - name: z_base_PsfFlux_flag_badCentroid
     '@id': '#forced_photometry.z_base_PsfFlux_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7467,7 +6935,6 @@ tables:
   - name: z_base_InputCount_flag
     '@id': '#forced_photometry.z_base_InputCount_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -7475,7 +6942,6 @@ tables:
   - name: z_base_InputCount_flag_noInputs
     '@id': '#forced_photometry.z_base_InputCount_flag_noInputs'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: No coadd inputs available
@@ -7483,7 +6949,6 @@ tables:
   - name: z_base_InputCount_flag_badCentroid
     '@id': '#forced_photometry.z_base_InputCount_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7498,7 +6963,6 @@ tables:
   - name: z_base_Variance_flag
     '@id': '#forced_photometry.z_base_Variance_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set for any fatal failure
@@ -7506,7 +6970,6 @@ tables:
   - name: z_base_Variance_flag_emptyFootprint
     '@id': '#forced_photometry.z_base_Variance_flag_emptyFootprint'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: Set to True when the footprint has no usable pixels
@@ -7514,7 +6977,6 @@ tables:
   - name: z_base_Variance_flag_badCentroid
     '@id': '#forced_photometry.z_base_Variance_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7536,7 +6998,6 @@ tables:
   - name: z_base_LocalBackground_flag
     '@id': '#forced_photometry.z_base_LocalBackground_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7544,7 +7005,6 @@ tables:
   - name: z_base_LocalBackground_flag_noGoodPixels
     '@id': '#forced_photometry.z_base_LocalBackground_flag_noGoodPixels'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no good pixels in the annulus
@@ -7552,7 +7012,6 @@ tables:
   - name: z_base_LocalBackground_flag_noPsf
     '@id': '#forced_photometry.z_base_LocalBackground_flag_noPsf'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: no PSF provided
@@ -7560,7 +7019,6 @@ tables:
   - name: z_base_LocalBackground_flag_badCentroid
     '@id': '#forced_photometry.z_base_LocalBackground_flag_badCentroid'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: General Failure Flag
@@ -7673,7 +7131,6 @@ tables:
   - name: z_modelfit_CModel_initial_flag
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the initial flux failed
@@ -7681,7 +7138,6 @@ tables:
   - name: z_modelfit_CModel_initial_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -7689,7 +7145,6 @@ tables:
   - name: z_modelfit_CModel_initial_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -7699,7 +7154,6 @@ tables:
   - name: z_modelfit_CModel_exp_flag
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the exponential flux failed
@@ -7707,7 +7161,6 @@ tables:
   - name: z_modelfit_CModel_exp_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -7715,7 +7168,6 @@ tables:
   - name: z_modelfit_CModel_exp_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -7725,7 +7177,6 @@ tables:
   - name: z_modelfit_CModel_dev_flag
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: flag set when the flux for the de Vaucouleur flux failed
@@ -7733,7 +7184,6 @@ tables:
   - name: z_modelfit_CModel_dev_flag_badReference
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_badReference'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: The original fit in the reference catalog failed.
@@ -7741,7 +7191,6 @@ tables:
   - name: z_modelfit_CModel_dev_flag_numericError
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_numericError'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: numerical underflow or overflow in model evaluation; usually this
@@ -7751,7 +7200,6 @@ tables:
   - name: z_modelfit_CModel_exp_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_exp_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_exp
@@ -7759,7 +7207,6 @@ tables:
   - name: z_modelfit_CModel_dev_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_dev_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_dev
@@ -7767,7 +7214,6 @@ tables:
   - name: z_modelfit_CModel_initial_flag_apCorr
     '@id': '#forced_photometry.z_modelfit_CModel_initial_flag_apCorr'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: set if unable to aperture correct modelfit_CModel_initial
@@ -7860,7 +7306,6 @@ tables:
     '@id': '#object.xy_flag'
     datatype: boolean
     description: Flag for issues with x and y
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psNdata
@@ -7907,7 +7352,6 @@ tables:
     '@id': '#object.I_flag'
     datatype: boolean
     description: Flag for issues with Ixx_pixel, Iyy_pixel, and Ixy_pixel.
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: IxxPSF_pixel
@@ -8115,42 +7559,36 @@ tables:
     '@id': '#object.psFlux_flag_g'
     datatype: boolean
     description: flag for issues with psFlux_g
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFlux_flag_i
     '@id': '#object.psFlux_flag_i'
     datatype: boolean
     description: flag for issues with psFlux_i
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFlux_flag_r
     '@id': '#object.psFlux_flag_r'
     datatype: boolean
     description: flag for issues with psFlux_r
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFlux_flag_u
     '@id': '#object.psFlux_flag_u'
     datatype: boolean
     description: flag for issues with psFlux_u
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFlux_flag_y
     '@id': '#object.psFlux_flag_y'
     datatype: boolean
     description: flag for issues with psFlux_y
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFlux_flag_z
     '@id': '#object.psFlux_flag_z'
     datatype: boolean
     description: flag for issues with psFlux_zs
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: psFluxErr_g
@@ -8295,42 +7733,36 @@ tables:
     '@id': '#object.I_flag_g'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, g band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: I_flag_i
     '@id': '#object.I_flag_i'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, i band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: I_flag_r
     '@id': '#object.I_flag_r'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, r band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: I_flag_u
     '@id': '#object.I_flag_u'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, u band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: I_flag_y
     '@id': '#object.I_flag_y'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, y band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: I_flag_z
     '@id': '#object.I_flag_z'
     datatype: boolean
     description: Flag for issues with second moments of source intensity, z band
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
   - name: Ixx_pixel_g
@@ -8589,14 +8021,12 @@ tables:
     '@id': '#object.good'
     datatype: boolean
     description: True if the source has no flagged pixels
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
   - name: clean
     '@id': '#object.clean'
     datatype: boolean
     description: True if the source has no flagged pixels and is not deblended
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
   - name: cModelFlux_g
@@ -8674,42 +8104,36 @@ tables:
   - name: cModelFlux_flag_g
     '@id': '#object.cModelFlux_flag_g'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_i
     '@id': '#object.cModelFlux_flag_i'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_r
     '@id': '#object.cModelFlux_flag_r'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_u
     '@id': '#object.cModelFlux_flag_u'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_y
     '@id': '#object.cModelFlux_flag_y'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
   - name: cModelFlux_flag_z
     '@id': '#object.cModelFlux_flag_z'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: Flag for issues with cModelFlux_flag_<band>
@@ -8944,14 +8368,12 @@ tables:
   - name: is_good_match
     '@id': '#truth_match.is_good_match'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if this object--truth matching pair satisfies all matching criteria
   - name: is_nearest_neighbor
     '@id': '#truth_match.is_nearest_neighbor'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True if this truth entry is the nearest neighbor of the object specified
@@ -8959,7 +8381,6 @@ tables:
   - name: is_unique_truth_entry
     '@id': '#truth_match.is_unique_truth_entry'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 1
     description: True for truth entries that appear for the first time in this truth

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -36,49 +36,41 @@ tables:
     "@id": "#Object.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_fromBlend
     "@id": "#Object.detect_fromBlend"
     datatype: boolean
     description: This source is deblended from a parent with more than one child.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedModelSource
     "@id": "#Object.detect_isDeblendedModelSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky source and is a deblended child
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedSource
     "@id": "#Object.detect_isDeblendedSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky source and is either an unblended isolated source or a deblended child from a parent with
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isIsolated
     "@id": "#Object.detect_isIsolated"
     datatype: boolean
     description: This source is not a part of a blend.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPatchInner
     "@id": "#Object.detect_isPatchInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd patch
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Object.detect_isPrimary"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isTractInner
     "@id": "#Object.detect_isTractInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd tract
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: footprintArea
     "@id": "#Object.footprintArea"
@@ -89,7 +81,6 @@ tables:
     "@id": "#Object.merge_peak_sky"
     datatype: boolean
     description: Peak detected in filter sky
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: parentObjectId
     "@id": "#Object.parentObjectId"
@@ -126,7 +117,6 @@ tables:
     "@id": "#Object.shape_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: shape_xx
     "@id": "#Object.shape_xx"
@@ -147,7 +137,6 @@ tables:
     "@id": "#Object.sky_object"
     datatype: boolean
     description: No source was detected here. This object exists to characterize properties of the sky background
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: skymap
     "@id": "#Object.skymap"
@@ -176,7 +165,6 @@ tables:
     "@id": "#Object.xy_flag"
     datatype: boolean
     description: General Failure Flag. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y
     "@id": "#Object.y"
@@ -202,7 +190,6 @@ tables:
     "@id": "#Object.g_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap06Flux
     "@id": "#Object.g_ap06Flux"
@@ -218,7 +205,6 @@ tables:
     "@id": "#Object.g_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap09Flux
     "@id": "#Object.g_ap09Flux"
@@ -234,7 +220,6 @@ tables:
     "@id": "#Object.g_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap12Flux
     "@id": "#Object.g_ap12Flux"
@@ -250,7 +235,6 @@ tables:
     "@id": "#Object.g_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap17Flux
     "@id": "#Object.g_ap17Flux"
@@ -266,7 +250,6 @@ tables:
     "@id": "#Object.g_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap25Flux
     "@id": "#Object.g_ap25Flux"
@@ -282,7 +265,6 @@ tables:
     "@id": "#Object.g_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap35Flux
     "@id": "#Object.g_ap35Flux"
@@ -298,7 +280,6 @@ tables:
     "@id": "#Object.g_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap50Flux
     "@id": "#Object.g_ap50Flux"
@@ -314,7 +295,6 @@ tables:
     "@id": "#Object.g_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap70Flux
     "@id": "#Object.g_ap70Flux"
@@ -330,25 +310,21 @@ tables:
     "@id": "#Object.g_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag
     "@id": "#Object.g_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_apertureTruncated
     "@id": "#Object.g_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_bdChi2
     "@id": "#Object.g_bdChi2"
@@ -404,7 +380,6 @@ tables:
     "@id": "#Object.g_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModelFlux
     "@id": "#Object.g_cModelFlux"
@@ -425,13 +400,11 @@ tables:
     "@id": "#Object.g_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModel_flag_apCorr
     "@id": "#Object.g_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux
     "@id": "#Object.g_calibFlux"
@@ -447,61 +420,51 @@ tables:
     "@id": "#Object.g_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_apertureTruncated
     "@id": "#Object.g_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_astrometry_used
     "@id": "#Object.g_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_reserved
     "@id": "#Object.g_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_used
     "@id": "#Object.g_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_candidate
     "@id": "#Object.g_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_reserved
     "@id": "#Object.g_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_used
     "@id": "#Object.g_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_flag
     "@id": "#Object.g_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_x
     "@id": "#Object.g_centroid_x"
@@ -538,7 +501,6 @@ tables:
     "@id": "#Object.g_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux
     "@id": "#Object.g_free_cModelFlux"
@@ -554,7 +516,6 @@ tables:
     "@id": "#Object.g_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux_inner
     "@id": "#Object.g_free_cModelFlux_inner"
@@ -575,7 +536,6 @@ tables:
     "@id": "#Object.g_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_fwhm
     "@id": "#Object.g_fwhm"
@@ -596,7 +556,6 @@ tables:
     "@id": "#Object.g_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap0p7Flux
     "@id": "#Object.g_gaap0p7Flux"
@@ -612,7 +571,6 @@ tables:
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p0Flux
     "@id": "#Object.g_gaap1p0Flux"
@@ -628,7 +586,6 @@ tables:
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p5Flux
     "@id": "#Object.g_gaap1p5Flux"
@@ -644,7 +601,6 @@ tables:
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap2p5Flux
     "@id": "#Object.g_gaap2p5Flux"
@@ -660,7 +616,6 @@ tables:
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap3p0Flux
     "@id": "#Object.g_gaap3p0Flux"
@@ -676,25 +631,21 @@ tables:
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag
     "@id": "#Object.g_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_edge
     "@id": "#Object.g_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_gaussianization
     "@id": "#Object.g_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapOptimalFlux
     "@id": "#Object.g_gaapOptimalFlux"
@@ -710,7 +661,6 @@ tables:
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapPsfFlux
     "@id": "#Object.g_gaapPsfFlux"
@@ -736,7 +686,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsmShapeRegauss_sigma
     "@id": "#Object.g_hsmShapeRegauss_sigma"
@@ -747,13 +696,11 @@ tables:
     "@id": "#Object.g_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iPSF_flag
     "@id": "#Object.g_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iRound_flag
     "@id": "#Object.g_iRound_flag"
@@ -764,7 +711,6 @@ tables:
     "@id": "#Object.g_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount
     "@id": "#Object.g_inputCount"
@@ -775,13 +721,11 @@ tables:
     "@id": "#Object.g_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount_flag_noInputs
     "@id": "#Object.g_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ixx
     "@id": "#Object.g_ixx"
@@ -857,61 +801,51 @@ tables:
     "@id": "#Object.g_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_radius
     "@id": "#Object.g_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape
     "@id": "#Object.g_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.g_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_edge
     "@id": "#Object.g_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_fallback_radius
     "@id": "#Object.g_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_minimum_radius
     "@id": "#Object.g_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_small_radius
     "@id": "#Object.g_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_minimum_radius
     "@id": "#Object.g_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_psf_radius
     "@id": "#Object.g_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronRad
     "@id": "#Object.g_kronRad"
@@ -922,103 +856,86 @@ tables:
     "@id": "#Object.g_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clipped
     "@id": "#Object.g_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clippedCenter
     "@id": "#Object.g_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_cr
     "@id": "#Object.g_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_crCenter
     "@id": "#Object.g_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_edge
     "@id": "#Object.g_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psf
     "@id": "#Object.g_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psfCenter
     "@id": "#Object.g_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolated
     "@id": "#Object.g_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolatedCenter
     "@id": "#Object.g_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_offimage
     "@id": "#Object.g_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturated
     "@id": "#Object.g_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturatedCenter
     "@id": "#Object.g_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edge
     "@id": "#Object.g_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edgeCenter
     "@id": "#Object.g_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspect
     "@id": "#Object.g_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspectCenter
     "@id": "#Object.g_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux
     "@id": "#Object.g_psfFlux"
@@ -1039,25 +956,21 @@ tables:
     "@id": "#Object.g_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_apCorr
     "@id": "#Object.g_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_edge
     "@id": "#Object.g_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_noGoodPixels
     "@id": "#Object.g_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ra
     "@id": "#Object.g_ra"
@@ -1079,7 +992,6 @@ tables:
     "@id": "#Object.i_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap06Flux
     "@id": "#Object.i_ap06Flux"
@@ -1095,7 +1007,6 @@ tables:
     "@id": "#Object.i_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap09Flux
     "@id": "#Object.i_ap09Flux"
@@ -1111,7 +1022,6 @@ tables:
     "@id": "#Object.i_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap12Flux
     "@id": "#Object.i_ap12Flux"
@@ -1127,7 +1037,6 @@ tables:
     "@id": "#Object.i_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap17Flux
     "@id": "#Object.i_ap17Flux"
@@ -1143,7 +1052,6 @@ tables:
     "@id": "#Object.i_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap25Flux
     "@id": "#Object.i_ap25Flux"
@@ -1159,7 +1067,6 @@ tables:
     "@id": "#Object.i_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap35Flux
     "@id": "#Object.i_ap35Flux"
@@ -1175,7 +1082,6 @@ tables:
     "@id": "#Object.i_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap50Flux
     "@id": "#Object.i_ap50Flux"
@@ -1191,7 +1097,6 @@ tables:
     "@id": "#Object.i_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap70Flux
     "@id": "#Object.i_ap70Flux"
@@ -1207,25 +1112,21 @@ tables:
     "@id": "#Object.i_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag
     "@id": "#Object.i_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_apertureTruncated
     "@id": "#Object.i_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_bdChi2
     "@id": "#Object.i_bdChi2"
@@ -1281,7 +1182,6 @@ tables:
     "@id": "#Object.i_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModelFlux
     "@id": "#Object.i_cModelFlux"
@@ -1302,13 +1202,11 @@ tables:
     "@id": "#Object.i_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModel_flag_apCorr
     "@id": "#Object.i_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux
     "@id": "#Object.i_calibFlux"
@@ -1324,61 +1222,51 @@ tables:
     "@id": "#Object.i_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_apertureTruncated
     "@id": "#Object.i_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_astrometry_used
     "@id": "#Object.i_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_reserved
     "@id": "#Object.i_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_used
     "@id": "#Object.i_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_candidate
     "@id": "#Object.i_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_reserved
     "@id": "#Object.i_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_used
     "@id": "#Object.i_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_flag
     "@id": "#Object.i_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_x
     "@id": "#Object.i_centroid_x"
@@ -1415,7 +1303,6 @@ tables:
     "@id": "#Object.i_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux
     "@id": "#Object.i_free_cModelFlux"
@@ -1431,7 +1318,6 @@ tables:
     "@id": "#Object.i_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux_inner
     "@id": "#Object.i_free_cModelFlux_inner"
@@ -1452,7 +1338,6 @@ tables:
     "@id": "#Object.i_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_fwhm
     "@id": "#Object.i_fwhm"
@@ -1473,7 +1358,6 @@ tables:
     "@id": "#Object.i_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap0p7Flux
     "@id": "#Object.i_gaap0p7Flux"
@@ -1489,7 +1373,6 @@ tables:
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p0Flux
     "@id": "#Object.i_gaap1p0Flux"
@@ -1505,7 +1388,6 @@ tables:
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p5Flux
     "@id": "#Object.i_gaap1p5Flux"
@@ -1521,7 +1403,6 @@ tables:
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap2p5Flux
     "@id": "#Object.i_gaap2p5Flux"
@@ -1537,7 +1418,6 @@ tables:
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap3p0Flux
     "@id": "#Object.i_gaap3p0Flux"
@@ -1553,25 +1433,21 @@ tables:
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag
     "@id": "#Object.i_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_edge
     "@id": "#Object.i_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_gaussianization
     "@id": "#Object.i_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapOptimalFlux
     "@id": "#Object.i_gaapOptimalFlux"
@@ -1587,7 +1463,6 @@ tables:
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapPsfFlux
     "@id": "#Object.i_gaapPsfFlux"
@@ -1613,7 +1488,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsmShapeRegauss_sigma
     "@id": "#Object.i_hsmShapeRegauss_sigma"
@@ -1624,13 +1498,11 @@ tables:
     "@id": "#Object.i_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iPSF_flag
     "@id": "#Object.i_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iRound_flag
     "@id": "#Object.i_iRound_flag"
@@ -1641,7 +1513,6 @@ tables:
     "@id": "#Object.i_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount
     "@id": "#Object.i_inputCount"
@@ -1652,13 +1523,11 @@ tables:
     "@id": "#Object.i_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount_flag_noInputs
     "@id": "#Object.i_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ixx
     "@id": "#Object.i_ixx"
@@ -1734,61 +1603,51 @@ tables:
     "@id": "#Object.i_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_radius
     "@id": "#Object.i_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape
     "@id": "#Object.i_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.i_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_edge
     "@id": "#Object.i_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_fallback_radius
     "@id": "#Object.i_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_minimum_radius
     "@id": "#Object.i_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_small_radius
     "@id": "#Object.i_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_minimum_radius
     "@id": "#Object.i_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_psf_radius
     "@id": "#Object.i_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronRad
     "@id": "#Object.i_kronRad"
@@ -1799,103 +1658,86 @@ tables:
     "@id": "#Object.i_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clipped
     "@id": "#Object.i_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clippedCenter
     "@id": "#Object.i_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_cr
     "@id": "#Object.i_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_crCenter
     "@id": "#Object.i_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_edge
     "@id": "#Object.i_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psf
     "@id": "#Object.i_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psfCenter
     "@id": "#Object.i_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolated
     "@id": "#Object.i_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolatedCenter
     "@id": "#Object.i_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_offimage
     "@id": "#Object.i_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturated
     "@id": "#Object.i_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturatedCenter
     "@id": "#Object.i_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edge
     "@id": "#Object.i_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edgeCenter
     "@id": "#Object.i_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspect
     "@id": "#Object.i_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspectCenter
     "@id": "#Object.i_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux
     "@id": "#Object.i_psfFlux"
@@ -1916,25 +1758,21 @@ tables:
     "@id": "#Object.i_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_apCorr
     "@id": "#Object.i_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_edge
     "@id": "#Object.i_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_noGoodPixels
     "@id": "#Object.i_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ra
     "@id": "#Object.i_ra"
@@ -1956,7 +1794,6 @@ tables:
     "@id": "#Object.r_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap06Flux
     "@id": "#Object.r_ap06Flux"
@@ -1972,7 +1809,6 @@ tables:
     "@id": "#Object.r_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap09Flux
     "@id": "#Object.r_ap09Flux"
@@ -1988,7 +1824,6 @@ tables:
     "@id": "#Object.r_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap12Flux
     "@id": "#Object.r_ap12Flux"
@@ -2004,7 +1839,6 @@ tables:
     "@id": "#Object.r_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap17Flux
     "@id": "#Object.r_ap17Flux"
@@ -2020,7 +1854,6 @@ tables:
     "@id": "#Object.r_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap25Flux
     "@id": "#Object.r_ap25Flux"
@@ -2036,7 +1869,6 @@ tables:
     "@id": "#Object.r_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap35Flux
     "@id": "#Object.r_ap35Flux"
@@ -2052,7 +1884,6 @@ tables:
     "@id": "#Object.r_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap50Flux
     "@id": "#Object.r_ap50Flux"
@@ -2068,7 +1899,6 @@ tables:
     "@id": "#Object.r_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap70Flux
     "@id": "#Object.r_ap70Flux"
@@ -2084,25 +1914,21 @@ tables:
     "@id": "#Object.r_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag
     "@id": "#Object.r_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_apertureTruncated
     "@id": "#Object.r_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_bdChi2
     "@id": "#Object.r_bdChi2"
@@ -2158,7 +1984,6 @@ tables:
     "@id": "#Object.r_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModelFlux
     "@id": "#Object.r_cModelFlux"
@@ -2179,13 +2004,11 @@ tables:
     "@id": "#Object.r_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModel_flag_apCorr
     "@id": "#Object.r_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux
     "@id": "#Object.r_calibFlux"
@@ -2201,61 +2024,51 @@ tables:
     "@id": "#Object.r_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_apertureTruncated
     "@id": "#Object.r_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_astrometry_used
     "@id": "#Object.r_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_reserved
     "@id": "#Object.r_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_used
     "@id": "#Object.r_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_candidate
     "@id": "#Object.r_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_reserved
     "@id": "#Object.r_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_used
     "@id": "#Object.r_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_flag
     "@id": "#Object.r_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_x
     "@id": "#Object.r_centroid_x"
@@ -2292,7 +2105,6 @@ tables:
     "@id": "#Object.r_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux
     "@id": "#Object.r_free_cModelFlux"
@@ -2308,7 +2120,6 @@ tables:
     "@id": "#Object.r_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux_inner
     "@id": "#Object.r_free_cModelFlux_inner"
@@ -2329,7 +2140,6 @@ tables:
     "@id": "#Object.r_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_fwhm
     "@id": "#Object.r_fwhm"
@@ -2350,7 +2160,6 @@ tables:
     "@id": "#Object.r_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap0p7Flux
     "@id": "#Object.r_gaap0p7Flux"
@@ -2366,7 +2175,6 @@ tables:
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p0Flux
     "@id": "#Object.r_gaap1p0Flux"
@@ -2382,7 +2190,6 @@ tables:
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p5Flux
     "@id": "#Object.r_gaap1p5Flux"
@@ -2398,7 +2205,6 @@ tables:
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap2p5Flux
     "@id": "#Object.r_gaap2p5Flux"
@@ -2414,7 +2220,6 @@ tables:
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap3p0Flux
     "@id": "#Object.r_gaap3p0Flux"
@@ -2430,25 +2235,21 @@ tables:
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag
     "@id": "#Object.r_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_edge
     "@id": "#Object.r_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_gaussianization
     "@id": "#Object.r_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapOptimalFlux
     "@id": "#Object.r_gaapOptimalFlux"
@@ -2464,7 +2265,6 @@ tables:
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapPsfFlux
     "@id": "#Object.r_gaapPsfFlux"
@@ -2490,7 +2290,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsmShapeRegauss_sigma
     "@id": "#Object.r_hsmShapeRegauss_sigma"
@@ -2501,13 +2300,11 @@ tables:
     "@id": "#Object.r_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iPSF_flag
     "@id": "#Object.r_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iRound_flag
     "@id": "#Object.r_iRound_flag"
@@ -2518,7 +2315,6 @@ tables:
     "@id": "#Object.r_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount
     "@id": "#Object.r_inputCount"
@@ -2529,13 +2325,11 @@ tables:
     "@id": "#Object.r_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount_flag_noInputs
     "@id": "#Object.r_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ixx
     "@id": "#Object.r_ixx"
@@ -2611,61 +2405,51 @@ tables:
     "@id": "#Object.r_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_radius
     "@id": "#Object.r_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape
     "@id": "#Object.r_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.r_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_edge
     "@id": "#Object.r_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_fallback_radius
     "@id": "#Object.r_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_minimum_radius
     "@id": "#Object.r_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_small_radius
     "@id": "#Object.r_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_minimum_radius
     "@id": "#Object.r_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_psf_radius
     "@id": "#Object.r_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronRad
     "@id": "#Object.r_kronRad"
@@ -2676,103 +2460,86 @@ tables:
     "@id": "#Object.r_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clipped
     "@id": "#Object.r_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clippedCenter
     "@id": "#Object.r_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_cr
     "@id": "#Object.r_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_crCenter
     "@id": "#Object.r_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_edge
     "@id": "#Object.r_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psf
     "@id": "#Object.r_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psfCenter
     "@id": "#Object.r_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolated
     "@id": "#Object.r_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolatedCenter
     "@id": "#Object.r_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_offimage
     "@id": "#Object.r_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturated
     "@id": "#Object.r_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturatedCenter
     "@id": "#Object.r_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edge
     "@id": "#Object.r_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edgeCenter
     "@id": "#Object.r_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspect
     "@id": "#Object.r_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspectCenter
     "@id": "#Object.r_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux
     "@id": "#Object.r_psfFlux"
@@ -2793,25 +2560,21 @@ tables:
     "@id": "#Object.r_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_apCorr
     "@id": "#Object.r_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_edge
     "@id": "#Object.r_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_noGoodPixels
     "@id": "#Object.r_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ra
     "@id": "#Object.r_ra"
@@ -2833,7 +2596,6 @@ tables:
     "@id": "#Object.u_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap06Flux
     "@id": "#Object.u_ap06Flux"
@@ -2849,7 +2611,6 @@ tables:
     "@id": "#Object.u_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap09Flux
     "@id": "#Object.u_ap09Flux"
@@ -2865,7 +2626,6 @@ tables:
     "@id": "#Object.u_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap12Flux
     "@id": "#Object.u_ap12Flux"
@@ -2881,7 +2641,6 @@ tables:
     "@id": "#Object.u_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap17Flux
     "@id": "#Object.u_ap17Flux"
@@ -2897,7 +2656,6 @@ tables:
     "@id": "#Object.u_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap25Flux
     "@id": "#Object.u_ap25Flux"
@@ -2913,7 +2671,6 @@ tables:
     "@id": "#Object.u_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap35Flux
     "@id": "#Object.u_ap35Flux"
@@ -2929,7 +2686,6 @@ tables:
     "@id": "#Object.u_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap50Flux
     "@id": "#Object.u_ap50Flux"
@@ -2945,7 +2701,6 @@ tables:
     "@id": "#Object.u_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap70Flux
     "@id": "#Object.u_ap70Flux"
@@ -2961,25 +2716,21 @@ tables:
     "@id": "#Object.u_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag
     "@id": "#Object.u_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag_apertureTruncated
     "@id": "#Object.u_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.u_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_bdChi2
     "@id": "#Object.u_bdChi2"
@@ -3035,7 +2786,6 @@ tables:
     "@id": "#Object.u_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_cModelFlux
     "@id": "#Object.u_cModelFlux"
@@ -3056,13 +2806,11 @@ tables:
     "@id": "#Object.u_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_cModel_flag_apCorr
     "@id": "#Object.u_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux
     "@id": "#Object.u_calibFlux"
@@ -3078,61 +2826,51 @@ tables:
     "@id": "#Object.u_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux_flag_apertureTruncated
     "@id": "#Object.u_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.u_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_astrometry_used
     "@id": "#Object.u_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_photometry_reserved
     "@id": "#Object.u_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_photometry_used
     "@id": "#Object.u_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_candidate
     "@id": "#Object.u_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_reserved
     "@id": "#Object.u_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_used
     "@id": "#Object.u_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_centroid_flag
     "@id": "#Object.u_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_centroid_x
     "@id": "#Object.u_centroid_x"
@@ -3169,7 +2907,6 @@ tables:
     "@id": "#Object.u_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_free_cModelFlux
     "@id": "#Object.u_free_cModelFlux"
@@ -3185,7 +2922,6 @@ tables:
     "@id": "#Object.u_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_free_cModelFlux_inner
     "@id": "#Object.u_free_cModelFlux_inner"
@@ -3206,7 +2942,6 @@ tables:
     "@id": "#Object.u_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_fwhm
     "@id": "#Object.u_fwhm"
@@ -3227,7 +2962,6 @@ tables:
     "@id": "#Object.u_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap0p7Flux
     "@id": "#Object.u_gaap0p7Flux"
@@ -3243,7 +2977,6 @@ tables:
     "@id": "#Object.u_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap1p0Flux
     "@id": "#Object.u_gaap1p0Flux"
@@ -3259,7 +2992,6 @@ tables:
     "@id": "#Object.u_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap1p5Flux
     "@id": "#Object.u_gaap1p5Flux"
@@ -3275,7 +3007,6 @@ tables:
     "@id": "#Object.u_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap2p5Flux
     "@id": "#Object.u_gaap2p5Flux"
@@ -3291,7 +3022,6 @@ tables:
     "@id": "#Object.u_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap3p0Flux
     "@id": "#Object.u_gaap3p0Flux"
@@ -3307,25 +3037,21 @@ tables:
     "@id": "#Object.u_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag
     "@id": "#Object.u_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag_edge
     "@id": "#Object.u_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag_gaussianization
     "@id": "#Object.u_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapOptimalFlux
     "@id": "#Object.u_gaapOptimalFlux"
@@ -3341,7 +3067,6 @@ tables:
     "@id": "#Object.u_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapPsfFlux
     "@id": "#Object.u_gaapPsfFlux"
@@ -3367,7 +3092,6 @@ tables:
     "@id": "#Object.u_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_hsmShapeRegauss_sigma
     "@id": "#Object.u_hsmShapeRegauss_sigma"
@@ -3378,13 +3102,11 @@ tables:
     "@id": "#Object.u_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_iPSF_flag
     "@id": "#Object.u_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_iRound_flag
     "@id": "#Object.u_iRound_flag"
@@ -3395,7 +3117,6 @@ tables:
     "@id": "#Object.u_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_inputCount
     "@id": "#Object.u_inputCount"
@@ -3406,13 +3127,11 @@ tables:
     "@id": "#Object.u_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_inputCount_flag_noInputs
     "@id": "#Object.u_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ixx
     "@id": "#Object.u_ixx"
@@ -3488,61 +3207,51 @@ tables:
     "@id": "#Object.u_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_radius
     "@id": "#Object.u_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_shape
     "@id": "#Object.u_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.u_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_edge
     "@id": "#Object.u_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_no_fallback_radius
     "@id": "#Object.u_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_no_minimum_radius
     "@id": "#Object.u_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_small_radius
     "@id": "#Object.u_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_used_minimum_radius
     "@id": "#Object.u_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_used_psf_radius
     "@id": "#Object.u_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronRad
     "@id": "#Object.u_kronRad"
@@ -3553,103 +3262,86 @@ tables:
     "@id": "#Object.u_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_clipped
     "@id": "#Object.u_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_clippedCenter
     "@id": "#Object.u_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_cr
     "@id": "#Object.u_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_crCenter
     "@id": "#Object.u_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_edge
     "@id": "#Object.u_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_inexact_psf
     "@id": "#Object.u_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_inexact_psfCenter
     "@id": "#Object.u_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_interpolated
     "@id": "#Object.u_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_interpolatedCenter
     "@id": "#Object.u_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_offimage
     "@id": "#Object.u_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_saturated
     "@id": "#Object.u_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_saturatedCenter
     "@id": "#Object.u_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_sensor_edge
     "@id": "#Object.u_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_sensor_edgeCenter
     "@id": "#Object.u_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_suspect
     "@id": "#Object.u_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_suspectCenter
     "@id": "#Object.u_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux
     "@id": "#Object.u_psfFlux"
@@ -3670,25 +3362,21 @@ tables:
     "@id": "#Object.u_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_apCorr
     "@id": "#Object.u_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_edge
     "@id": "#Object.u_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_noGoodPixels
     "@id": "#Object.u_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ra
     "@id": "#Object.u_ra"
@@ -3710,7 +3398,6 @@ tables:
     "@id": "#Object.y_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap06Flux
     "@id": "#Object.y_ap06Flux"
@@ -3726,7 +3413,6 @@ tables:
     "@id": "#Object.y_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap09Flux
     "@id": "#Object.y_ap09Flux"
@@ -3742,7 +3428,6 @@ tables:
     "@id": "#Object.y_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap12Flux
     "@id": "#Object.y_ap12Flux"
@@ -3758,7 +3443,6 @@ tables:
     "@id": "#Object.y_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap17Flux
     "@id": "#Object.y_ap17Flux"
@@ -3774,7 +3458,6 @@ tables:
     "@id": "#Object.y_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap25Flux
     "@id": "#Object.y_ap25Flux"
@@ -3790,7 +3473,6 @@ tables:
     "@id": "#Object.y_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap35Flux
     "@id": "#Object.y_ap35Flux"
@@ -3806,7 +3488,6 @@ tables:
     "@id": "#Object.y_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap50Flux
     "@id": "#Object.y_ap50Flux"
@@ -3822,7 +3503,6 @@ tables:
     "@id": "#Object.y_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap70Flux
     "@id": "#Object.y_ap70Flux"
@@ -3838,25 +3518,21 @@ tables:
     "@id": "#Object.y_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag
     "@id": "#Object.y_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_apertureTruncated
     "@id": "#Object.y_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_bdChi2
     "@id": "#Object.y_bdChi2"
@@ -3912,7 +3588,6 @@ tables:
     "@id": "#Object.y_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModelFlux
     "@id": "#Object.y_cModelFlux"
@@ -3933,13 +3608,11 @@ tables:
     "@id": "#Object.y_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModel_flag_apCorr
     "@id": "#Object.y_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux
     "@id": "#Object.y_calibFlux"
@@ -3955,61 +3628,51 @@ tables:
     "@id": "#Object.y_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_apertureTruncated
     "@id": "#Object.y_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_astrometry_used
     "@id": "#Object.y_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_reserved
     "@id": "#Object.y_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_used
     "@id": "#Object.y_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_candidate
     "@id": "#Object.y_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_reserved
     "@id": "#Object.y_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_used
     "@id": "#Object.y_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_flag
     "@id": "#Object.y_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_x
     "@id": "#Object.y_centroid_x"
@@ -4046,7 +3709,6 @@ tables:
     "@id": "#Object.y_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux
     "@id": "#Object.y_free_cModelFlux"
@@ -4062,7 +3724,6 @@ tables:
     "@id": "#Object.y_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux_inner
     "@id": "#Object.y_free_cModelFlux_inner"
@@ -4083,7 +3744,6 @@ tables:
     "@id": "#Object.y_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_fwhm
     "@id": "#Object.y_fwhm"
@@ -4104,7 +3764,6 @@ tables:
     "@id": "#Object.y_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap0p7Flux
     "@id": "#Object.y_gaap0p7Flux"
@@ -4120,7 +3779,6 @@ tables:
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p0Flux
     "@id": "#Object.y_gaap1p0Flux"
@@ -4136,7 +3794,6 @@ tables:
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p5Flux
     "@id": "#Object.y_gaap1p5Flux"
@@ -4152,7 +3809,6 @@ tables:
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap2p5Flux
     "@id": "#Object.y_gaap2p5Flux"
@@ -4168,7 +3824,6 @@ tables:
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap3p0Flux
     "@id": "#Object.y_gaap3p0Flux"
@@ -4184,25 +3839,21 @@ tables:
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag
     "@id": "#Object.y_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_edge
     "@id": "#Object.y_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_gaussianization
     "@id": "#Object.y_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapOptimalFlux
     "@id": "#Object.y_gaapOptimalFlux"
@@ -4218,7 +3869,6 @@ tables:
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapPsfFlux
     "@id": "#Object.y_gaapPsfFlux"
@@ -4244,7 +3894,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsmShapeRegauss_sigma
     "@id": "#Object.y_hsmShapeRegauss_sigma"
@@ -4255,13 +3904,11 @@ tables:
     "@id": "#Object.y_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iPSF_flag
     "@id": "#Object.y_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iRound_flag
     "@id": "#Object.y_iRound_flag"
@@ -4272,7 +3919,6 @@ tables:
     "@id": "#Object.y_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount
     "@id": "#Object.y_inputCount"
@@ -4283,13 +3929,11 @@ tables:
     "@id": "#Object.y_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount_flag_noInputs
     "@id": "#Object.y_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ixx
     "@id": "#Object.y_ixx"
@@ -4365,61 +4009,51 @@ tables:
     "@id": "#Object.y_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_radius
     "@id": "#Object.y_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape
     "@id": "#Object.y_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.y_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_edge
     "@id": "#Object.y_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_fallback_radius
     "@id": "#Object.y_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_minimum_radius
     "@id": "#Object.y_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_small_radius
     "@id": "#Object.y_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_minimum_radius
     "@id": "#Object.y_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_psf_radius
     "@id": "#Object.y_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronRad
     "@id": "#Object.y_kronRad"
@@ -4430,103 +4064,86 @@ tables:
     "@id": "#Object.y_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clipped
     "@id": "#Object.y_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clippedCenter
     "@id": "#Object.y_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_cr
     "@id": "#Object.y_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_crCenter
     "@id": "#Object.y_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_edge
     "@id": "#Object.y_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psf
     "@id": "#Object.y_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psfCenter
     "@id": "#Object.y_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolated
     "@id": "#Object.y_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolatedCenter
     "@id": "#Object.y_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_offimage
     "@id": "#Object.y_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturated
     "@id": "#Object.y_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturatedCenter
     "@id": "#Object.y_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edge
     "@id": "#Object.y_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edgeCenter
     "@id": "#Object.y_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspect
     "@id": "#Object.y_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspectCenter
     "@id": "#Object.y_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux
     "@id": "#Object.y_psfFlux"
@@ -4547,25 +4164,21 @@ tables:
     "@id": "#Object.y_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_apCorr
     "@id": "#Object.y_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_edge
     "@id": "#Object.y_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_noGoodPixels
     "@id": "#Object.y_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ra
     "@id": "#Object.y_ra"
@@ -4587,7 +4200,6 @@ tables:
     "@id": "#Object.z_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap06Flux
     "@id": "#Object.z_ap06Flux"
@@ -4603,7 +4215,6 @@ tables:
     "@id": "#Object.z_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap09Flux
     "@id": "#Object.z_ap09Flux"
@@ -4619,7 +4230,6 @@ tables:
     "@id": "#Object.z_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap12Flux
     "@id": "#Object.z_ap12Flux"
@@ -4635,7 +4245,6 @@ tables:
     "@id": "#Object.z_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap17Flux
     "@id": "#Object.z_ap17Flux"
@@ -4651,7 +4260,6 @@ tables:
     "@id": "#Object.z_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap25Flux
     "@id": "#Object.z_ap25Flux"
@@ -4667,7 +4275,6 @@ tables:
     "@id": "#Object.z_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap35Flux
     "@id": "#Object.z_ap35Flux"
@@ -4683,7 +4290,6 @@ tables:
     "@id": "#Object.z_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap50Flux
     "@id": "#Object.z_ap50Flux"
@@ -4699,7 +4305,6 @@ tables:
     "@id": "#Object.z_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap70Flux
     "@id": "#Object.z_ap70Flux"
@@ -4715,25 +4320,21 @@ tables:
     "@id": "#Object.z_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag
     "@id": "#Object.z_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_apertureTruncated
     "@id": "#Object.z_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_bdChi2
     "@id": "#Object.z_bdChi2"
@@ -4789,7 +4390,6 @@ tables:
     "@id": "#Object.z_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModelFlux
     "@id": "#Object.z_cModelFlux"
@@ -4810,13 +4410,11 @@ tables:
     "@id": "#Object.z_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModel_flag_apCorr
     "@id": "#Object.z_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux
     "@id": "#Object.z_calibFlux"
@@ -4832,61 +4430,51 @@ tables:
     "@id": "#Object.z_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_apertureTruncated
     "@id": "#Object.z_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_astrometry_used
     "@id": "#Object.z_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_reserved
     "@id": "#Object.z_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_used
     "@id": "#Object.z_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_candidate
     "@id": "#Object.z_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_reserved
     "@id": "#Object.z_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_used
     "@id": "#Object.z_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_flag
     "@id": "#Object.z_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_x
     "@id": "#Object.z_centroid_x"
@@ -4923,7 +4511,6 @@ tables:
     "@id": "#Object.z_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux
     "@id": "#Object.z_free_cModelFlux"
@@ -4939,7 +4526,6 @@ tables:
     "@id": "#Object.z_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux_inner
     "@id": "#Object.z_free_cModelFlux_inner"
@@ -4960,7 +4546,6 @@ tables:
     "@id": "#Object.z_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_fwhm
     "@id": "#Object.z_fwhm"
@@ -4981,7 +4566,6 @@ tables:
     "@id": "#Object.z_gaap0p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap0p7Flux
     "@id": "#Object.z_gaap0p7Flux"
@@ -4997,7 +4581,6 @@ tables:
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p0Flux
     "@id": "#Object.z_gaap1p0Flux"
@@ -5013,7 +4596,6 @@ tables:
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p5Flux
     "@id": "#Object.z_gaap1p5Flux"
@@ -5029,7 +4611,6 @@ tables:
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap2p5Flux
     "@id": "#Object.z_gaap2p5Flux"
@@ -5045,7 +4626,6 @@ tables:
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap3p0Flux
     "@id": "#Object.z_gaap3p0Flux"
@@ -5061,25 +4641,21 @@ tables:
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag
     "@id": "#Object.z_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_edge
     "@id": "#Object.z_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_gaussianization
     "@id": "#Object.z_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapOptimalFlux
     "@id": "#Object.z_gaapOptimalFlux"
@@ -5095,7 +4671,6 @@ tables:
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapPsfFlux
     "@id": "#Object.z_gaapPsfFlux"
@@ -5121,7 +4696,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsmShapeRegauss_sigma
     "@id": "#Object.z_hsmShapeRegauss_sigma"
@@ -5132,13 +4706,11 @@ tables:
     "@id": "#Object.z_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iPSF_flag
     "@id": "#Object.z_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iRound_flag
     "@id": "#Object.z_iRound_flag"
@@ -5149,7 +4721,6 @@ tables:
     "@id": "#Object.z_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount
     "@id": "#Object.z_inputCount"
@@ -5160,13 +4731,11 @@ tables:
     "@id": "#Object.z_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount_flag_noInputs
     "@id": "#Object.z_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ixx
     "@id": "#Object.z_ixx"
@@ -5242,61 +4811,51 @@ tables:
     "@id": "#Object.z_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_radius
     "@id": "#Object.z_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape
     "@id": "#Object.z_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.z_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_edge
     "@id": "#Object.z_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_fallback_radius
     "@id": "#Object.z_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_minimum_radius
     "@id": "#Object.z_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not be enforced, no minimum value or PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_small_radius
     "@id": "#Object.z_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_minimum_radius
     "@id": "#Object.z_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_psf_radius
     "@id": "#Object.z_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronRad
     "@id": "#Object.z_kronRad"
@@ -5307,103 +4866,86 @@ tables:
     "@id": "#Object.z_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clipped
     "@id": "#Object.z_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clippedCenter
     "@id": "#Object.z_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_cr
     "@id": "#Object.z_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_crCenter
     "@id": "#Object.z_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_edge
     "@id": "#Object.z_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psf
     "@id": "#Object.z_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psfCenter
     "@id": "#Object.z_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolated
     "@id": "#Object.z_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolatedCenter
     "@id": "#Object.z_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_offimage
     "@id": "#Object.z_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturated
     "@id": "#Object.z_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturatedCenter
     "@id": "#Object.z_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edge
     "@id": "#Object.z_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edgeCenter
     "@id": "#Object.z_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspect
     "@id": "#Object.z_pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspectCenter
     "@id": "#Object.z_pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux
     "@id": "#Object.z_psfFlux"
@@ -5424,25 +4966,21 @@ tables:
     "@id": "#Object.z_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_apCorr
     "@id": "#Object.z_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_edge
     "@id": "#Object.z_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_noGoodPixels
     "@id": "#Object.z_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ra
     "@id": "#Object.z_ra"
@@ -5542,7 +5080,6 @@ tables:
     "@id": "#Source.ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap06Flux
     "@id": "#Source.ap06Flux"
@@ -5558,7 +5095,6 @@ tables:
     "@id": "#Source.ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap09Flux
     "@id": "#Source.ap09Flux"
@@ -5574,7 +5110,6 @@ tables:
     "@id": "#Source.ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap12Flux
     "@id": "#Source.ap12Flux"
@@ -5590,7 +5125,6 @@ tables:
     "@id": "#Source.ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap17Flux
     "@id": "#Source.ap17Flux"
@@ -5606,7 +5140,6 @@ tables:
     "@id": "#Source.ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap25Flux
     "@id": "#Source.ap25Flux"
@@ -5622,7 +5155,6 @@ tables:
     "@id": "#Source.ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap35Flux
     "@id": "#Source.ap35Flux"
@@ -5638,7 +5170,6 @@ tables:
     "@id": "#Source.ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap50Flux
     "@id": "#Source.ap50Flux"
@@ -5654,7 +5185,6 @@ tables:
     "@id": "#Source.ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap70Flux
     "@id": "#Source.ap70Flux"
@@ -5670,7 +5200,6 @@ tables:
     "@id": "#Source.ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky
     "@id": "#Source.sky"
@@ -5746,7 +5275,6 @@ tables:
     "@id": "#Source.localPhotoCalib_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localPhotoCalibErr
     "@id": "#Source.localPhotoCalibErr"
@@ -5757,7 +5285,6 @@ tables:
     "@id": "#Source.localWcs_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localWcs_CDMatrix_2_1
     "@id": "#Source.localWcs_CDMatrix_2_1"
@@ -5788,37 +5315,31 @@ tables:
     "@id": "#Source.blendedness_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noCentroid
     "@id": "#Source.blendedness_flag_noCentroid"
     datatype: boolean
     description: Object has no centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noShape
     "@id": "#Source.blendedness_flag_noShape"
     datatype: boolean
     description: Object has no shape
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag
     "@id": "#Source.apFlux_12_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_apertureTruncated
     "@id": "#Source.apFlux_12_0_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_sincCoeffsTruncated
     "@id": "#Source.apFlux_12_0_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_instFlux
     "@id": "#Source.apFlux_12_0_instFlux"
@@ -5834,7 +5355,6 @@ tables:
     "@id": "#Source.apFlux_17_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_17_0_instFlux
     "@id": "#Source.apFlux_17_0_instFlux"
@@ -5850,7 +5370,6 @@ tables:
     "@id": "#Source.extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: footprintArea_value
     "@id": "#Source.footprintArea_value"
@@ -5861,7 +5380,6 @@ tables:
     "@id": "#Source.jacobian_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: jacobian_value
     "@id": "#Source.jacobian_value"
@@ -5882,85 +5400,71 @@ tables:
     "@id": "#Source.localBackground_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noGoodPixels
     "@id": "#Source.localBackground_flag_noGoodPixels"
     datatype: boolean
     description: No good pixels in the annulus
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noPsf
     "@id": "#Source.localBackground_flag_noPsf"
     datatype: boolean
     description: No PSF provided
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#Source.pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#Source.pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#Source.pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#Source.pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#Source.pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#Source.pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_offimage
     "@id": "#Source.pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#Source.pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#Source.pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#Source.pixelFlags_suspect"
     datatype: boolean
     description: Source's footprint includes suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#Source.pixelFlags_suspectCenter"
     datatype: boolean
     description: Source's center is close to suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_apCorr
     "@id": "#Source.psfFlux_apCorr"
@@ -5981,85 +5485,71 @@ tables:
     "@id": "#Source.psfFlux_flag"
     datatype: boolean
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_apCorr
     "@id": "#Source.psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_edge
     "@id": "#Source.psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: gaussianFlux_flag
     "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag
     "@id": "#Source.centroid_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_almostNoSecondDerivative
     "@id": "#Source.centroid_flag_almostNoSecondDerivative"
     datatype: boolean
     description: Almost vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_badError
     "@id": "#Source.centroid_flag_badError"
     datatype: boolean
     description: Uncertainty on x and/or y position is NaN
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_edge
     "@id": "#Source.centroid_flag_edge"
     datatype: boolean
     description: Object too close to edge
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_noSecondDerivative
     "@id": "#Source.centroid_flag_noSecondDerivative"
     datatype: boolean
     description: Vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_notAtMaximum
     "@id": "#Source.centroid_flag_notAtMaximum"
     datatype: boolean
     description: Object is not at a maximum
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_resetToPeak
     "@id": "#Source.centroid_flag_resetToPeak"
     datatype: boolean
     description: Set if CentroidChecker reset the centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag
     "@id": "#Source.variance_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag_emptyFootprint
     "@id": "#Source.variance_flag_emptyFootprint"
     datatype: boolean
     description: Set to True when the footprint has no usable pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_value
     "@id": "#Source.variance_value"
@@ -6070,61 +5560,51 @@ tables:
     "@id": "#Source.calib_astrometry_used"
     datatype: boolean
     description: Set if source was used in astrometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_detected
     "@id": "#Source.calib_detected"
     datatype: boolean
     description: Source was detected as an image characterization source (icSrc)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_reserved
     "@id": "#Source.calib_photometry_reserved"
     datatype: boolean
     description: Set if source was reserved from photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_used
     "@id": "#Source.calib_photometry_used"
     datatype: boolean
     description: Set if source was used in photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_candidate
     "@id": "#Source.calib_psf_candidate"
     datatype: boolean
     description: Flag set if the source was a candidate for PSF determination, as determined by the star selector.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_reserved
     "@id": "#Source.calib_psf_reserved"
     datatype: boolean
     description: Set if source was reserved from PSF determination
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_used
     "@id": "#Source.calib_psf_used"
     datatype: boolean
     description: Flag set if the source was actually used for PSF determination, as determined by the
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_deblendedAsPsf
     "@id": "#Source.deblend_deblendedAsPsf"
     datatype: boolean
     description: Deblender thought this source looked like a PSF
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_hasStrayFlux
     "@id": "#Source.deblend_hasStrayFlux"
     datatype: boolean
     description: This source was assigned some stray flux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_masked
     "@id": "#Source.deblend_masked"
     datatype: boolean
     description: Parent footprint was predominantly masked
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_nChild
     "@id": "#Source.deblend_nChild"
@@ -6135,97 +5615,81 @@ tables:
     "@id": "#Source.deblend_parentTooBig"
     datatype: boolean
     description: Parent footprint covered too many pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_patchedTemplate
     "@id": "#Source.deblend_patchedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used patched edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_rampedTemplate
     "@id": "#Source.deblend_rampedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used ramp edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Source.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_tooManyPeaks
     "@id": "#Source.deblend_tooManyPeaks"
     datatype: boolean
     description: Source had too many peaks; only the brightest were included
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag
     "@id": "#Source.hsmPsfMoments_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_no_pixels
     "@id": "#Source.hsmPsfMoments_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_not_contained
     "@id": "#Source.hsmPsfMoments_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_parent_source
     "@id": "#Source.hsmPsfMoments_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag
     "@id": "#Source.hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_galsim
     "@id": "#Source.hsmShapeRegauss_flag_galsim"
     datatype: boolean
     description: GalSim failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_no_pixels
     "@id": "#Source.hsmShapeRegauss_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_not_contained
     "@id": "#Source.hsmShapeRegauss_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_parent_source
     "@id": "#Source.hsmShapeRegauss_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky_source
     "@id": "#Source.sky_source"
     datatype: boolean
     description: Sky objects.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Source.detect_isPrimary"
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: band
     "@id": "#Source.band"
@@ -6368,7 +5832,6 @@ tables:
   - name: detect_isPatchInner
     "@id": "#ForcedSource.detect_isPatchInner"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd patch
     fits:tunit:
     ivoa:ucd: meta.code
@@ -6377,7 +5840,6 @@ tables:
   - name: detect_isPrimary
     "@id": "#ForcedSource.detect_isPrimary"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -6386,7 +5848,6 @@ tables:
   - name: detect_isTractInner
     "@id": "#ForcedSource.detect_isTractInner"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd tract
     fits:tunit:
     ivoa:ucd: meta.code
@@ -6419,7 +5880,6 @@ tables:
   - name: localPhotoCalib_flag
     "@id": "#ForcedSource.localPhotoCalib_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -6468,7 +5928,6 @@ tables:
   - name: localWcs_flag
     "@id": "#ForcedSource.localWcs_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -6477,7 +5936,6 @@ tables:
   - name: pixelFlags_bad
     "@id": "#ForcedSource.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6486,7 +5944,6 @@ tables:
   - name: pixelFlags_crCenter
     "@id": "#ForcedSource.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6495,7 +5952,6 @@ tables:
   - name: pixelFlags_cr
     "@id": "#ForcedSource.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6504,7 +5960,6 @@ tables:
   - name: pixelFlags_edge
     "@id": "#ForcedSource.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6513,7 +5968,6 @@ tables:
   - name: pixelFlags_interpolatedCenter
     "@id": "#ForcedSource.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6522,7 +5976,6 @@ tables:
   - name: pixelFlags_interpolated
     "@id": "#ForcedSource.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6531,7 +5984,6 @@ tables:
   - name: pixelFlags_saturatedCenter
     "@id": "#ForcedSource.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6540,7 +5992,6 @@ tables:
   - name: pixelFlags_saturated
     "@id": "#ForcedSource.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6549,7 +6000,6 @@ tables:
   - name: pixelFlags_suspectCenter
     "@id": "#ForcedSource.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's center is close to suspect pixels
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6558,7 +6008,6 @@ tables:
   - name: pixelFlags_suspect
     "@id": "#ForcedSource.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's footprint includes suspect pixels
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -6575,7 +6024,6 @@ tables:
   - name: psfDiffFlux_flag
     "@id": "#ForcedSource.psfDiffFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the image difference
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -6600,7 +6048,6 @@ tables:
   - name: psfFlux_flag
     "@id": "#ForcedSource.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -7213,13 +6660,11 @@ tables:
   - name: apFlux_flag
     "@id": "#DiaSource.apFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General Failure Flag
     fits:tunit:
   - name: apFlux_flag_apertureTruncated
     "@id": "#DiaSource.apFlux_flag_apertureTruncated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Aperture did not fit within measurement image
     fits:tunit:
   - name: bboxSize
@@ -7236,19 +6681,16 @@ tables:
   - name: centroid_flag
     "@id": "#DiaSource.centroid_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General failure flag, set if anything went wrong
     fits:tunit:
   - name: centroid_neg_flag
     "@id": "#DiaSource.centroid_neg_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure flag for negative, set if anything went wrong
     fits:tunit:
   - name: centroid_pos_flag
     "@id": "#DiaSource.centroid_pos_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure flag for positive, set if anything went wrong
     fits:tunit:
   - name: coord_dec
@@ -7326,25 +6768,21 @@ tables:
   - name: forced_PsfFlux_flag
     "@id": "#DiaSource.forced_PsfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux general failure flag.
     fits:tunit:
   - name: forced_PsfFlux_flag_edge
     "@id": "#DiaSource.forced_PsfFlux_flag_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux object was too close to the edge of the image to use the full PSF model.
     fits:tunit:
   - name: forced_PsfFlux_flag_noGoodPixels
     "@id": "#DiaSource.forced_PsfFlux_flag_noGoodPixels"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux not enough non-rejected pixels in data to attempt the fit.
     fits:tunit:
   - name: isDipole
     "@id": "#DiaSource.isDipole"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Flag indicating diaSource is classified as a dipole
     fits:tunit:
   - name: ixx
@@ -7391,73 +6829,61 @@ tables:
   - name: pixelFlags
     "@id": "#DiaSource.pixelFlags"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General failure flag, set if anything went wrong
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#DiaSource.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#DiaSource.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#DiaSource.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#DiaSource.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#DiaSource.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#DiaSource.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_offimage
     "@id": "#DiaSource.pixelFlags_offimage"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source center is off image
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#DiaSource.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#DiaSource.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#DiaSource.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's footprint includes suspect pixels
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#DiaSource.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's center is close to suspect pixels
     fits:tunit:
   - name: pixelId
@@ -7478,19 +6904,16 @@ tables:
   - name: psfFlux_flag
     "@id": "#DiaSource.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
   - name: psfFlux_flag_edge
     "@id": "#DiaSource.psfFlux_flag_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Object was too close to the edge of the image to use the full PSF model
     fits:tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#DiaSource.psfFlux_flag_noGoodPixels"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Not enough non-rejected pixels in data to attempt the fit
     fits:tunit:
   - name: ra
@@ -7502,37 +6925,31 @@ tables:
   - name: shape_flag
     "@id": "#DiaSource.shape_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General Failure Flag
     fits:tunit:
   - name: shape_flag_maxIter
     "@id": "#DiaSource.shape_flag_maxIter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Too many iterations in adaptive moments
     fits:tunit:
   - name: shape_flag_psf
     "@id": "#DiaSource.shape_flag_psf"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure in measuring PSF model shape
     fits:tunit:
   - name: shape_flag_shift
     "@id": "#DiaSource.shape_flag_shift"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Centroid shifted by more than the maximum allowed amount
     fits:tunit:
   - name: shape_flag_unweighted
     "@id": "#DiaSource.shape_flag_unweighted"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Weighted moments converged to an invalid value; using unweighted moments
     fits:tunit:
   - name: shape_flag_unweightedBad
     "@id": "#DiaSource.shape_flag_unweightedBad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Both weighted and unweighted moments were invalid
     fits:tunit:
   - name: snr
@@ -7685,7 +7102,6 @@ tables:
   - name: localPhotoCalib_flag
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalib_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -7726,7 +7142,6 @@ tables:
   - name: localWcs_flag
     "@id": "#ForcedSourceOnDiaObject.localWcs_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -7751,7 +7166,6 @@ tables:
   - name: pixelFlags_bad
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7760,7 +7174,6 @@ tables:
   - name: pixelFlags_cr
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7769,7 +7182,6 @@ tables:
   - name: pixelFlags_crCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7778,7 +7190,6 @@ tables:
   - name: pixelFlags_edge
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7787,7 +7198,6 @@ tables:
   - name: pixelFlags_interpolated
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7796,7 +7206,6 @@ tables:
   - name: pixelFlags_interpolatedCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7805,7 +7214,6 @@ tables:
   - name: pixelFlags_saturated
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7814,7 +7222,6 @@ tables:
   - name: pixelFlags_saturatedCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7823,7 +7230,6 @@ tables:
   - name: pixelFlags_suspect
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's footprint includes suspect pixels
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7832,7 +7238,6 @@ tables:
   - name: pixelFlags_suspectCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source's center is close to suspect pixels
     fits:tunit:
     ivoa:ucd: meta.code.qual;instr.pixel
@@ -7857,7 +7262,6 @@ tables:
   - name: psfDiffFlux_flag
     "@id": "#ForcedSourceOnDiaObject.psfDiffFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the image difference
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -7882,7 +7286,6 @@ tables:
   - name: psfFlux_flag
     "@id": "#ForcedSourceOnDiaObject.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
     ivoa:ucd: meta.code.qual
@@ -8388,7 +7791,6 @@ tables:
   - name: match_candidate
     '@id': '#MatchesTruth.match_candidate'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     tap:column_index: 999
     tap:principal: 0
     description: True for sources that were selected for matching

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -54,43 +54,36 @@ tables:
     "@id": "#Object.deblend_failed"
     datatype: boolean
     description: Deblender failed to deblend this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Object.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_isolatedParent
     "@id": "#Object.deblend_isolatedParent"
     datatype: boolean
     description: Deblender skipped this footprint because there was only a single peak
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_parentTooBig
     "@id": "#Object.deblend_parentTooBig"
     datatype: boolean
     description: Deblender skipped this source because the parent footprint was too large.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_tooManyPeaks
     "@id": "#Object.deblend_tooManyPeaks"
     datatype: boolean
     description: Deblender skipped this source because there were too many peaks in the Footprint.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_masked
     "@id": "#Object.deblend_masked"
     datatype: boolean
     description: Deblender skipped this source because there were too many masked pixels.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_incompleteData
     "@id": "#Object.deblend_incompleteData"
     datatype: boolean
     description: One or more bands were not deblended due to an inability to model the PSF.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_iterations
     "@id": "#Object.deblend_iterations"
@@ -116,43 +109,36 @@ tables:
     "@id": "#Object.detect_fromBlend"
     datatype: boolean
     description: This source is deblended from a parent with more than one child.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedModelSource
     "@id": "#Object.detect_isDeblendedModelSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is a deblended child
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedSource
     "@id": "#Object.detect_isDeblendedSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isIsolated
     "@id": "#Object.detect_isIsolated"
     datatype: boolean
     description: This source is not a part of a blend.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPatchInner
     "@id": "#Object.detect_isPatchInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd patch
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Object.detect_isPrimary"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isTractInner
     "@id": "#Object.detect_isTractInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd tract
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ebv
     "@id": "#Object.ebv"
@@ -168,7 +154,6 @@ tables:
     "@id": "#Object.merge_peak_sky"
     datatype: boolean
     description: Peak detected in filter sky
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: parentObjectId
     "@id": "#Object.parentObjectId"
@@ -206,7 +191,6 @@ tables:
     "@id": "#Object.shape_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: shape_xx
     "@id": "#Object.shape_xx"
@@ -227,7 +211,6 @@ tables:
     "@id": "#Object.sky_object"
     datatype: boolean
     description: No source was detected here. This object exists to characterize properties of the sky background
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: tract
     "@id": "#Object.tract"
@@ -248,7 +231,6 @@ tables:
     "@id": "#Object.xy_flag"
     datatype: boolean
     description: General Failure Flag. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y
     "@id": "#Object.y"
@@ -274,7 +256,6 @@ tables:
     "@id": "#Object.g_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap06Flux
     "@id": "#Object.g_ap06Flux"
@@ -290,7 +271,6 @@ tables:
     "@id": "#Object.g_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap09Flux
     "@id": "#Object.g_ap09Flux"
@@ -306,7 +286,6 @@ tables:
     "@id": "#Object.g_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap12Flux
     "@id": "#Object.g_ap12Flux"
@@ -322,7 +301,6 @@ tables:
     "@id": "#Object.g_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap17Flux
     "@id": "#Object.g_ap17Flux"
@@ -338,7 +316,6 @@ tables:
     "@id": "#Object.g_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap25Flux
     "@id": "#Object.g_ap25Flux"
@@ -354,7 +331,6 @@ tables:
     "@id": "#Object.g_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap35Flux
     "@id": "#Object.g_ap35Flux"
@@ -370,7 +346,6 @@ tables:
     "@id": "#Object.g_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap50Flux
     "@id": "#Object.g_ap50Flux"
@@ -386,7 +361,6 @@ tables:
     "@id": "#Object.g_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap70Flux
     "@id": "#Object.g_ap70Flux"
@@ -402,25 +376,21 @@ tables:
     "@id": "#Object.g_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag
     "@id": "#Object.g_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_apertureTruncated
     "@id": "#Object.g_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_bdChi2
     "@id": "#Object.g_bdChi2"
@@ -476,7 +446,6 @@ tables:
     "@id": "#Object.g_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModelFlux
     "@id": "#Object.g_cModelFlux"
@@ -497,13 +466,11 @@ tables:
     "@id": "#Object.g_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModel_flag_apCorr
     "@id": "#Object.g_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux
     "@id": "#Object.g_calibFlux"
@@ -519,61 +486,51 @@ tables:
     "@id": "#Object.g_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_apertureTruncated
     "@id": "#Object.g_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_astrometry_used
     "@id": "#Object.g_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_reserved
     "@id": "#Object.g_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_used
     "@id": "#Object.g_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_candidate
     "@id": "#Object.g_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_reserved
     "@id": "#Object.g_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_used
     "@id": "#Object.g_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_flag
     "@id": "#Object.g_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_x
     "@id": "#Object.g_centroid_x"
@@ -620,7 +577,6 @@ tables:
     "@id": "#Object.g_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_sizeExtendedness
     "@id": "#Object.g_sizeExtendedness"
@@ -631,7 +587,6 @@ tables:
     "@id": "#Object.g_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux
     "@id": "#Object.g_free_cModelFlux"
@@ -647,7 +602,6 @@ tables:
     "@id": "#Object.g_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux_inner
     "@id": "#Object.g_free_cModelFlux_inner"
@@ -668,7 +622,6 @@ tables:
     "@id": "#Object.g_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_fwhm
     "@id": "#Object.g_fwhm"
@@ -724,7 +677,6 @@ tables:
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap0p7Flux
     "@id": "#Object.g_gaap0p7Flux"
@@ -735,7 +687,6 @@ tables:
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p0Flux
     "@id": "#Object.g_gaap1p0Flux"
@@ -746,7 +697,6 @@ tables:
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p5Flux
     "@id": "#Object.g_gaap1p5Flux"
@@ -757,7 +707,6 @@ tables:
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap2p5Flux
     "@id": "#Object.g_gaap2p5Flux"
@@ -768,7 +717,6 @@ tables:
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap3p0Flux
     "@id": "#Object.g_gaap3p0Flux"
@@ -779,25 +727,21 @@ tables:
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag
     "@id": "#Object.g_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_edge
     "@id": "#Object.g_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_gaussianization
     "@id": "#Object.g_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsmShapeRegauss_e1
     "@id": "#Object.g_hsmShapeRegauss_e1"
@@ -813,7 +757,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsmShapeRegauss_sigma
     "@id": "#Object.g_hsmShapeRegauss_sigma"
@@ -824,13 +767,11 @@ tables:
     "@id": "#Object.g_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iPSF_flag
     "@id": "#Object.g_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iRound_flag
     "@id": "#Object.g_iRound_flag"
@@ -841,7 +782,6 @@ tables:
     "@id": "#Object.g_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount
     "@id": "#Object.g_inputCount"
@@ -852,13 +792,11 @@ tables:
     "@id": "#Object.g_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount_flag_noInputs
     "@id": "#Object.g_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ixx
     "@id": "#Object.g_ixx"
@@ -1014,13 +952,11 @@ tables:
     "@id": "#Object.g_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with g_i_flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsm_momentsPsf_flag
     "@id": "#Object.g_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with g_iPSF_flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux
     "@id": "#Object.g_kronFlux"
@@ -1036,61 +972,51 @@ tables:
     "@id": "#Object.g_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_radius
     "@id": "#Object.g_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape
     "@id": "#Object.g_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.g_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_edge
     "@id": "#Object.g_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_fallback_radius
     "@id": "#Object.g_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_minimum_radius
     "@id": "#Object.g_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_small_radius
     "@id": "#Object.g_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_minimum_radius
     "@id": "#Object.g_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_psf_radius
     "@id": "#Object.g_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronRad
     "@id": "#Object.g_kronRad"
@@ -1101,114 +1027,95 @@ tables:
     "@id": "#Object.g_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clipped
     "@id": "#Object.g_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clippedCenter
     "@id": "#Object.g_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_cr
     "@id": "#Object.g_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_crCenter
     "@id": "#Object.g_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_edge
     "@id": "#Object.g_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psf
     "@id": "#Object.g_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psfCenter
     "@id": "#Object.g_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolated
     "@id": "#Object.g_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolatedCenter
     "@id": "#Object.g_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_offimage
     "@id": "#Object.g_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturated
     "@id": "#Object.g_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturatedCenter
     "@id": "#Object.g_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edge
     "@id": "#Object.g_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edgeCenter
     "@id": "#Object.g_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspect
     "@id": "#Object.g_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspectCenter
     "@id": "#Object.g_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_streak
     "@id": "#Object.g_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on g-band.
     fits:tunit:
   - name: g_pixelFlags_streakCenter
     "@id": "#Object.g_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on g-band.
     fits:tunit:
   - name: g_psfFlux
@@ -1230,25 +1137,21 @@ tables:
     "@id": "#Object.g_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_apCorr
     "@id": "#Object.g_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_edge
     "@id": "#Object.g_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_noGoodPixels
     "@id": "#Object.g_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ra
     "@id": "#Object.g_ra"
@@ -1289,7 +1192,6 @@ tables:
     "@id": "#Object.g_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap03Flux
     "@id": "#Object.i_ap03Flux"
@@ -1305,7 +1207,6 @@ tables:
     "@id": "#Object.i_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap06Flux
     "@id": "#Object.i_ap06Flux"
@@ -1321,7 +1222,6 @@ tables:
     "@id": "#Object.i_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap09Flux
     "@id": "#Object.i_ap09Flux"
@@ -1337,7 +1237,6 @@ tables:
     "@id": "#Object.i_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap12Flux
     "@id": "#Object.i_ap12Flux"
@@ -1353,7 +1252,6 @@ tables:
     "@id": "#Object.i_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap17Flux
     "@id": "#Object.i_ap17Flux"
@@ -1369,7 +1267,6 @@ tables:
     "@id": "#Object.i_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap25Flux
     "@id": "#Object.i_ap25Flux"
@@ -1385,7 +1282,6 @@ tables:
     "@id": "#Object.i_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap35Flux
     "@id": "#Object.i_ap35Flux"
@@ -1401,7 +1297,6 @@ tables:
     "@id": "#Object.i_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap50Flux
     "@id": "#Object.i_ap50Flux"
@@ -1417,7 +1312,6 @@ tables:
     "@id": "#Object.i_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap70Flux
     "@id": "#Object.i_ap70Flux"
@@ -1433,25 +1327,21 @@ tables:
     "@id": "#Object.i_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag
     "@id": "#Object.i_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_apertureTruncated
     "@id": "#Object.i_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_bdChi2
     "@id": "#Object.i_bdChi2"
@@ -1507,7 +1397,6 @@ tables:
     "@id": "#Object.i_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModelFlux
     "@id": "#Object.i_cModelFlux"
@@ -1528,13 +1417,11 @@ tables:
     "@id": "#Object.i_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModel_flag_apCorr
     "@id": "#Object.i_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux
     "@id": "#Object.i_calibFlux"
@@ -1550,61 +1437,51 @@ tables:
     "@id": "#Object.i_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_apertureTruncated
     "@id": "#Object.i_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_astrometry_used
     "@id": "#Object.i_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_reserved
     "@id": "#Object.i_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_used
     "@id": "#Object.i_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_candidate
     "@id": "#Object.i_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_reserved
     "@id": "#Object.i_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_used
     "@id": "#Object.i_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_flag
     "@id": "#Object.i_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_x
     "@id": "#Object.i_centroid_x"
@@ -1651,7 +1528,6 @@ tables:
     "@id": "#Object.i_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_sizeExtendedness
     "@id": "#Object.i_sizeExtendedness"
@@ -1662,7 +1538,6 @@ tables:
     "@id": "#Object.i_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux
     "@id": "#Object.i_free_cModelFlux"
@@ -1678,7 +1553,6 @@ tables:
     "@id": "#Object.i_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux_inner
     "@id": "#Object.i_free_cModelFlux_inner"
@@ -1699,7 +1573,6 @@ tables:
     "@id": "#Object.i_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_fwhm
     "@id": "#Object.i_fwhm"
@@ -1755,7 +1628,6 @@ tables:
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap0p7Flux
     "@id": "#Object.i_gaap0p7Flux"
@@ -1766,7 +1638,6 @@ tables:
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p0Flux
     "@id": "#Object.i_gaap1p0Flux"
@@ -1777,7 +1648,6 @@ tables:
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p5Flux
     "@id": "#Object.i_gaap1p5Flux"
@@ -1788,7 +1658,6 @@ tables:
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap2p5Flux
     "@id": "#Object.i_gaap2p5Flux"
@@ -1799,7 +1668,6 @@ tables:
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap3p0Flux
     "@id": "#Object.i_gaap3p0Flux"
@@ -1810,25 +1678,21 @@ tables:
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag
     "@id": "#Object.i_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_edge
     "@id": "#Object.i_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_gaussianization
     "@id": "#Object.i_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsmShapeRegauss_e1
     "@id": "#Object.i_hsmShapeRegauss_e1"
@@ -1844,7 +1708,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsmShapeRegauss_sigma
     "@id": "#Object.i_hsmShapeRegauss_sigma"
@@ -1855,13 +1718,11 @@ tables:
     "@id": "#Object.i_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iPSF_flag
     "@id": "#Object.i_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iRound_flag
     "@id": "#Object.i_iRound_flag"
@@ -1872,7 +1733,6 @@ tables:
     "@id": "#Object.i_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount
     "@id": "#Object.i_inputCount"
@@ -1883,13 +1743,11 @@ tables:
     "@id": "#Object.i_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount_flag_noInputs
     "@id": "#Object.i_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ixx
     "@id": "#Object.i_ixx"
@@ -2045,13 +1903,11 @@ tables:
     "@id": "#Object.i_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with i_i_flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsm_momentsPsf_flag
     "@id": "#Object.i_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with i_iPSF_flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux
     "@id": "#Object.i_kronFlux"
@@ -2067,61 +1923,51 @@ tables:
     "@id": "#Object.i_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_radius
     "@id": "#Object.i_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape
     "@id": "#Object.i_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.i_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_edge
     "@id": "#Object.i_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_fallback_radius
     "@id": "#Object.i_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_minimum_radius
     "@id": "#Object.i_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_small_radius
     "@id": "#Object.i_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_minimum_radius
     "@id": "#Object.i_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_psf_radius
     "@id": "#Object.i_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronRad
     "@id": "#Object.i_kronRad"
@@ -2132,114 +1978,95 @@ tables:
     "@id": "#Object.i_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clipped
     "@id": "#Object.i_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clippedCenter
     "@id": "#Object.i_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_cr
     "@id": "#Object.i_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_crCenter
     "@id": "#Object.i_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_edge
     "@id": "#Object.i_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psf
     "@id": "#Object.i_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psfCenter
     "@id": "#Object.i_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolated
     "@id": "#Object.i_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolatedCenter
     "@id": "#Object.i_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_offimage
     "@id": "#Object.i_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturated
     "@id": "#Object.i_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturatedCenter
     "@id": "#Object.i_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edge
     "@id": "#Object.i_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edgeCenter
     "@id": "#Object.i_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspect
     "@id": "#Object.i_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspectCenter
     "@id": "#Object.i_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_streak
     "@id": "#Object.i_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on i-band.
     fits:tunit:
   - name: i_pixelFlags_streakCenter
     "@id": "#Object.i_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on i-band.
     fits:tunit:
   - name: i_psfFlux
@@ -2261,25 +2088,21 @@ tables:
     "@id": "#Object.i_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_apCorr
     "@id": "#Object.i_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_edge
     "@id": "#Object.i_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_noGoodPixels
     "@id": "#Object.i_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ra
     "@id": "#Object.i_ra"
@@ -2320,7 +2143,6 @@ tables:
     "@id": "#Object.i_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap03Flux
     "@id": "#Object.r_ap03Flux"
@@ -2336,7 +2158,6 @@ tables:
     "@id": "#Object.r_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap06Flux
     "@id": "#Object.r_ap06Flux"
@@ -2352,7 +2173,6 @@ tables:
     "@id": "#Object.r_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap09Flux
     "@id": "#Object.r_ap09Flux"
@@ -2368,7 +2188,6 @@ tables:
     "@id": "#Object.r_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap12Flux
     "@id": "#Object.r_ap12Flux"
@@ -2384,7 +2203,6 @@ tables:
     "@id": "#Object.r_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap17Flux
     "@id": "#Object.r_ap17Flux"
@@ -2400,7 +2218,6 @@ tables:
     "@id": "#Object.r_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap25Flux
     "@id": "#Object.r_ap25Flux"
@@ -2416,7 +2233,6 @@ tables:
     "@id": "#Object.r_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap35Flux
     "@id": "#Object.r_ap35Flux"
@@ -2432,7 +2248,6 @@ tables:
     "@id": "#Object.r_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap50Flux
     "@id": "#Object.r_ap50Flux"
@@ -2448,7 +2263,6 @@ tables:
     "@id": "#Object.r_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap70Flux
     "@id": "#Object.r_ap70Flux"
@@ -2464,25 +2278,21 @@ tables:
     "@id": "#Object.r_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag
     "@id": "#Object.r_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_apertureTruncated
     "@id": "#Object.r_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_bdChi2
     "@id": "#Object.r_bdChi2"
@@ -2538,7 +2348,6 @@ tables:
     "@id": "#Object.r_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModelFlux
     "@id": "#Object.r_cModelFlux"
@@ -2559,13 +2368,11 @@ tables:
     "@id": "#Object.r_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModel_flag_apCorr
     "@id": "#Object.r_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux
     "@id": "#Object.r_calibFlux"
@@ -2581,61 +2388,51 @@ tables:
     "@id": "#Object.r_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_apertureTruncated
     "@id": "#Object.r_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_astrometry_used
     "@id": "#Object.r_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_reserved
     "@id": "#Object.r_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_used
     "@id": "#Object.r_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_candidate
     "@id": "#Object.r_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_reserved
     "@id": "#Object.r_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_used
     "@id": "#Object.r_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_flag
     "@id": "#Object.r_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_x
     "@id": "#Object.r_centroid_x"
@@ -2682,7 +2479,6 @@ tables:
     "@id": "#Object.r_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_sizeExtendedness
     "@id": "#Object.r_sizeExtendedness"
@@ -2693,7 +2489,6 @@ tables:
     "@id": "#Object.r_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux
     "@id": "#Object.r_free_cModelFlux"
@@ -2709,7 +2504,6 @@ tables:
     "@id": "#Object.r_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux_inner
     "@id": "#Object.r_free_cModelFlux_inner"
@@ -2730,7 +2524,6 @@ tables:
     "@id": "#Object.r_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_fwhm
     "@id": "#Object.r_fwhm"
@@ -2786,7 +2579,6 @@ tables:
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap0p7Flux
     "@id": "#Object.r_gaap0p7Flux"
@@ -2797,7 +2589,6 @@ tables:
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p0Flux
     "@id": "#Object.r_gaap1p0Flux"
@@ -2808,7 +2599,6 @@ tables:
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p5Flux
     "@id": "#Object.r_gaap1p5Flux"
@@ -2819,7 +2609,6 @@ tables:
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap2p5Flux
     "@id": "#Object.r_gaap2p5Flux"
@@ -2830,7 +2619,6 @@ tables:
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap3p0Flux
     "@id": "#Object.r_gaap3p0Flux"
@@ -2841,25 +2629,21 @@ tables:
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag
     "@id": "#Object.r_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_edge
     "@id": "#Object.r_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_gaussianization
     "@id": "#Object.r_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsmShapeRegauss_e1
     "@id": "#Object.r_hsmShapeRegauss_e1"
@@ -2875,7 +2659,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsmShapeRegauss_sigma
     "@id": "#Object.r_hsmShapeRegauss_sigma"
@@ -2886,13 +2669,11 @@ tables:
     "@id": "#Object.r_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iPSF_flag
     "@id": "#Object.r_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iRound_flag
     "@id": "#Object.r_iRound_flag"
@@ -2903,7 +2684,6 @@ tables:
     "@id": "#Object.r_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount
     "@id": "#Object.r_inputCount"
@@ -2914,13 +2694,11 @@ tables:
     "@id": "#Object.r_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount_flag_noInputs
     "@id": "#Object.r_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ixx
     "@id": "#Object.r_ixx"
@@ -3076,13 +2854,11 @@ tables:
     "@id": "#Object.r_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with r_i_flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsm_momentsPsf_flag
     "@id": "#Object.r_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with r_iPSF_flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux
     "@id": "#Object.r_kronFlux"
@@ -3098,61 +2874,51 @@ tables:
     "@id": "#Object.r_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_radius
     "@id": "#Object.r_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape
     "@id": "#Object.r_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.r_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_edge
     "@id": "#Object.r_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_fallback_radius
     "@id": "#Object.r_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_minimum_radius
     "@id": "#Object.r_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_small_radius
     "@id": "#Object.r_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_minimum_radius
     "@id": "#Object.r_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_psf_radius
     "@id": "#Object.r_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronRad
     "@id": "#Object.r_kronRad"
@@ -3163,114 +2929,95 @@ tables:
     "@id": "#Object.r_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clipped
     "@id": "#Object.r_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clippedCenter
     "@id": "#Object.r_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_cr
     "@id": "#Object.r_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_crCenter
     "@id": "#Object.r_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_edge
     "@id": "#Object.r_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psf
     "@id": "#Object.r_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psfCenter
     "@id": "#Object.r_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolated
     "@id": "#Object.r_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolatedCenter
     "@id": "#Object.r_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_offimage
     "@id": "#Object.r_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturated
     "@id": "#Object.r_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturatedCenter
     "@id": "#Object.r_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edge
     "@id": "#Object.r_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edgeCenter
     "@id": "#Object.r_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspect
     "@id": "#Object.r_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspectCenter
     "@id": "#Object.r_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_streak
     "@id": "#Object.r_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on r-band.
     fits:tunit:
   - name: r_pixelFlags_streakCenter
     "@id": "#Object.r_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on r-band.
     fits:tunit:
   - name: r_psfFlux
@@ -3292,25 +3039,21 @@ tables:
     "@id": "#Object.r_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_apCorr
     "@id": "#Object.r_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_edge
     "@id": "#Object.r_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_noGoodPixels
     "@id": "#Object.r_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ra
     "@id": "#Object.r_ra"
@@ -3351,7 +3094,6 @@ tables:
     "@id": "#Object.r_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap03Flux
     "@id": "#Object.y_ap03Flux"
@@ -3367,7 +3109,6 @@ tables:
     "@id": "#Object.y_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap06Flux
     "@id": "#Object.y_ap06Flux"
@@ -3383,7 +3124,6 @@ tables:
     "@id": "#Object.y_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap09Flux
     "@id": "#Object.y_ap09Flux"
@@ -3399,7 +3139,6 @@ tables:
     "@id": "#Object.y_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap12Flux
     "@id": "#Object.y_ap12Flux"
@@ -3415,7 +3154,6 @@ tables:
     "@id": "#Object.y_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap17Flux
     "@id": "#Object.y_ap17Flux"
@@ -3431,7 +3169,6 @@ tables:
     "@id": "#Object.y_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap25Flux
     "@id": "#Object.y_ap25Flux"
@@ -3447,7 +3184,6 @@ tables:
     "@id": "#Object.y_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap35Flux
     "@id": "#Object.y_ap35Flux"
@@ -3463,7 +3199,6 @@ tables:
     "@id": "#Object.y_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap50Flux
     "@id": "#Object.y_ap50Flux"
@@ -3479,7 +3214,6 @@ tables:
     "@id": "#Object.y_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap70Flux
     "@id": "#Object.y_ap70Flux"
@@ -3495,25 +3229,21 @@ tables:
     "@id": "#Object.y_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag
     "@id": "#Object.y_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_apertureTruncated
     "@id": "#Object.y_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_bdChi2
     "@id": "#Object.y_bdChi2"
@@ -3569,7 +3299,6 @@ tables:
     "@id": "#Object.y_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModelFlux
     "@id": "#Object.y_cModelFlux"
@@ -3590,13 +3319,11 @@ tables:
     "@id": "#Object.y_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModel_flag_apCorr
     "@id": "#Object.y_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux
     "@id": "#Object.y_calibFlux"
@@ -3612,61 +3339,51 @@ tables:
     "@id": "#Object.y_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_apertureTruncated
     "@id": "#Object.y_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_astrometry_used
     "@id": "#Object.y_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_reserved
     "@id": "#Object.y_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_used
     "@id": "#Object.y_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_candidate
     "@id": "#Object.y_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_reserved
     "@id": "#Object.y_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_used
     "@id": "#Object.y_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_flag
     "@id": "#Object.y_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_x
     "@id": "#Object.y_centroid_x"
@@ -3713,7 +3430,6 @@ tables:
     "@id": "#Object.y_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_sizeExtendedness
     "@id": "#Object.y_sizeExtendedness"
@@ -3724,7 +3440,6 @@ tables:
     "@id": "#Object.y_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux
     "@id": "#Object.y_free_cModelFlux"
@@ -3740,7 +3455,6 @@ tables:
     "@id": "#Object.y_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux_inner
     "@id": "#Object.y_free_cModelFlux_inner"
@@ -3761,7 +3475,6 @@ tables:
     "@id": "#Object.y_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_fwhm
     "@id": "#Object.y_fwhm"
@@ -3817,7 +3530,6 @@ tables:
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap0p7Flux
     "@id": "#Object.y_gaap0p7Flux"
@@ -3828,7 +3540,6 @@ tables:
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p0Flux
     "@id": "#Object.y_gaap1p0Flux"
@@ -3839,7 +3550,6 @@ tables:
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p5Flux
     "@id": "#Object.y_gaap1p5Flux"
@@ -3850,7 +3560,6 @@ tables:
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap2p5Flux
     "@id": "#Object.y_gaap2p5Flux"
@@ -3861,7 +3570,6 @@ tables:
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap3p0Flux
     "@id": "#Object.y_gaap3p0Flux"
@@ -3872,25 +3580,21 @@ tables:
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag
     "@id": "#Object.y_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_edge
     "@id": "#Object.y_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_gaussianization
     "@id": "#Object.y_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsmShapeRegauss_e1
     "@id": "#Object.y_hsmShapeRegauss_e1"
@@ -3906,7 +3610,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsmShapeRegauss_sigma
     "@id": "#Object.y_hsmShapeRegauss_sigma"
@@ -3917,13 +3620,11 @@ tables:
     "@id": "#Object.y_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iPSF_flag
     "@id": "#Object.y_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iRound_flag
     "@id": "#Object.y_iRound_flag"
@@ -3934,7 +3635,6 @@ tables:
     "@id": "#Object.y_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount
     "@id": "#Object.y_inputCount"
@@ -3945,13 +3645,11 @@ tables:
     "@id": "#Object.y_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount_flag_noInputs
     "@id": "#Object.y_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ixx
     "@id": "#Object.y_ixx"
@@ -4107,13 +3805,11 @@ tables:
     "@id": "#Object.y_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with y_i_flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsm_momentsPsf_flag
     "@id": "#Object.y_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with y_iPSF_flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux
     "@id": "#Object.y_kronFlux"
@@ -4129,61 +3825,51 @@ tables:
     "@id": "#Object.y_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_radius
     "@id": "#Object.y_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape
     "@id": "#Object.y_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.y_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_edge
     "@id": "#Object.y_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_fallback_radius
     "@id": "#Object.y_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_minimum_radius
     "@id": "#Object.y_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_small_radius
     "@id": "#Object.y_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_minimum_radius
     "@id": "#Object.y_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_psf_radius
     "@id": "#Object.y_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronRad
     "@id": "#Object.y_kronRad"
@@ -4194,114 +3880,95 @@ tables:
     "@id": "#Object.y_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clipped
     "@id": "#Object.y_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clippedCenter
     "@id": "#Object.y_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_cr
     "@id": "#Object.y_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_crCenter
     "@id": "#Object.y_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_edge
     "@id": "#Object.y_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psf
     "@id": "#Object.y_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psfCenter
     "@id": "#Object.y_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolated
     "@id": "#Object.y_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolatedCenter
     "@id": "#Object.y_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_offimage
     "@id": "#Object.y_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturated
     "@id": "#Object.y_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturatedCenter
     "@id": "#Object.y_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edge
     "@id": "#Object.y_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edgeCenter
     "@id": "#Object.y_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspect
     "@id": "#Object.y_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspectCenter
     "@id": "#Object.y_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_streak
     "@id": "#Object.y_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on y-band.
     fits:tunit:
   - name: y_pixelFlags_streakCenter
     "@id": "#Object.y_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on y-band.
     fits:tunit:
   - name: y_psfFlux
@@ -4323,25 +3990,21 @@ tables:
     "@id": "#Object.y_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_apCorr
     "@id": "#Object.y_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_edge
     "@id": "#Object.y_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_noGoodPixels
     "@id": "#Object.y_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ra
     "@id": "#Object.y_ra"
@@ -4382,7 +4045,6 @@ tables:
     "@id": "#Object.y_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap03Flux
     "@id": "#Object.z_ap03Flux"
@@ -4398,7 +4060,6 @@ tables:
     "@id": "#Object.z_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap06Flux
     "@id": "#Object.z_ap06Flux"
@@ -4414,7 +4075,6 @@ tables:
     "@id": "#Object.z_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap09Flux
     "@id": "#Object.z_ap09Flux"
@@ -4430,7 +4090,6 @@ tables:
     "@id": "#Object.z_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap12Flux
     "@id": "#Object.z_ap12Flux"
@@ -4446,7 +4105,6 @@ tables:
     "@id": "#Object.z_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap17Flux
     "@id": "#Object.z_ap17Flux"
@@ -4462,7 +4120,6 @@ tables:
     "@id": "#Object.z_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap25Flux
     "@id": "#Object.z_ap25Flux"
@@ -4478,7 +4135,6 @@ tables:
     "@id": "#Object.z_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap35Flux
     "@id": "#Object.z_ap35Flux"
@@ -4494,7 +4150,6 @@ tables:
     "@id": "#Object.z_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap50Flux
     "@id": "#Object.z_ap50Flux"
@@ -4510,7 +4165,6 @@ tables:
     "@id": "#Object.z_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap70Flux
     "@id": "#Object.z_ap70Flux"
@@ -4526,25 +4180,21 @@ tables:
     "@id": "#Object.z_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag
     "@id": "#Object.z_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_apertureTruncated
     "@id": "#Object.z_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_bdChi2
     "@id": "#Object.z_bdChi2"
@@ -4600,7 +4250,6 @@ tables:
     "@id": "#Object.z_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModelFlux
     "@id": "#Object.z_cModelFlux"
@@ -4621,13 +4270,11 @@ tables:
     "@id": "#Object.z_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModel_flag_apCorr
     "@id": "#Object.z_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux
     "@id": "#Object.z_calibFlux"
@@ -4643,61 +4290,51 @@ tables:
     "@id": "#Object.z_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_apertureTruncated
     "@id": "#Object.z_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_astrometry_used
     "@id": "#Object.z_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_reserved
     "@id": "#Object.z_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_used
     "@id": "#Object.z_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_candidate
     "@id": "#Object.z_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_reserved
     "@id": "#Object.z_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_used
     "@id": "#Object.z_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_flag
     "@id": "#Object.z_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_x
     "@id": "#Object.z_centroid_x"
@@ -4744,7 +4381,6 @@ tables:
     "@id": "#Object.z_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_sizeExtendedness
     "@id": "#Object.z_sizeExtendedness"
@@ -4755,7 +4391,6 @@ tables:
     "@id": "#Object.z_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux
     "@id": "#Object.z_free_cModelFlux"
@@ -4771,7 +4406,6 @@ tables:
     "@id": "#Object.z_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux_inner
     "@id": "#Object.z_free_cModelFlux_inner"
@@ -4792,7 +4426,6 @@ tables:
     "@id": "#Object.z_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_fwhm
     "@id": "#Object.z_fwhm"
@@ -4848,7 +4481,6 @@ tables:
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap0p7Flux
     "@id": "#Object.z_gaap0p7Flux"
@@ -4859,7 +4491,6 @@ tables:
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p0Flux
     "@id": "#Object.z_gaap1p0Flux"
@@ -4870,7 +4501,6 @@ tables:
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p5Flux
     "@id": "#Object.z_gaap1p5Flux"
@@ -4881,7 +4511,6 @@ tables:
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap2p5Flux
     "@id": "#Object.z_gaap2p5Flux"
@@ -4892,7 +4521,6 @@ tables:
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap3p0Flux
     "@id": "#Object.z_gaap3p0Flux"
@@ -4903,25 +4531,21 @@ tables:
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag
     "@id": "#Object.z_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_edge
     "@id": "#Object.z_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_gaussianization
     "@id": "#Object.z_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsmShapeRegauss_e1
     "@id": "#Object.z_hsmShapeRegauss_e1"
@@ -4937,7 +4561,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsmShapeRegauss_sigma
     "@id": "#Object.z_hsmShapeRegauss_sigma"
@@ -4948,13 +4571,11 @@ tables:
     "@id": "#Object.z_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iPSF_flag
     "@id": "#Object.z_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iRound_flag
     "@id": "#Object.z_iRound_flag"
@@ -4965,7 +4586,6 @@ tables:
     "@id": "#Object.z_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount
     "@id": "#Object.z_inputCount"
@@ -4976,13 +4596,11 @@ tables:
     "@id": "#Object.z_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount_flag_noInputs
     "@id": "#Object.z_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ixx
     "@id": "#Object.z_ixx"
@@ -5138,13 +4756,11 @@ tables:
     "@id": "#Object.z_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with z_i_flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsm_momentsPsf_flag
     "@id": "#Object.z_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with z_iPSF_flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux
     "@id": "#Object.z_kronFlux"
@@ -5160,61 +4776,51 @@ tables:
     "@id": "#Object.z_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_radius
     "@id": "#Object.z_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape
     "@id": "#Object.z_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.z_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_edge
     "@id": "#Object.z_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_fallback_radius
     "@id": "#Object.z_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_minimum_radius
     "@id": "#Object.z_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_small_radius
     "@id": "#Object.z_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_minimum_radius
     "@id": "#Object.z_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_psf_radius
     "@id": "#Object.z_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronRad
     "@id": "#Object.z_kronRad"
@@ -5225,114 +4831,95 @@ tables:
     "@id": "#Object.z_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clipped
     "@id": "#Object.z_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clippedCenter
     "@id": "#Object.z_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_cr
     "@id": "#Object.z_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_crCenter
     "@id": "#Object.z_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_edge
     "@id": "#Object.z_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psf
     "@id": "#Object.z_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psfCenter
     "@id": "#Object.z_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolated
     "@id": "#Object.z_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolatedCenter
     "@id": "#Object.z_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_offimage
     "@id": "#Object.z_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturated
     "@id": "#Object.z_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturatedCenter
     "@id": "#Object.z_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edge
     "@id": "#Object.z_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edgeCenter
     "@id": "#Object.z_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspect
     "@id": "#Object.z_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspectCenter
     "@id": "#Object.z_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_streak
     "@id": "#Object.z_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on z-band.
     fits:tunit:
   - name: z_pixelFlags_streakCenter
     "@id": "#Object.z_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on z-band.
     fits:tunit:
   - name: z_psfFlux
@@ -5354,25 +4941,21 @@ tables:
     "@id": "#Object.z_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_apCorr
     "@id": "#Object.z_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_edge
     "@id": "#Object.z_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_noGoodPixels
     "@id": "#Object.z_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ra
     "@id": "#Object.z_ra"
@@ -5413,7 +4996,6 @@ tables:
     "@id": "#Object.z_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
 
 - name: Source
@@ -5522,7 +5104,6 @@ tables:
     "@id": "#Source.ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap06Flux
     "@id": "#Source.ap06Flux"
@@ -5538,7 +5119,6 @@ tables:
     "@id": "#Source.ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap09Flux
     "@id": "#Source.ap09Flux"
@@ -5554,7 +5134,6 @@ tables:
     "@id": "#Source.ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap12Flux
     "@id": "#Source.ap12Flux"
@@ -5570,7 +5149,6 @@ tables:
     "@id": "#Source.ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap17Flux
     "@id": "#Source.ap17Flux"
@@ -5586,7 +5164,6 @@ tables:
     "@id": "#Source.ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap25Flux
     "@id": "#Source.ap25Flux"
@@ -5602,7 +5179,6 @@ tables:
     "@id": "#Source.ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap35Flux
     "@id": "#Source.ap35Flux"
@@ -5618,7 +5194,6 @@ tables:
     "@id": "#Source.ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap50Flux
     "@id": "#Source.ap50Flux"
@@ -5634,7 +5209,6 @@ tables:
     "@id": "#Source.ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap70Flux
     "@id": "#Source.ap70Flux"
@@ -5650,7 +5224,6 @@ tables:
     "@id": "#Source.ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky
     "@id": "#Source.sky"
@@ -5746,7 +5319,6 @@ tables:
     "@id": "#Source.localPhotoCalib_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localPhotoCalibErr
     "@id": "#Source.localPhotoCalibErr"
@@ -5757,7 +5329,6 @@ tables:
     "@id": "#Source.localWcs_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localWcs_CDMatrix_2_1
     "@id": "#Source.localWcs_CDMatrix_2_1"
@@ -5788,37 +5359,31 @@ tables:
     "@id": "#Source.blendedness_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noCentroid
     "@id": "#Source.blendedness_flag_noCentroid"
     datatype: boolean
     description: Object has no centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noShape
     "@id": "#Source.blendedness_flag_noShape"
     datatype: boolean
     description: Object has no shape
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag
     "@id": "#Source.apFlux_12_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_apertureTruncated
     "@id": "#Source.apFlux_12_0_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_sincCoeffsTruncated
     "@id": "#Source.apFlux_12_0_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_instFlux
     "@id": "#Source.apFlux_12_0_instFlux"
@@ -5834,7 +5399,6 @@ tables:
     "@id": "#Source.apFlux_17_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_17_0_instFlux
     "@id": "#Source.apFlux_17_0_instFlux"
@@ -5850,7 +5414,6 @@ tables:
     "@id": "#Source.apFlux_35_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_35_0_instFlux
     "@id": "#Source.apFlux_35_0_instFlux"
@@ -5866,7 +5429,6 @@ tables:
     "@id": "#Source.apFlux_50_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_50_0_instFlux
     "@id": "#Source.apFlux_50_0_instFlux"
@@ -5882,13 +5444,11 @@ tables:
     "@id": "#Source.extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sizeExtendedness_flag
     "@id": "#Source.sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: footprintArea_value
     "@id": "#Source.footprintArea_value"
@@ -5899,7 +5459,6 @@ tables:
     "@id": "#Source.jacobian_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: jacobian_value
     "@id": "#Source.jacobian_value"
@@ -5920,96 +5479,80 @@ tables:
     "@id": "#Source.localBackground_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noGoodPixels
     "@id": "#Source.localBackground_flag_noGoodPixels"
     datatype: boolean
     description: No good pixels in the annulus
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noPsf
     "@id": "#Source.localBackground_flag_noPsf"
     datatype: boolean
     description: No PSF provided
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#Source.pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#Source.pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#Source.pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#Source.pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#Source.pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#Source.pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_offimage
     "@id": "#Source.pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#Source.pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#Source.pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#Source.pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#Source.pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_streak
     "@id": "#Source.pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint.
     fits:tunit:
   - name: pixelFlags_streakCenter
     "@id": "#Source.pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center.
     fits:tunit:
   - name: psfFlux_apCorr
@@ -6031,85 +5574,71 @@ tables:
     "@id": "#Source.psfFlux_flag"
     datatype: boolean
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_apCorr
     "@id": "#Source.psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_edge
     "@id": "#Source.psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: gaussianFlux_flag
     "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag
     "@id": "#Source.centroid_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_almostNoSecondDerivative
     "@id": "#Source.centroid_flag_almostNoSecondDerivative"
     datatype: boolean
     description: Almost vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_badError
     "@id": "#Source.centroid_flag_badError"
     datatype: boolean
     description: Error on x and/or y position is NaN
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_edge
     "@id": "#Source.centroid_flag_edge"
     datatype: boolean
     description: Object too close to edge
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_noSecondDerivative
     "@id": "#Source.centroid_flag_noSecondDerivative"
     datatype: boolean
     description: Vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_notAtMaximum
     "@id": "#Source.centroid_flag_notAtMaximum"
     datatype: boolean
     description: Object is not at a maximum
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_resetToPeak
     "@id": "#Source.centroid_flag_resetToPeak"
     datatype: boolean
     description: Set if CentroidChecker reset the centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag
     "@id": "#Source.variance_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag_emptyFootprint
     "@id": "#Source.variance_flag_emptyFootprint"
     datatype: boolean
     description: Set to True when the footprint has no usable pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_value
     "@id": "#Source.variance_value"
@@ -6120,61 +5649,51 @@ tables:
     "@id": "#Source.calib_astrometry_used"
     datatype: boolean
     description: Set if source was used in astrometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_detected
     "@id": "#Source.calib_detected"
     datatype: boolean
     description: Source was detected as an icSource
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_reserved
     "@id": "#Source.calib_photometry_reserved"
     datatype: boolean
     description: Set if source was reserved from photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_used
     "@id": "#Source.calib_photometry_used"
     datatype: boolean
     description: Set if source was used in photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_candidate
     "@id": "#Source.calib_psf_candidate"
     datatype: boolean
     description: Flag set if the source was a candidate for PSF determination, as determined by the star selector.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_reserved
     "@id": "#Source.calib_psf_reserved"
     datatype: boolean
     description: Set if source was reserved from PSF determination
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_used
     "@id": "#Source.calib_psf_used"
     datatype: boolean
     description: Flag set if the source was actually used for PSF determination, as determined by the
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_deblendedAsPsf
     "@id": "#Source.deblend_deblendedAsPsf"
     datatype: boolean
     description: Deblender thought this source looked like a PSF
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_hasStrayFlux
     "@id": "#Source.deblend_hasStrayFlux"
     datatype: boolean
     description: This source was assigned some stray flux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_masked
     "@id": "#Source.deblend_masked"
     datatype: boolean
     description: Parent footprint was predominantly masked
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_nChild
     "@id": "#Source.deblend_nChild"
@@ -6185,133 +5704,111 @@ tables:
     "@id": "#Source.deblend_parentTooBig"
     datatype: boolean
     description: Parent footprint covered too many pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_patchedTemplate
     "@id": "#Source.deblend_patchedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used patched edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_rampedTemplate
     "@id": "#Source.deblend_rampedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used ramp edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Source.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_tooManyPeaks
     "@id": "#Source.deblend_tooManyPeaks"
     datatype: boolean
     description: Source had too many peaks; only the brightest were included
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag
     "@id": "#Source.hsmPsfMoments_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_no_pixels
     "@id": "#Source.hsmPsfMoments_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_not_contained
     "@id": "#Source.hsmPsfMoments_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_parent_source
     "@id": "#Source.hsmPsfMoments_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag
     "@id": "#Source.iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_no_pixels
     "@id": "#Source.iDebiasedPSF_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_not_contained
     "@id": "#Source.iDebiasedPSF_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_parent_source
     "@id": "#Source.iDebiasedPSF_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_galsim
     "@id": "#Source.iDebiasedPSF_flag_galsim"
     datatype: boolean
     description: GalSim failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_edge
     "@id": "#Source.iDebiasedPSF_flag_edge"
     datatype: boolean
     description: Variance undefined outside image edge
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag
     "@id": "#Source.hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_galsim
     "@id": "#Source.hsmShapeRegauss_flag_galsim"
     datatype: boolean
     description: GalSim failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_no_pixels
     "@id": "#Source.hsmShapeRegauss_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_not_contained
     "@id": "#Source.hsmShapeRegauss_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_parent_source
     "@id": "#Source.hsmShapeRegauss_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky_source
     "@id": "#Source.sky_source"
     datatype: boolean
     description: Sky objects.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Source.detect_isPrimary"
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: band
     "@id": "#Source.band"

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -62,43 +62,36 @@ tables:
     "@id": "#Object.deblend_failed"
     datatype: boolean
     description: Deblender failed to deblend this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Object.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_isolatedParent
     "@id": "#Object.deblend_isolatedParent"
     datatype: boolean
     description: Deblender skipped this footprint because there was only a single peak
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_parentTooBig
     "@id": "#Object.deblend_parentTooBig"
     datatype: boolean
     description: Deblender skipped this source because the parent footprint was too large.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_tooManyPeaks
     "@id": "#Object.deblend_tooManyPeaks"
     datatype: boolean
     description: Deblender skipped this source because there were too many peaks in the Footprint.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_masked
     "@id": "#Object.deblend_masked"
     datatype: boolean
     description: Deblender skipped this source because there were too many masked pixels.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_incompleteData
     "@id": "#Object.deblend_incompleteData"
     datatype: boolean
     description: One or more bands were not deblended due to an inability to model the PSF.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_iterations
     "@id": "#Object.deblend_iterations"
@@ -124,43 +117,36 @@ tables:
     "@id": "#Object.detect_fromBlend"
     datatype: boolean
     description: This source is deblended from a parent with more than one child.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedModelSource
     "@id": "#Object.detect_isDeblendedModelSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is a deblended child
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isDeblendedSource
     "@id": "#Object.detect_isDeblendedSource"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isIsolated
     "@id": "#Object.detect_isIsolated"
     datatype: boolean
     description: This source is not a part of a blend.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPatchInner
     "@id": "#Object.detect_isPatchInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd patch
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Object.detect_isPrimary"
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isTractInner
     "@id": "#Object.detect_isTractInner"
     datatype: boolean
     description: True if source is in the inner region of a coadd tract
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ebv
     "@id": "#Object.ebv"
@@ -176,7 +162,6 @@ tables:
     "@id": "#Object.merge_peak_sky"
     datatype: boolean
     description: Peak detected in filter sky
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: parentObjectId
     "@id": "#Object.parentObjectId"
@@ -214,7 +199,6 @@ tables:
     "@id": "#Object.shape_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: shape_xx
     "@id": "#Object.shape_xx"
@@ -235,7 +219,6 @@ tables:
     "@id": "#Object.sky_object"
     datatype: boolean
     description: No source was detected here. This object exists to characterize properties of the sky background
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: tract
     "@id": "#Object.tract"
@@ -256,7 +239,6 @@ tables:
     "@id": "#Object.xy_flag"
     datatype: boolean
     description: General Failure Flag. Reference band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y
     "@id": "#Object.y"
@@ -282,7 +264,6 @@ tables:
     "@id": "#Object.g_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap06Flux
     "@id": "#Object.g_ap06Flux"
@@ -298,7 +279,6 @@ tables:
     "@id": "#Object.g_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap09Flux
     "@id": "#Object.g_ap09Flux"
@@ -314,7 +294,6 @@ tables:
     "@id": "#Object.g_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap12Flux
     "@id": "#Object.g_ap12Flux"
@@ -330,7 +309,6 @@ tables:
     "@id": "#Object.g_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap17Flux
     "@id": "#Object.g_ap17Flux"
@@ -346,7 +324,6 @@ tables:
     "@id": "#Object.g_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap25Flux
     "@id": "#Object.g_ap25Flux"
@@ -362,7 +339,6 @@ tables:
     "@id": "#Object.g_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap35Flux
     "@id": "#Object.g_ap35Flux"
@@ -378,7 +354,6 @@ tables:
     "@id": "#Object.g_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap50Flux
     "@id": "#Object.g_ap50Flux"
@@ -394,7 +369,6 @@ tables:
     "@id": "#Object.g_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ap70Flux
     "@id": "#Object.g_ap70Flux"
@@ -410,25 +384,21 @@ tables:
     "@id": "#Object.g_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag
     "@id": "#Object.g_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_apertureTruncated
     "@id": "#Object.g_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_bdChi2
     "@id": "#Object.g_bdChi2"
@@ -484,7 +454,6 @@ tables:
     "@id": "#Object.g_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModelFlux
     "@id": "#Object.g_cModelFlux"
@@ -505,13 +474,11 @@ tables:
     "@id": "#Object.g_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_cModel_flag_apCorr
     "@id": "#Object.g_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux
     "@id": "#Object.g_calibFlux"
@@ -527,61 +494,51 @@ tables:
     "@id": "#Object.g_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_apertureTruncated
     "@id": "#Object.g_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.g_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_astrometry_used
     "@id": "#Object.g_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_reserved
     "@id": "#Object.g_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_photometry_used
     "@id": "#Object.g_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_candidate
     "@id": "#Object.g_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_reserved
     "@id": "#Object.g_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_calib_psf_used
     "@id": "#Object.g_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_flag
     "@id": "#Object.g_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_centroid_x
     "@id": "#Object.g_centroid_x"
@@ -630,7 +587,6 @@ tables:
     "@id": "#Object.g_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_sizeExtendedness
     "@id": "#Object.g_extendedLikehood"
@@ -641,7 +597,6 @@ tables:
     "@id": "#Object.g_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux
     "@id": "#Object.g_free_cModelFlux"
@@ -657,7 +612,6 @@ tables:
     "@id": "#Object.g_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_free_cModelFlux_inner
     "@id": "#Object.g_free_cModelFlux_inner"
@@ -678,7 +632,6 @@ tables:
     "@id": "#Object.g_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_fwhm
     "@id": "#Object.g_fwhm"
@@ -699,7 +652,6 @@ tables:
     "@id": "#Object.g_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p0Flux
     "@id": "#Object.g_gaap1p0Flux"
@@ -715,7 +667,6 @@ tables:
     "@id": "#Object.g_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap1p5Flux
     "@id": "#Object.g_gaap1p5Flux"
@@ -731,7 +682,6 @@ tables:
     "@id": "#Object.g_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap2p5Flux
     "@id": "#Object.g_gaap2p5Flux"
@@ -747,7 +697,6 @@ tables:
     "@id": "#Object.g_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaap3p0Flux
     "@id": "#Object.g_gaap3p0Flux"
@@ -763,25 +712,21 @@ tables:
     "@id": "#Object.g_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag
     "@id": "#Object.g_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_edge
     "@id": "#Object.g_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapFlux_flag_gaussianization
     "@id": "#Object.g_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapOptimalFlux
     "@id": "#Object.g_gaapOptimalFlux"
@@ -797,7 +742,6 @@ tables:
     "@id": "#Object.g_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_gaapPsfFlux
     "@id": "#Object.g_gaapPsfFlux"
@@ -823,7 +767,6 @@ tables:
     "@id": "#Object.g_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsmShapeRegauss_sigma
     "@id": "#Object.g_hsmShapeRegauss_sigma"
@@ -834,13 +777,11 @@ tables:
     "@id": "#Object.g_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iPSF_flag
     "@id": "#Object.g_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_iRound_flag
     "@id": "#Object.g_iRound_flag"
@@ -851,7 +792,6 @@ tables:
     "@id": "#Object.g_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount
     "@id": "#Object.g_inputCount"
@@ -862,13 +802,11 @@ tables:
     "@id": "#Object.g_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_inputCount_flag_noInputs
     "@id": "#Object.g_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ixx
     "@id": "#Object.g_ixx"
@@ -1024,13 +962,11 @@ tables:
     "@id": "#Object.g_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with g_i_flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_hsm_momentsPsf_flag
     "@id": "#Object.g_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with g-band._iPSF_flag. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux
     "@id": "#Object.g_kronFlux"
@@ -1046,61 +982,51 @@ tables:
     "@id": "#Object.g_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_radius
     "@id": "#Object.g_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape
     "@id": "#Object.g_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.g_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_edge
     "@id": "#Object.g_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_fallback_radius
     "@id": "#Object.g_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_no_minimum_radius
     "@id": "#Object.g_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_small_radius
     "@id": "#Object.g_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_minimum_radius
     "@id": "#Object.g_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronFlux_flag_used_psf_radius
     "@id": "#Object.g_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_kronRad
     "@id": "#Object.g_kronRad"
@@ -1111,114 +1037,95 @@ tables:
     "@id": "#Object.g_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clipped
     "@id": "#Object.g_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_clippedCenter
     "@id": "#Object.g_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_cr
     "@id": "#Object.g_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_crCenter
     "@id": "#Object.g_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_edge
     "@id": "#Object.g_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psf
     "@id": "#Object.g_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_inexact_psfCenter
     "@id": "#Object.g_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolated
     "@id": "#Object.g_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_interpolatedCenter
     "@id": "#Object.g_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_offimage
     "@id": "#Object.g_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturated
     "@id": "#Object.g_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_saturatedCenter
     "@id": "#Object.g_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edge
     "@id": "#Object.g_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_sensor_edgeCenter
     "@id": "#Object.g_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspect
     "@id": "#Object.g_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_suspectCenter
     "@id": "#Object.g_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_pixelFlags_streak
     "@id": "#Object.g_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on g-band.
     fits:tunit:
   - name: g_pixelFlags_streakCenter
     "@id": "#Object.g_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on g-band.
     fits:tunit:
   - name: g_psfFlux
@@ -1240,25 +1147,21 @@ tables:
     "@id": "#Object.g_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_apCorr
     "@id": "#Object.g_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_edge
     "@id": "#Object.g_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_psfFlux_flag_noGoodPixels
     "@id": "#Object.g_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on g-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: g_ra
     "@id": "#Object.g_ra"
@@ -1302,7 +1205,6 @@ tables:
     "@id": "#Object.g_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap03Flux
     "@id": "#Object.i_ap03Flux"
@@ -1318,7 +1220,6 @@ tables:
     "@id": "#Object.i_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap06Flux
     "@id": "#Object.i_ap06Flux"
@@ -1334,7 +1235,6 @@ tables:
     "@id": "#Object.i_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap09Flux
     "@id": "#Object.i_ap09Flux"
@@ -1350,7 +1250,6 @@ tables:
     "@id": "#Object.i_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap12Flux
     "@id": "#Object.i_ap12Flux"
@@ -1366,7 +1265,6 @@ tables:
     "@id": "#Object.i_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap17Flux
     "@id": "#Object.i_ap17Flux"
@@ -1382,7 +1280,6 @@ tables:
     "@id": "#Object.i_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap25Flux
     "@id": "#Object.i_ap25Flux"
@@ -1398,7 +1295,6 @@ tables:
     "@id": "#Object.i_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap35Flux
     "@id": "#Object.i_ap35Flux"
@@ -1414,7 +1310,6 @@ tables:
     "@id": "#Object.i_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap50Flux
     "@id": "#Object.i_ap50Flux"
@@ -1430,7 +1325,6 @@ tables:
     "@id": "#Object.i_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ap70Flux
     "@id": "#Object.i_ap70Flux"
@@ -1446,25 +1340,21 @@ tables:
     "@id": "#Object.i_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag
     "@id": "#Object.i_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_apertureTruncated
     "@id": "#Object.i_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_bdChi2
     "@id": "#Object.i_bdChi2"
@@ -1520,7 +1410,6 @@ tables:
     "@id": "#Object.i_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModelFlux
     "@id": "#Object.i_cModelFlux"
@@ -1541,13 +1430,11 @@ tables:
     "@id": "#Object.i_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_cModel_flag_apCorr
     "@id": "#Object.i_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux
     "@id": "#Object.i_calibFlux"
@@ -1563,61 +1450,51 @@ tables:
     "@id": "#Object.i_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_apertureTruncated
     "@id": "#Object.i_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.i_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_astrometry_used
     "@id": "#Object.i_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_reserved
     "@id": "#Object.i_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_photometry_used
     "@id": "#Object.i_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_candidate
     "@id": "#Object.i_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_reserved
     "@id": "#Object.i_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_calib_psf_used
     "@id": "#Object.i_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_flag
     "@id": "#Object.i_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_centroid_x
     "@id": "#Object.i_centroid_x"
@@ -1666,7 +1543,6 @@ tables:
     "@id": "#Object.i_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_sizeExtendedness
     "@id": "#Object.i_extendedLikehood"
@@ -1677,7 +1553,6 @@ tables:
     "@id": "#Object.i_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux
     "@id": "#Object.i_free_cModelFlux"
@@ -1693,7 +1568,6 @@ tables:
     "@id": "#Object.i_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_free_cModelFlux_inner
     "@id": "#Object.i_free_cModelFlux_inner"
@@ -1714,7 +1588,6 @@ tables:
     "@id": "#Object.i_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_fwhm
     "@id": "#Object.i_fwhm"
@@ -1735,7 +1608,6 @@ tables:
     "@id": "#Object.i_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p0Flux
     "@id": "#Object.i_gaap1p0Flux"
@@ -1751,7 +1623,6 @@ tables:
     "@id": "#Object.i_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap1p5Flux
     "@id": "#Object.i_gaap1p5Flux"
@@ -1767,7 +1638,6 @@ tables:
     "@id": "#Object.i_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap2p5Flux
     "@id": "#Object.i_gaap2p5Flux"
@@ -1783,7 +1653,6 @@ tables:
     "@id": "#Object.i_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaap3p0Flux
     "@id": "#Object.i_gaap3p0Flux"
@@ -1799,25 +1668,21 @@ tables:
     "@id": "#Object.i_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag
     "@id": "#Object.i_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_edge
     "@id": "#Object.i_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapFlux_flag_gaussianization
     "@id": "#Object.i_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapOptimalFlux
     "@id": "#Object.i_gaapOptimalFlux"
@@ -1833,7 +1698,6 @@ tables:
     "@id": "#Object.i_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_gaapPsfFlux
     "@id": "#Object.i_gaapPsfFlux"
@@ -1859,7 +1723,6 @@ tables:
     "@id": "#Object.i_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsmShapeRegauss_sigma
     "@id": "#Object.i_hsmShapeRegauss_sigma"
@@ -1870,13 +1733,11 @@ tables:
     "@id": "#Object.i_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iPSF_flag
     "@id": "#Object.i_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_iRound_flag
     "@id": "#Object.i_iRound_flag"
@@ -1887,7 +1748,6 @@ tables:
     "@id": "#Object.i_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount
     "@id": "#Object.i_inputCount"
@@ -1898,13 +1758,11 @@ tables:
     "@id": "#Object.i_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_inputCount_flag_noInputs
     "@id": "#Object.i_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ixx
     "@id": "#Object.i_ixx"
@@ -2060,13 +1918,11 @@ tables:
     "@id": "#Object.i_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with i_i_flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_hsm_momentsPsf_flag
     "@id": "#Object.i_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with i_iPSF_flag. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux
     "@id": "#Object.i_kronFlux"
@@ -2082,61 +1938,51 @@ tables:
     "@id": "#Object.i_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_radius
     "@id": "#Object.i_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape
     "@id": "#Object.i_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.i_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_edge
     "@id": "#Object.i_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_fallback_radius
     "@id": "#Object.i_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_no_minimum_radius
     "@id": "#Object.i_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_small_radius
     "@id": "#Object.i_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_minimum_radius
     "@id": "#Object.i_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronFlux_flag_used_psf_radius
     "@id": "#Object.i_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_kronRad
     "@id": "#Object.i_kronRad"
@@ -2147,114 +1993,95 @@ tables:
     "@id": "#Object.i_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clipped
     "@id": "#Object.i_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_clippedCenter
     "@id": "#Object.i_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_cr
     "@id": "#Object.i_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_crCenter
     "@id": "#Object.i_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_edge
     "@id": "#Object.i_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psf
     "@id": "#Object.i_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_inexact_psfCenter
     "@id": "#Object.i_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolated
     "@id": "#Object.i_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_interpolatedCenter
     "@id": "#Object.i_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_offimage
     "@id": "#Object.i_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturated
     "@id": "#Object.i_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_saturatedCenter
     "@id": "#Object.i_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edge
     "@id": "#Object.i_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_sensor_edgeCenter
     "@id": "#Object.i_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspect
     "@id": "#Object.i_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_suspectCenter
     "@id": "#Object.i_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_pixelFlags_streak
     "@id": "#Object.i_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on i-band.
     fits:tunit:
   - name: i_pixelFlags_streakCenter
     "@id": "#Object.i_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on i-band.
     fits:tunit:
   - name: i_psfFlux
@@ -2276,25 +2103,21 @@ tables:
     "@id": "#Object.i_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_apCorr
     "@id": "#Object.i_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_edge
     "@id": "#Object.i_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_psfFlux_flag_noGoodPixels
     "@id": "#Object.i_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on i-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: i_ra
     "@id": "#Object.i_ra"
@@ -2338,7 +2161,6 @@ tables:
     "@id": "#Object.i_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap03Flux
     "@id": "#Object.r_ap03Flux"
@@ -2354,7 +2176,6 @@ tables:
     "@id": "#Object.r_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap06Flux
     "@id": "#Object.r_ap06Flux"
@@ -2370,7 +2191,6 @@ tables:
     "@id": "#Object.r_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap09Flux
     "@id": "#Object.r_ap09Flux"
@@ -2386,7 +2206,6 @@ tables:
     "@id": "#Object.r_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap12Flux
     "@id": "#Object.r_ap12Flux"
@@ -2402,7 +2221,6 @@ tables:
     "@id": "#Object.r_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap17Flux
     "@id": "#Object.r_ap17Flux"
@@ -2418,7 +2236,6 @@ tables:
     "@id": "#Object.r_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap25Flux
     "@id": "#Object.r_ap25Flux"
@@ -2434,7 +2251,6 @@ tables:
     "@id": "#Object.r_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap35Flux
     "@id": "#Object.r_ap35Flux"
@@ -2450,7 +2266,6 @@ tables:
     "@id": "#Object.r_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap50Flux
     "@id": "#Object.r_ap50Flux"
@@ -2466,7 +2281,6 @@ tables:
     "@id": "#Object.r_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ap70Flux
     "@id": "#Object.r_ap70Flux"
@@ -2482,25 +2296,21 @@ tables:
     "@id": "#Object.r_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag
     "@id": "#Object.r_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_apertureTruncated
     "@id": "#Object.r_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_bdChi2
     "@id": "#Object.r_bdChi2"
@@ -2556,7 +2366,6 @@ tables:
     "@id": "#Object.r_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModelFlux
     "@id": "#Object.r_cModelFlux"
@@ -2577,13 +2386,11 @@ tables:
     "@id": "#Object.r_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_cModel_flag_apCorr
     "@id": "#Object.r_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux
     "@id": "#Object.r_calibFlux"
@@ -2599,61 +2406,51 @@ tables:
     "@id": "#Object.r_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_apertureTruncated
     "@id": "#Object.r_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.r_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_astrometry_used
     "@id": "#Object.r_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_reserved
     "@id": "#Object.r_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_photometry_used
     "@id": "#Object.r_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_candidate
     "@id": "#Object.r_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_reserved
     "@id": "#Object.r_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_calib_psf_used
     "@id": "#Object.r_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_flag
     "@id": "#Object.r_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_centroid_x
     "@id": "#Object.r_centroid_x"
@@ -2702,7 +2499,6 @@ tables:
     "@id": "#Object.r_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_sizeExtendedness
     "@id": "#Object.r_extendedLikehood"
@@ -2713,7 +2509,6 @@ tables:
     "@id": "#Object.r_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux
     "@id": "#Object.r_free_cModelFlux"
@@ -2729,7 +2524,6 @@ tables:
     "@id": "#Object.r_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_free_cModelFlux_inner
     "@id": "#Object.r_free_cModelFlux_inner"
@@ -2750,7 +2544,6 @@ tables:
     "@id": "#Object.r_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_fwhm
     "@id": "#Object.r_fwhm"
@@ -2771,7 +2564,6 @@ tables:
     "@id": "#Object.r_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p0Flux
     "@id": "#Object.r_gaap1p0Flux"
@@ -2787,7 +2579,6 @@ tables:
     "@id": "#Object.r_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap1p5Flux
     "@id": "#Object.r_gaap1p5Flux"
@@ -2803,7 +2594,6 @@ tables:
     "@id": "#Object.r_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap2p5Flux
     "@id": "#Object.r_gaap2p5Flux"
@@ -2819,7 +2609,6 @@ tables:
     "@id": "#Object.r_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaap3p0Flux
     "@id": "#Object.r_gaap3p0Flux"
@@ -2835,25 +2624,21 @@ tables:
     "@id": "#Object.r_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag
     "@id": "#Object.r_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_edge
     "@id": "#Object.r_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapFlux_flag_gaussianization
     "@id": "#Object.r_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapOptimalFlux
     "@id": "#Object.r_gaapOptimalFlux"
@@ -2869,7 +2654,6 @@ tables:
     "@id": "#Object.r_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_gaapPsfFlux
     "@id": "#Object.r_gaapPsfFlux"
@@ -2895,7 +2679,6 @@ tables:
     "@id": "#Object.r_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsmShapeRegauss_sigma
     "@id": "#Object.r_hsmShapeRegauss_sigma"
@@ -2906,13 +2689,11 @@ tables:
     "@id": "#Object.r_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iPSF_flag
     "@id": "#Object.r_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_iRound_flag
     "@id": "#Object.r_iRound_flag"
@@ -2923,7 +2704,6 @@ tables:
     "@id": "#Object.r_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount
     "@id": "#Object.r_inputCount"
@@ -2934,13 +2714,11 @@ tables:
     "@id": "#Object.r_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_inputCount_flag_noInputs
     "@id": "#Object.r_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ixx
     "@id": "#Object.r_ixx"
@@ -3096,13 +2874,11 @@ tables:
     "@id": "#Object.r_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with r_i_flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_hsm_momentsPsf_flag
     "@id": "#Object.r_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with r_iPSF_flag. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux
     "@id": "#Object.r_kronFlux"
@@ -3118,61 +2894,51 @@ tables:
     "@id": "#Object.r_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_radius
     "@id": "#Object.r_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape
     "@id": "#Object.r_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.r_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_edge
     "@id": "#Object.r_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_fallback_radius
     "@id": "#Object.r_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_no_minimum_radius
     "@id": "#Object.r_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_small_radius
     "@id": "#Object.r_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_minimum_radius
     "@id": "#Object.r_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronFlux_flag_used_psf_radius
     "@id": "#Object.r_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_kronRad
     "@id": "#Object.r_kronRad"
@@ -3183,114 +2949,95 @@ tables:
     "@id": "#Object.r_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clipped
     "@id": "#Object.r_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_clippedCenter
     "@id": "#Object.r_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_cr
     "@id": "#Object.r_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_crCenter
     "@id": "#Object.r_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_edge
     "@id": "#Object.r_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psf
     "@id": "#Object.r_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_inexact_psfCenter
     "@id": "#Object.r_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolated
     "@id": "#Object.r_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_interpolatedCenter
     "@id": "#Object.r_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_offimage
     "@id": "#Object.r_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturated
     "@id": "#Object.r_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_saturatedCenter
     "@id": "#Object.r_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edge
     "@id": "#Object.r_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_sensor_edgeCenter
     "@id": "#Object.r_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspect
     "@id": "#Object.r_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_suspectCenter
     "@id": "#Object.r_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_pixelFlags_streak
     "@id": "#Object.r_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on r-band.
     fits:tunit:
   - name: r_pixelFlags_streakCenter
     "@id": "#Object.r_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on r-band.
     fits:tunit:
   - name: r_psfFlux
@@ -3312,25 +3059,21 @@ tables:
     "@id": "#Object.r_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_apCorr
     "@id": "#Object.r_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_edge
     "@id": "#Object.r_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_psfFlux_flag_noGoodPixels
     "@id": "#Object.r_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on r-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: r_ra
     "@id": "#Object.r_ra"
@@ -3374,7 +3117,6 @@ tables:
     "@id": "#Object.r_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap03Flux
     "@id": "#Object.u_ap03Flux"
@@ -3390,7 +3132,6 @@ tables:
     "@id": "#Object.u_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap06Flux
     "@id": "#Object.u_ap06Flux"
@@ -3406,7 +3147,6 @@ tables:
     "@id": "#Object.u_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap09Flux
     "@id": "#Object.u_ap09Flux"
@@ -3422,7 +3162,6 @@ tables:
     "@id": "#Object.u_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap12Flux
     "@id": "#Object.u_ap12Flux"
@@ -3438,7 +3177,6 @@ tables:
     "@id": "#Object.u_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap17Flux
     "@id": "#Object.u_ap17Flux"
@@ -3454,7 +3192,6 @@ tables:
     "@id": "#Object.u_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap25Flux
     "@id": "#Object.u_ap25Flux"
@@ -3470,7 +3207,6 @@ tables:
     "@id": "#Object.u_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap35Flux
     "@id": "#Object.u_ap35Flux"
@@ -3486,7 +3222,6 @@ tables:
     "@id": "#Object.u_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap50Flux
     "@id": "#Object.u_ap50Flux"
@@ -3502,7 +3237,6 @@ tables:
     "@id": "#Object.u_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ap70Flux
     "@id": "#Object.u_ap70Flux"
@@ -3518,25 +3252,21 @@ tables:
     "@id": "#Object.u_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag
     "@id": "#Object.u_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag_apertureTruncated
     "@id": "#Object.u_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.u_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_bdChi2
     "@id": "#Object.u_bdChi2"
@@ -3592,7 +3322,6 @@ tables:
     "@id": "#Object.u_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_cModelFlux
     "@id": "#Object.u_cModelFlux"
@@ -3613,13 +3342,11 @@ tables:
     "@id": "#Object.u_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_cModel_flag_apCorr
     "@id": "#Object.u_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux
     "@id": "#Object.u_calibFlux"
@@ -3635,61 +3362,51 @@ tables:
     "@id": "#Object.u_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux_flag_apertureTruncated
     "@id": "#Object.u_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.u_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_astrometry_used
     "@id": "#Object.u_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_photometry_reserved
     "@id": "#Object.u_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_photometry_used
     "@id": "#Object.u_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_candidate
     "@id": "#Object.u_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_reserved
     "@id": "#Object.u_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_calib_psf_used
     "@id": "#Object.u_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_centroid_flag
     "@id": "#Object.u_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_centroid_x
     "@id": "#Object.u_centroid_x"
@@ -3738,7 +3455,6 @@ tables:
     "@id": "#Object.u_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_sizeExtendedness
     "@id": "#Object.u_extendedLikehood"
@@ -3749,7 +3465,6 @@ tables:
     "@id": "#Object.u_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_free_cModelFlux
     "@id": "#Object.u_free_cModelFlux"
@@ -3765,7 +3480,6 @@ tables:
     "@id": "#Object.u_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_free_cModelFlux_inner
     "@id": "#Object.u_free_cModelFlux_inner"
@@ -3786,7 +3500,6 @@ tables:
     "@id": "#Object.u_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_fwhm
     "@id": "#Object.u_fwhm"
@@ -3807,7 +3520,6 @@ tables:
     "@id": "#Object.u_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap1p0Flux
     "@id": "#Object.u_gaap1p0Flux"
@@ -3823,7 +3535,6 @@ tables:
     "@id": "#Object.u_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap1p5Flux
     "@id": "#Object.u_gaap1p5Flux"
@@ -3839,7 +3550,6 @@ tables:
     "@id": "#Object.u_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap2p5Flux
     "@id": "#Object.u_gaap2p5Flux"
@@ -3855,7 +3565,6 @@ tables:
     "@id": "#Object.u_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaap3p0Flux
     "@id": "#Object.u_gaap3p0Flux"
@@ -3871,25 +3580,21 @@ tables:
     "@id": "#Object.u_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag
     "@id": "#Object.u_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag_edge
     "@id": "#Object.u_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapFlux_flag_gaussianization
     "@id": "#Object.u_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapOptimalFlux
     "@id": "#Object.u_gaapOptimalFlux"
@@ -3905,7 +3610,6 @@ tables:
     "@id": "#Object.u_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_gaapPsfFlux
     "@id": "#Object.u_gaapPsfFlux"
@@ -3931,7 +3635,6 @@ tables:
     "@id": "#Object.u_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_hsmShapeRegauss_sigma
     "@id": "#Object.u_hsmShapeRegauss_sigma"
@@ -3942,13 +3645,11 @@ tables:
     "@id": "#Object.u_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_iPSF_flag
     "@id": "#Object.u_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_iRound_flag
     "@id": "#Object.u_iRound_flag"
@@ -3959,7 +3660,6 @@ tables:
     "@id": "#Object.u_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_inputCount
     "@id": "#Object.u_inputCount"
@@ -3970,13 +3670,11 @@ tables:
     "@id": "#Object.u_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_inputCount_flag_noInputs
     "@id": "#Object.u_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ixx
     "@id": "#Object.u_ixx"
@@ -4132,13 +3830,11 @@ tables:
     "@id": "#Object.u_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with u_i_flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_hsm_momentsPsf_flag
     "@id": "#Object.u_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with u_iPSF_flag. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux
     "@id": "#Object.u_kronFlux"
@@ -4154,61 +3850,51 @@ tables:
     "@id": "#Object.u_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_radius
     "@id": "#Object.u_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_shape
     "@id": "#Object.u_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.u_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_edge
     "@id": "#Object.u_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_no_fallback_radius
     "@id": "#Object.u_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_no_minimum_radius
     "@id": "#Object.u_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_small_radius
     "@id": "#Object.u_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_used_minimum_radius
     "@id": "#Object.u_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronFlux_flag_used_psf_radius
     "@id": "#Object.u_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_kronRad
     "@id": "#Object.u_kronRad"
@@ -4219,114 +3905,95 @@ tables:
     "@id": "#Object.u_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_clipped
     "@id": "#Object.u_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_clippedCenter
     "@id": "#Object.u_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_cr
     "@id": "#Object.u_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_crCenter
     "@id": "#Object.u_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_edge
     "@id": "#Object.u_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_inexact_psf
     "@id": "#Object.u_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_inexact_psfCenter
     "@id": "#Object.u_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_interpolated
     "@id": "#Object.u_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_interpolatedCenter
     "@id": "#Object.u_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_offimage
     "@id": "#Object.u_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_saturated
     "@id": "#Object.u_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_saturatedCenter
     "@id": "#Object.u_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_sensor_edge
     "@id": "#Object.u_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_sensor_edgeCenter
     "@id": "#Object.u_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_suspect
     "@id": "#Object.u_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_suspectCenter
     "@id": "#Object.u_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_pixelFlags_streak
     "@id": "#Object.u_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on u-band.
     fits:tunit:
   - name: u_pixelFlags_streakCenter
     "@id": "#Object.u_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on u-band.
     fits:tunit:
   - name: u_psfFlux
@@ -4348,25 +4015,21 @@ tables:
     "@id": "#Object.u_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_apCorr
     "@id": "#Object.u_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_edge
     "@id": "#Object.u_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_psfFlux_flag_noGoodPixels
     "@id": "#Object.u_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on u-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: u_ra
     "@id": "#Object.u_ra"
@@ -4410,7 +4073,6 @@ tables:
     "@id": "#Object.u_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap03Flux
     "@id": "#Object.y_ap03Flux"
@@ -4426,7 +4088,6 @@ tables:
     "@id": "#Object.y_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap06Flux
     "@id": "#Object.y_ap06Flux"
@@ -4442,7 +4103,6 @@ tables:
     "@id": "#Object.y_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap09Flux
     "@id": "#Object.y_ap09Flux"
@@ -4458,7 +4118,6 @@ tables:
     "@id": "#Object.y_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap12Flux
     "@id": "#Object.y_ap12Flux"
@@ -4474,7 +4133,6 @@ tables:
     "@id": "#Object.y_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap17Flux
     "@id": "#Object.y_ap17Flux"
@@ -4490,7 +4148,6 @@ tables:
     "@id": "#Object.y_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap25Flux
     "@id": "#Object.y_ap25Flux"
@@ -4506,7 +4163,6 @@ tables:
     "@id": "#Object.y_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap35Flux
     "@id": "#Object.y_ap35Flux"
@@ -4522,7 +4178,6 @@ tables:
     "@id": "#Object.y_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap50Flux
     "@id": "#Object.y_ap50Flux"
@@ -4538,7 +4193,6 @@ tables:
     "@id": "#Object.y_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ap70Flux
     "@id": "#Object.y_ap70Flux"
@@ -4554,25 +4208,21 @@ tables:
     "@id": "#Object.y_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag
     "@id": "#Object.y_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_apertureTruncated
     "@id": "#Object.y_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_bdChi2
     "@id": "#Object.y_bdChi2"
@@ -4628,7 +4278,6 @@ tables:
     "@id": "#Object.y_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModelFlux
     "@id": "#Object.y_cModelFlux"
@@ -4649,13 +4298,11 @@ tables:
     "@id": "#Object.y_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_cModel_flag_apCorr
     "@id": "#Object.y_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux
     "@id": "#Object.y_calibFlux"
@@ -4671,61 +4318,51 @@ tables:
     "@id": "#Object.y_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_apertureTruncated
     "@id": "#Object.y_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.y_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_astrometry_used
     "@id": "#Object.y_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_reserved
     "@id": "#Object.y_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_photometry_used
     "@id": "#Object.y_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_candidate
     "@id": "#Object.y_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_reserved
     "@id": "#Object.y_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_calib_psf_used
     "@id": "#Object.y_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_flag
     "@id": "#Object.y_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_centroid_x
     "@id": "#Object.y_centroid_x"
@@ -4774,7 +4411,6 @@ tables:
     "@id": "#Object.y_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_sizeExtendedness
     "@id": "#Object.y_extendedLikehood"
@@ -4785,7 +4421,6 @@ tables:
     "@id": "#Object.y_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux
     "@id": "#Object.y_free_cModelFlux"
@@ -4801,7 +4436,6 @@ tables:
     "@id": "#Object.y_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_free_cModelFlux_inner
     "@id": "#Object.y_free_cModelFlux_inner"
@@ -4822,7 +4456,6 @@ tables:
     "@id": "#Object.y_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_fwhm
     "@id": "#Object.y_fwhm"
@@ -4843,7 +4476,6 @@ tables:
     "@id": "#Object.y_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p0Flux
     "@id": "#Object.y_gaap1p0Flux"
@@ -4859,7 +4491,6 @@ tables:
     "@id": "#Object.y_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap1p5Flux
     "@id": "#Object.y_gaap1p5Flux"
@@ -4875,7 +4506,6 @@ tables:
     "@id": "#Object.y_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap2p5Flux
     "@id": "#Object.y_gaap2p5Flux"
@@ -4891,7 +4521,6 @@ tables:
     "@id": "#Object.y_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaap3p0Flux
     "@id": "#Object.y_gaap3p0Flux"
@@ -4907,25 +4536,21 @@ tables:
     "@id": "#Object.y_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag
     "@id": "#Object.y_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_edge
     "@id": "#Object.y_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapFlux_flag_gaussianization
     "@id": "#Object.y_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapOptimalFlux
     "@id": "#Object.y_gaapOptimalFlux"
@@ -4941,7 +4566,6 @@ tables:
     "@id": "#Object.y_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_gaapPsfFlux
     "@id": "#Object.y_gaapPsfFlux"
@@ -4967,7 +4591,6 @@ tables:
     "@id": "#Object.y_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsmShapeRegauss_sigma
     "@id": "#Object.y_hsmShapeRegauss_sigma"
@@ -4978,13 +4601,11 @@ tables:
     "@id": "#Object.y_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iPSF_flag
     "@id": "#Object.y_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_iRound_flag
     "@id": "#Object.y_iRound_flag"
@@ -4995,7 +4616,6 @@ tables:
     "@id": "#Object.y_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount
     "@id": "#Object.y_inputCount"
@@ -5006,13 +4626,11 @@ tables:
     "@id": "#Object.y_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_inputCount_flag_noInputs
     "@id": "#Object.y_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ixx
     "@id": "#Object.y_ixx"
@@ -5168,13 +4786,11 @@ tables:
     "@id": "#Object.y_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with y_i_flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_hsm_momentsPsf_flag
     "@id": "#Object.y_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with y_iPSF_flag. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux
     "@id": "#Object.y_kronFlux"
@@ -5190,61 +4806,51 @@ tables:
     "@id": "#Object.y_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_radius
     "@id": "#Object.y_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape
     "@id": "#Object.y_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.y_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_edge
     "@id": "#Object.y_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_fallback_radius
     "@id": "#Object.y_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_no_minimum_radius
     "@id": "#Object.y_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_small_radius
     "@id": "#Object.y_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_minimum_radius
     "@id": "#Object.y_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronFlux_flag_used_psf_radius
     "@id": "#Object.y_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_kronRad
     "@id": "#Object.y_kronRad"
@@ -5255,114 +4861,95 @@ tables:
     "@id": "#Object.y_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clipped
     "@id": "#Object.y_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_clippedCenter
     "@id": "#Object.y_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_cr
     "@id": "#Object.y_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_crCenter
     "@id": "#Object.y_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_edge
     "@id": "#Object.y_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psf
     "@id": "#Object.y_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_inexact_psfCenter
     "@id": "#Object.y_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolated
     "@id": "#Object.y_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_interpolatedCenter
     "@id": "#Object.y_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_offimage
     "@id": "#Object.y_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturated
     "@id": "#Object.y_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_saturatedCenter
     "@id": "#Object.y_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edge
     "@id": "#Object.y_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_sensor_edgeCenter
     "@id": "#Object.y_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspect
     "@id": "#Object.y_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_suspectCenter
     "@id": "#Object.y_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_pixelFlags_streak
     "@id": "#Object.y_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on y-band.
     fits:tunit:
   - name: y_pixelFlags_streakCenter
     "@id": "#Object.y_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on y-band.
     fits:tunit:
   - name: y_psfFlux
@@ -5384,25 +4971,21 @@ tables:
     "@id": "#Object.y_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_apCorr
     "@id": "#Object.y_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_edge
     "@id": "#Object.y_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_psfFlux_flag_noGoodPixels
     "@id": "#Object.y_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on y-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: y_ra
     "@id": "#Object.y_ra"
@@ -5446,7 +5029,6 @@ tables:
     "@id": "#Object.y_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap03Flux
     "@id": "#Object.z_ap03Flux"
@@ -5462,7 +5044,6 @@ tables:
     "@id": "#Object.z_ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap06Flux
     "@id": "#Object.z_ap06Flux"
@@ -5478,7 +5059,6 @@ tables:
     "@id": "#Object.z_ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap09Flux
     "@id": "#Object.z_ap09Flux"
@@ -5494,7 +5074,6 @@ tables:
     "@id": "#Object.z_ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap12Flux
     "@id": "#Object.z_ap12Flux"
@@ -5510,7 +5089,6 @@ tables:
     "@id": "#Object.z_ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap17Flux
     "@id": "#Object.z_ap17Flux"
@@ -5526,7 +5104,6 @@ tables:
     "@id": "#Object.z_ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap25Flux
     "@id": "#Object.z_ap25Flux"
@@ -5542,7 +5119,6 @@ tables:
     "@id": "#Object.z_ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap35Flux
     "@id": "#Object.z_ap35Flux"
@@ -5558,7 +5134,6 @@ tables:
     "@id": "#Object.z_ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap50Flux
     "@id": "#Object.z_ap50Flux"
@@ -5574,7 +5149,6 @@ tables:
     "@id": "#Object.z_ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ap70Flux
     "@id": "#Object.z_ap70Flux"
@@ -5590,25 +5164,21 @@ tables:
     "@id": "#Object.z_ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag
     "@id": "#Object.z_apFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_apertureTruncated
     "@id": "#Object.z_apFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_apFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_apFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_bdChi2
     "@id": "#Object.z_bdChi2"
@@ -5664,7 +5234,6 @@ tables:
     "@id": "#Object.z_blendedness_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModelFlux
     "@id": "#Object.z_cModelFlux"
@@ -5685,13 +5254,11 @@ tables:
     "@id": "#Object.z_cModel_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_cModel_flag_apCorr
     "@id": "#Object.z_cModel_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct modelfit_CModel. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux
     "@id": "#Object.z_calibFlux"
@@ -5707,61 +5274,51 @@ tables:
     "@id": "#Object.z_calibFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_apertureTruncated
     "@id": "#Object.z_calibFlux_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calibFlux_flag_sincCoeffsTruncated
     "@id": "#Object.z_calibFlux_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_astrometry_used
     "@id": "#Object.z_calib_astrometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_reserved
     "@id": "#Object.z_calib_photometry_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_photometry_used
     "@id": "#Object.z_calib_photometry_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_candidate
     "@id": "#Object.z_calib_psf_candidate"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_reserved
     "@id": "#Object.z_calib_psf_reserved"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_calib_psf_used
     "@id": "#Object.z_calib_psf_used"
     datatype: boolean
     description: Propagated from sources. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_flag
     "@id": "#Object.z_centroid_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_centroid_x
     "@id": "#Object.z_centroid_x"
@@ -5810,7 +5367,6 @@ tables:
     "@id": "#Object.z_extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_sizeExtendedness
     "@id": "#Object.z_extendedLikehood"
@@ -5821,7 +5377,6 @@ tables:
     "@id": "#Object.z_sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux
     "@id": "#Object.z_free_cModelFlux"
@@ -5837,7 +5392,6 @@ tables:
     "@id": "#Object.z_free_cModelFlux_flag"
     datatype: boolean
     description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_free_cModelFlux_inner
     "@id": "#Object.z_free_cModelFlux_inner"
@@ -5858,7 +5412,6 @@ tables:
     "@id": "#Object.z_free_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_fwhm
     "@id": "#Object.z_fwhm"
@@ -5879,7 +5432,6 @@ tables:
     "@id": "#Object.z_gaap0p7Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p0Flux
     "@id": "#Object.z_gaap1p0Flux"
@@ -5895,7 +5447,6 @@ tables:
     "@id": "#Object.z_gaap1p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap1p5Flux
     "@id": "#Object.z_gaap1p5Flux"
@@ -5911,7 +5462,6 @@ tables:
     "@id": "#Object.z_gaap1p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap2p5Flux
     "@id": "#Object.z_gaap2p5Flux"
@@ -5927,7 +5477,6 @@ tables:
     "@id": "#Object.z_gaap2p5Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaap3p0Flux
     "@id": "#Object.z_gaap3p0Flux"
@@ -5943,25 +5492,21 @@ tables:
     "@id": "#Object.z_gaap3p0Flux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag
     "@id": "#Object.z_gaapFlux_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_edge
     "@id": "#Object.z_gaapFlux_flag_edge"
     datatype: boolean
     description: Source is too close to the edge. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapFlux_flag_gaussianization
     "@id": "#Object.z_gaapFlux_flag_gaussianization"
     datatype: boolean
     description: PSF Gaussianization failed when trying to scale by this factor. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapOptimalFlux
     "@id": "#Object.z_gaapOptimalFlux"
@@ -5977,7 +5522,6 @@ tables:
     "@id": "#Object.z_gaapOptimalFlux_flag_bigPsf"
     datatype: boolean
     description: The Gaussianized PSF is bigger than the aperture. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_gaapPsfFlux
     "@id": "#Object.z_gaapPsfFlux"
@@ -6003,7 +5547,6 @@ tables:
     "@id": "#Object.z_hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsmShapeRegauss_sigma
     "@id": "#Object.z_hsmShapeRegauss_sigma"
@@ -6014,13 +5557,11 @@ tables:
     "@id": "#Object.z_iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iPSF_flag
     "@id": "#Object.z_iPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_iRound_flag
     "@id": "#Object.z_iRound_flag"
@@ -6031,7 +5572,6 @@ tables:
     "@id": "#Object.z_i_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount
     "@id": "#Object.z_inputCount"
@@ -6042,13 +5582,11 @@ tables:
     "@id": "#Object.z_inputCount_flag"
     datatype: boolean
     description: Set for any fatal failure. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_inputCount_flag_noInputs
     "@id": "#Object.z_inputCount_flag_noInputs"
     datatype: boolean
     description: No coadd inputs available. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ixx
     "@id": "#Object.z_ixx"
@@ -6204,13 +5742,11 @@ tables:
     "@id": "#Object.z_hsm_moments_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with z_i_flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_hsm_momentsPsf_flag
     "@id": "#Object.z_hsm_momentsPsf_flag"
     datatype: boolean
     description: General failure flag, to be used in conjunction with z_iPSF_flag. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux
     "@id": "#Object.z_kronFlux"
@@ -6226,61 +5762,51 @@ tables:
     "@id": "#Object.z_kronFlux_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_radius
     "@id": "#Object.z_kronFlux_flag_bad_radius"
     datatype: boolean
     description: Bad Kron radius. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape
     "@id": "#Object.z_kronFlux_flag_bad_shape"
     datatype: boolean
     description: Shape for measuring Kron radius is bad; used PSF shape. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_bad_shape_no_psf
     "@id": "#Object.z_kronFlux_flag_bad_shape_no_psf"
     datatype: boolean
     description: Bad shape and no PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_edge
     "@id": "#Object.z_kronFlux_flag_edge"
     datatype: boolean
     description: Bad measurement due to image edge. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_fallback_radius
     "@id": "#Object.z_kronFlux_flag_no_fallback_radius"
     datatype: boolean
     description: No minimum radius and no PSF provided. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_no_minimum_radius
     "@id": "#Object.z_kronFlux_flag_no_minimum_radius"
     datatype: boolean
     description: Minimum radius could not enforced, no minimum value or PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_small_radius
     "@id": "#Object.z_kronFlux_flag_small_radius"
     datatype: boolean
     description: Measured Kron radius was smaller than that of the PSF. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_minimum_radius
     "@id": "#Object.z_kronFlux_flag_used_minimum_radius"
     datatype: boolean
     description: Used the minimum radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronFlux_flag_used_psf_radius
     "@id": "#Object.z_kronFlux_flag_used_psf_radius"
     datatype: boolean
     description: Used the PSF Kron radius for the Kron aperture. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_kronRad
     "@id": "#Object.z_kronRad"
@@ -6291,114 +5817,95 @@ tables:
     "@id": "#Object.z_pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clipped
     "@id": "#Object.z_pixelFlags_clipped"
     datatype: boolean
     description: Source footprint includes CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_clippedCenter
     "@id": "#Object.z_pixelFlags_clippedCenter"
     datatype: boolean
     description: Source center is close to CLIPPED pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_cr
     "@id": "#Object.z_pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_crCenter
     "@id": "#Object.z_pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_edge
     "@id": "#Object.z_pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA). Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psf
     "@id": "#Object.z_pixelFlags_inexact_psf"
     datatype: boolean
     description: Source footprint includes INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_inexact_psfCenter
     "@id": "#Object.z_pixelFlags_inexact_psfCenter"
     datatype: boolean
     description: Source center is close to INEXACT_PSF pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolated
     "@id": "#Object.z_pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_interpolatedCenter
     "@id": "#Object.z_pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_offimage
     "@id": "#Object.z_pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturated
     "@id": "#Object.z_pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_saturatedCenter
     "@id": "#Object.z_pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edge
     "@id": "#Object.z_pixelFlags_sensor_edge"
     datatype: boolean
     description: Source footprint includes SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_sensor_edgeCenter
     "@id": "#Object.z_pixelFlags_sensor_edgeCenter"
     datatype: boolean
     description: Source center is close to SENSOR_EDGE pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspect
     "@id": "#Object.z_pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_suspectCenter
     "@id": "#Object.z_pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels. Measured on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_pixelFlags_streak
     "@id": "#Object.z_pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint. Measured on z-band.
     fits:tunit:
   - name: z_pixelFlags_streakCenter
     "@id": "#Object.z_pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center. Measured on z-band.
     fits:tunit:
   - name: z_psfFlux
@@ -6420,25 +5927,21 @@ tables:
     "@id": "#Object.z_psfFlux_flag"
     datatype: boolean
     description: General Failure Flag. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_apCorr
     "@id": "#Object.z_psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_edge
     "@id": "#Object.z_psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_psfFlux_flag_noGoodPixels
     "@id": "#Object.z_psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit. Forced on z-band.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: z_ra
     "@id": "#Object.z_ra"
@@ -6482,7 +5985,6 @@ tables:
     "@id": "#Object.z_deblend_zeroFlux"
     datatype: boolean
     description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    mysql:datatype: BOOLEAN
     fits:tunit:
 
 
@@ -6600,7 +6102,6 @@ tables:
     "@id": "#Source.ap03Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap06Flux
     "@id": "#Source.ap06Flux"
@@ -6616,7 +6117,6 @@ tables:
     "@id": "#Source.ap06Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap09Flux
     "@id": "#Source.ap09Flux"
@@ -6632,7 +6132,6 @@ tables:
     "@id": "#Source.ap09Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap12Flux
     "@id": "#Source.ap12Flux"
@@ -6648,7 +6147,6 @@ tables:
     "@id": "#Source.ap12Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap17Flux
     "@id": "#Source.ap17Flux"
@@ -6664,7 +6162,6 @@ tables:
     "@id": "#Source.ap17Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap25Flux
     "@id": "#Source.ap25Flux"
@@ -6680,7 +6177,6 @@ tables:
     "@id": "#Source.ap25Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap35Flux
     "@id": "#Source.ap35Flux"
@@ -6696,7 +6192,6 @@ tables:
     "@id": "#Source.ap35Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap50Flux
     "@id": "#Source.ap50Flux"
@@ -6712,7 +6207,6 @@ tables:
     "@id": "#Source.ap50Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: ap70Flux
     "@id": "#Source.ap70Flux"
@@ -6728,7 +6222,6 @@ tables:
     "@id": "#Source.ap70Flux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky
     "@id": "#Source.sky"
@@ -6824,7 +6317,6 @@ tables:
     "@id": "#Source.localPhotoCalib_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localPhotoCalibErr
     "@id": "#Source.localPhotoCalibErr"
@@ -6835,7 +6327,6 @@ tables:
     "@id": "#Source.localWcs_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localWcs_CDMatrix_2_1
     "@id": "#Source.localWcs_CDMatrix_2_1"
@@ -6866,37 +6357,31 @@ tables:
     "@id": "#Source.blendedness_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noCentroid
     "@id": "#Source.blendedness_flag_noCentroid"
     datatype: boolean
     description: Object has no centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: blendedness_flag_noShape
     "@id": "#Source.blendedness_flag_noShape"
     datatype: boolean
     description: Object has no shape
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag
     "@id": "#Source.apFlux_12_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_apertureTruncated
     "@id": "#Source.apFlux_12_0_flag_apertureTruncated"
     datatype: boolean
     description: Aperture did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_flag_sincCoeffsTruncated
     "@id": "#Source.apFlux_12_0_flag_sincCoeffsTruncated"
     datatype: boolean
     description: Full sinc coefficient image did not fit within measurement image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_12_0_instFlux
     "@id": "#Source.apFlux_12_0_instFlux"
@@ -6912,7 +6397,6 @@ tables:
     "@id": "#Source.apFlux_17_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_17_0_instFlux
     "@id": "#Source.apFlux_17_0_instFlux"
@@ -6928,7 +6412,6 @@ tables:
     "@id": "#Source.apFlux_35_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_35_0_instFlux
     "@id": "#Source.apFlux_35_0_instFlux"
@@ -6944,7 +6427,6 @@ tables:
     "@id": "#Source.apFlux_50_0_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: apFlux_50_0_instFlux
     "@id": "#Source.apFlux_50_0_instFlux"
@@ -6960,13 +6442,11 @@ tables:
     "@id": "#Source.extendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sizeExtendedness_flag
     "@id": "#Source.sizeExtendedness_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: footprintArea_value
     "@id": "#Source.footprintArea_value"
@@ -6977,7 +6457,6 @@ tables:
     "@id": "#Source.jacobian_flag"
     datatype: boolean
     description: Set to 1 for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: jacobian_value
     "@id": "#Source.jacobian_value"
@@ -6998,96 +6477,80 @@ tables:
     "@id": "#Source.localBackground_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noGoodPixels
     "@id": "#Source.localBackground_flag_noGoodPixels"
     datatype: boolean
     description: No good pixels in the annulus
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: localBackground_flag_noPsf
     "@id": "#Source.localBackground_flag_noPsf"
     datatype: boolean
     description: No PSF provided
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#Source.pixelFlags_bad"
     datatype: boolean
     description: Bad pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#Source.pixelFlags_cr"
     datatype: boolean
     description: Cosmic ray in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#Source.pixelFlags_crCenter"
     datatype: boolean
     description: Cosmic ray in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#Source.pixelFlags_edge"
     datatype: boolean
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#Source.pixelFlags_interpolated"
     datatype: boolean
     description: Interpolated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#Source.pixelFlags_interpolatedCenter"
     datatype: boolean
     description: Interpolated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_offimage
     "@id": "#Source.pixelFlags_offimage"
     datatype: boolean
     description: Source center is off image
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#Source.pixelFlags_saturated"
     datatype: boolean
     description: Saturated pixel in the Source footprint
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#Source.pixelFlags_saturatedCenter"
     datatype: boolean
     description: Saturated pixel in the Source center
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#Source.pixelFlags_suspect"
     datatype: boolean
     description: Sources footprint includes suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#Source.pixelFlags_suspectCenter"
     datatype: boolean
     description: Sources center is close to suspect pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: pixelFlags_streak
     "@id": "#Source.pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint.
     fits:tunit:
   - name: pixelFlags_streakCenter
     "@id": "#Source.pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center.
     fits:tunit:
   - name: psfFlux_apCorr
@@ -7109,85 +6572,71 @@ tables:
     "@id": "#Source.psfFlux_flag"
     datatype: boolean
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_apCorr
     "@id": "#Source.psfFlux_flag_apCorr"
     datatype: boolean
     description: Set if unable to aperture correct base_PsfFlux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_edge
     "@id": "#Source.psfFlux_flag_edge"
     datatype: boolean
     description: Object was too close to the edge of the image to use the full PSF model
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#Source.psfFlux_flag_noGoodPixels"
     datatype: boolean
     description: Not enough non-rejected pixels in data to attempt the fit
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: gaussianFlux_flag
     "@id": "#Source.gaussianFlux_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag
     "@id": "#Source.centroid_flag"
     datatype: boolean
     description: General Failure Flag
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_almostNoSecondDerivative
     "@id": "#Source.centroid_flag_almostNoSecondDerivative"
     datatype: boolean
     description: Almost vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_badError
     "@id": "#Source.centroid_flag_badError"
     datatype: boolean
     description: Error on x and/or y position is NaN
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_edge
     "@id": "#Source.centroid_flag_edge"
     datatype: boolean
     description: Object too close to edge
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_noSecondDerivative
     "@id": "#Source.centroid_flag_noSecondDerivative"
     datatype: boolean
     description: Vanishing second derivative
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_notAtMaximum
     "@id": "#Source.centroid_flag_notAtMaximum"
     datatype: boolean
     description: Object is not at a maximum
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: centroid_flag_resetToPeak
     "@id": "#Source.centroid_flag_resetToPeak"
     datatype: boolean
     description: Set if CentroidChecker reset the centroid
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag
     "@id": "#Source.variance_flag"
     datatype: boolean
     description: Set for any fatal failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_flag_emptyFootprint
     "@id": "#Source.variance_flag_emptyFootprint"
     datatype: boolean
     description: Set to True when the footprint has no usable pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: variance_value
     "@id": "#Source.variance_value"
@@ -7198,61 +6647,51 @@ tables:
     "@id": "#Source.calib_astrometry_used"
     datatype: boolean
     description: Set if source was used in astrometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_detected
     "@id": "#Source.calib_detected"
     datatype: boolean
     description: Source was detected as an icSource
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_reserved
     "@id": "#Source.calib_photometry_reserved"
     datatype: boolean
     description: Set if source was reserved from photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_photometry_used
     "@id": "#Source.calib_photometry_used"
     datatype: boolean
     description: Set if source was used in photometric calibration
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_candidate
     "@id": "#Source.calib_psf_candidate"
     datatype: boolean
     description: Flag set if the source was a candidate for PSF determination, as determined by the star selector.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_reserved
     "@id": "#Source.calib_psf_reserved"
     datatype: boolean
     description: Set if source was reserved from PSF determination
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: calib_psf_used
     "@id": "#Source.calib_psf_used"
     datatype: boolean
     description: Flag set if the source was actually used for PSF determination, as determined by the
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_deblendedAsPsf
     "@id": "#Source.deblend_deblendedAsPsf"
     datatype: boolean
     description: Deblender thought this source looked like a PSF
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_hasStrayFlux
     "@id": "#Source.deblend_hasStrayFlux"
     datatype: boolean
     description: This source was assigned some stray flux
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_masked
     "@id": "#Source.deblend_masked"
     datatype: boolean
     description: Parent footprint was predominantly masked
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_nChild
     "@id": "#Source.deblend_nChild"
@@ -7263,133 +6702,111 @@ tables:
     "@id": "#Source.deblend_parentTooBig"
     datatype: boolean
     description: Parent footprint covered too many pixels
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_patchedTemplate
     "@id": "#Source.deblend_patchedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used patched edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_rampedTemplate
     "@id": "#Source.deblend_rampedTemplate"
     datatype: boolean
     description: This source was near an image edge and the deblender used ramp edge-handling.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_skipped
     "@id": "#Source.deblend_skipped"
     datatype: boolean
     description: Deblender skipped this source
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: deblend_tooManyPeaks
     "@id": "#Source.deblend_tooManyPeaks"
     datatype: boolean
     description: Source had too many peaks; only the brightest were included
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag
     "@id": "#Source.hsmPsfMoments_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_no_pixels
     "@id": "#Source.hsmPsfMoments_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_not_contained
     "@id": "#Source.hsmPsfMoments_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmPsfMoments_flag_parent_source
     "@id": "#Source.hsmPsfMoments_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag
     "@id": "#Source.iDebiasedPSF_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_no_pixels
     "@id": "#Source.iDebiasedPSF_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_not_contained
     "@id": "#Source.iDebiasedPSF_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_parent_source
     "@id": "#Source.iDebiasedPSF_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_galsim
     "@id": "#Source.iDebiasedPSF_flag_galsim"
     datatype: boolean
     description: GalSim failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: iDebiasedPSF_flag_edge
     "@id": "#Source.iDebiasedPSF_flag_edge"
     datatype: boolean
     description: Variance undefined outside image edge
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag
     "@id": "#Source.hsmShapeRegauss_flag"
     datatype: boolean
     description: General failure flag, set if anything went wrong
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_galsim
     "@id": "#Source.hsmShapeRegauss_flag_galsim"
     datatype: boolean
     description: GalSim failure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_no_pixels
     "@id": "#Source.hsmShapeRegauss_flag_no_pixels"
     datatype: boolean
     description: No pixels to measure
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_not_contained
     "@id": "#Source.hsmShapeRegauss_flag_not_contained"
     datatype: boolean
     description: Center not contained in footprint bounding box
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: hsmShapeRegauss_flag_parent_source
     "@id": "#Source.hsmShapeRegauss_flag_parent_source"
     datatype: boolean
     description: Parent source, ignored
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: sky_source
     "@id": "#Source.sky_source"
     datatype: boolean
     description: Sky objects.
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#Source.detect_isPrimary"
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    mysql:datatype: BOOLEAN
     fits:tunit:
   - name: band
     "@id": "#Source.band"
@@ -7473,19 +6890,16 @@ tables:
   - name: detect_isPatchInner
     "@id": "#ForcedSource.detect_isPatchInner"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd patch
     fits:tunit:
   - name: detect_isPrimary
     "@id": "#ForcedSource.detect_isPrimary"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
     fits:tunit:
   - name: detect_isTractInner
     "@id": "#ForcedSource.detect_isTractInner"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True if Object seed is in the inner region of a coadd tract
     fits:tunit:
   - name: localBackground_instFluxErr
@@ -7506,7 +6920,6 @@ tables:
   - name: localPhotoCalib_flag
     "@id": "#ForcedSource.localPhotoCalib_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
   - name: localPhotoCalib
@@ -7537,79 +6950,66 @@ tables:
   - name: localWcs_flag
     "@id": "#ForcedSource.localWcs_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#ForcedSource.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#ForcedSource.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#ForcedSource.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#ForcedSource.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#ForcedSource.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#ForcedSource.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#ForcedSource.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#ForcedSource.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#ForcedSource.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#ForcedSource.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources footprint includes suspect pixels
     fits:tunit:
   - name: pixelFlags_streak
     "@id": "#ForcedSource.pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint.
     fits:tunit:
   - name: pixelFlags_streakCenter
     "@id": "#ForcedSource.pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center.
     fits:tunit:
   - name: psfDiffFluxErr
@@ -7620,7 +7020,6 @@ tables:
   - name: psfDiffFlux_flag
     "@id": "#ForcedSource.psfDiffFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the image difference
     fits:tunit:
   - name: psfDiffFlux
@@ -7636,7 +7035,6 @@ tables:
   - name: psfFlux_flag
     "@id": "#ForcedSource.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
   - name: psfFlux
@@ -8218,13 +7616,11 @@ tables:
   - name: apFlux_flag
     "@id": "#DiaSource.apFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General Failure Flag
     fits:tunit:
   - name: apFlux_flag_apertureTruncated
     "@id": "#DiaSource.apFlux_flag_apertureTruncated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Aperture did not fit within measurement image.
     fits:tunit:
   - name: bboxSize
@@ -8240,7 +7636,6 @@ tables:
   - name: centroid_flag
     "@id": "#DiaSource.centroid_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General failure flag, set if anything went wrong.
     fits:tunit:
   - name: coord_dec
@@ -8327,25 +7722,21 @@ tables:
   - name: forced_PsfFlux_flag
     "@id": "#DiaSource.forced_PsfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux general failure flag.
     fits:tunit:
   - name: forced_PsfFlux_flag_edge
     "@id": "#DiaSource.forced_PsfFlux_flag_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux object was too close to the edge of the image to use the full PSF model.
     fits:tunit:
   - name: forced_PsfFlux_flag_noGoodPixels
     "@id": "#DiaSource.forced_PsfFlux_flag_noGoodPixels"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Forced PSF flux not enough non-rejected pixels in data to attempt the fit.
     fits:tunit:
   - name: isDipole
     "@id": "#DiaSource.isDipole"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Flag indicating diaSource is classified as a dipole.
     fits:tunit:
   - name: time_processed
@@ -8399,109 +7790,91 @@ tables:
   - name: pixelFlags
     "@id": "#DiaSource.pixelFlags"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General failure flag, set if anything went wrong.
     fits:tunit:
   - name: pixelFlags_bad
     "@id": "#DiaSource.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint.
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#DiaSource.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint.
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#DiaSource.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center.
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#DiaSource.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA).
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#DiaSource.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint.
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#DiaSource.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center.
     fits:tunit:
   - name: pixelFlags_offimage
     "@id": "#DiaSource.pixelFlags_offimage"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source center is off image.
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#DiaSource.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint.
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#DiaSource.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center.
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#DiaSource.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources footprint includes suspect pixels.
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#DiaSource.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels.
     fits:tunit:
   - name: pixelFlags_streak
     "@id": "#DiaSource.pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint.
     fits:tunit:
   - name: pixelFlags_streakCenter
     "@id": "#DiaSource.pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center.
     fits:tunit:
   - name: pixelFlags_injected
     "@id": "#DiaSource.pixelFlags_injected"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Injection in the Source footprint.
     fits:tunit:
   - name: pixelFlags_injectedCenter
     "@id": "#DiaSource.pixelFlags_injectedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Injection in the Source center.
     fits:tunit:
   - name: pixelFlags_injected_template
     "@id": "#DiaSource.pixelFlags_injected_template"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Template injection in the Source footprint.
     fits:tunit:
   - name: pixelFlags_injected_templateCenter
     "@id": "#DiaSource.pixelFlags_injected_templateCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Template injection in the Source center.
     fits:tunit:
   - name: psfFlux
@@ -8517,19 +7890,16 @@ tables:
   - name: psfFlux_flag
     "@id": "#DiaSource.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp.
     fits:tunit:
   - name: psfFlux_flag_edge
     "@id": "#DiaSource.psfFlux_flag_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Object was too close to the edge of the image to use the full PSF model.
     fits:tunit:
   - name: psfFlux_flag_noGoodPixels
     "@id": "#DiaSource.psfFlux_flag_noGoodPixels"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Not enough non-rejected pixels in data to attempt the fit.
     fits:tunit:
   - name: ra
@@ -8553,25 +7923,21 @@ tables:
   - name: shape_flag
     "@id": "#DiaSource.shape_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: General Failure Flag
     fits:tunit:
   - name: shape_flag_no_pixels
     "@id": "#DiaSource.shape_flag_no_pixels"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: no pixels to measure
     fits:tunit:
   - name: shape_flag_not_contained
     "@id": "#DiaSource.shape_flag_not_contained"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: center not contained in footprint bounding box
     fits:tunit:
   - name: shape_flag_parent_source
     "@id": "#DiaSource.shape_flag_parent_source"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: parent source, ignored
     fits:tunit:
   - name: snr
@@ -8663,7 +8029,6 @@ tables:
     datatype: boolean
     description: This flag is set if a trailed source extends onto or past edge pixels.
     fits:tunit:
-    mysql:datatype: BOOLEAN
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
   description: this is forcedSourceOnDiaObjectTable_tract in the butler repo
@@ -8724,7 +8089,6 @@ tables:
   - name: localPhotoCalib_flag
     "@id": "#ForcedSourceOnDiaObject.localPhotoCalib_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
   - name: localWcs_CDMatrix_1_1
@@ -8750,7 +8114,6 @@ tables:
   - name: localWcs_flag
     "@id": "#ForcedSourceOnDiaObject.localWcs_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Set for any fatal failure
     fits:tunit:
   - name: parentObjectId
@@ -8766,73 +8129,61 @@ tables:
   - name: pixelFlags_bad
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_bad"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Bad pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_cr
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_cr"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source footprint
     fits:tunit:
   - name: pixelFlags_crCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_crCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Cosmic ray in the Source center
     fits:tunit:
   - name: pixelFlags_edge
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_edge"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Source is outside usable exposure region (masked EDGE or NO_DATA)
     fits:tunit:
   - name: pixelFlags_interpolated
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_interpolated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_interpolatedCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_interpolatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Interpolated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_saturated
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_saturated"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source footprint
     fits:tunit:
   - name: pixelFlags_saturatedCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_saturatedCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Saturated pixel in the Source center
     fits:tunit:
   - name: pixelFlags_suspect
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_suspect"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources footprint includes suspect pixels
     fits:tunit:
   - name: pixelFlags_suspectCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_suspectCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Sources center is close to suspect pixels
     fits:tunit:
   - name: pixelFlags_streak
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_streak"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source footprint.
     fits:tunit:
   - name: pixelFlags_streakCenter
     "@id": "#ForcedSourceOnDiaObject.pixelFlags_streakCenter"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Streak in the Source center.
     fits:tunit:
   - name: psfDiffFlux
@@ -8848,7 +8199,6 @@ tables:
   - name: psfDiffFlux_flag
     "@id": "#ForcedSourceOnDiaObject.psfDiffFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the image difference
     fits:tunit:
   - name: psfFlux
@@ -8864,7 +8214,6 @@ tables:
   - name: psfFlux_flag
     "@id": "#ForcedSourceOnDiaObject.psfFlux_flag"
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: Failure to derive linear least-squares fit of psf model forced on the calexp
     fits:tunit:
   - name: tract
@@ -8883,7 +8232,6 @@ tables:
   - name: match_candidate
     '@id': '#MatchesTruth.match_candidate'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True for sources that were selected for matching
   - name: match_row
     '@id': '#MatchesTruth.match_row'
@@ -8926,7 +8274,6 @@ tables:
   - name: match_candidate
     '@id': '#MatchesObject.match_candidate'
     datatype: boolean
-    mysql:datatype: BOOLEAN
     description: True for sources that were selected for matching
   - name: match_row
     '@id': '#MatchesObject.match_row'


### PR DESCRIPTION
This removes all redundant `mysql:datatype: BOOLEAN` overrides from the schema files.