### PR TITLE
DM-43956: Remove all redundant overrides of fixed length strings

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -585,7 +585,6 @@ tables:
     datatype: string
     length: 64
     description: External catalog name of the nearest low-z potential host.
-    mysql:datatype: VARCHAR(64)
   - name: nearbyLowzGalSep
     "@id": "#DiaObject.nearbyLowzGalSep"
     datatype: float
@@ -2055,7 +2054,6 @@ tables:
     datatype: char
     length: 1
     description: Filter band this source was observed with.
-    mysql:datatype: CHAR(1)
   - name: isDipole
     "@id": "#DiaSource.isDipole"
     datatype: boolean
@@ -2172,7 +2170,6 @@ tables:
     length: 1
     description: Filter band this source was observed with.
     ivoa:ucd: meta.id;instr.filter
-    mysql:datatype: CHAR(1)
   - name: time_processed
     "@id": "#DiaForcedSource.time_processed"
     datatype: timestamp

--- a/yml/dp01_dc2.yaml
+++ b/yml/dp01_dc2.yaml
@@ -7266,7 +7266,6 @@ tables:
     '@id': '#object.patch'
     datatype: char
     length: 3
-    mysql:datatype: CHAR(3)
     tap:column_index: 999
     tap:principal: 1
     description: patch ID
@@ -8182,7 +8181,6 @@ tables:
     '@id': '#truth_match.id'
     datatype: char
     length: 20
-    mysql:datatype: CHAR(20)
     tap:column_index: 1
     tap:principal: 1
     description: Unique object ID
@@ -8329,7 +8327,6 @@ tables:
     '@id': '#truth_match.patch'
     datatype: char
     length: 3
-    mysql:datatype: CHAR(3)
     tap:column_index: 999
     tap:principal: 1
     description: Patch ID in Sky Map (as a string, x,y)

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -99,7 +99,6 @@ tables:
     datatype: char
     length: 1
     description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
-    mysql:datatype: CHAR(1)
     fits:tunit:
     votable:arraysize: "*"
     ivoa:ucd: meta.id;instr.filter;meta.main
@@ -143,7 +142,6 @@ tables:
     datatype: char
     description: Name of skymap used for coadd projection
     length: 12
-    mysql:datatype: CHAR(12)
     fits:tunit:
   - name: tract
     "@id": "#Object.tract"
@@ -5696,7 +5694,6 @@ tables:
     datatype: char
     length: 1
     description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
-    mysql:datatype: CHAR(1)
     fits:tunit:
     votable:arraysize: "*"
   - name: instrument
@@ -5704,7 +5701,6 @@ tables:
     datatype: char
     description: ID of instrument, the entity that produces observations.
     length: 13
-    mysql:datatype: CHAR(13)
     fits:tunit:
   - name: detector
     "@id": "#Source.detector"
@@ -5716,7 +5712,6 @@ tables:
     datatype: char
     description: ID of physical filter, the filter associated with a particular instrument.
     length: 9
-    mysql:datatype: CHAR(9)
     fits:tunit:
   - name: visit_system
     "@id": "#Source.visit_system"
@@ -5789,7 +5784,6 @@ tables:
     "@id": "#ForcedSource.skymap"
     datatype: char
     length: 12
-    mysql:datatype: CHAR(12)
     description: Name of skymap used for coadd projection
     fits:tunit:
     tap:principal: 0
@@ -5814,7 +5808,6 @@ tables:
     "@id": "#ForcedSource.band"
     datatype: char
     length: 1
-    mysql:datatype: CHAR(1)
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
     votable:arraysize: "*"
@@ -6762,7 +6755,6 @@ tables:
     "@id": "#DiaSource.filterName"
     datatype: char
     length: 1
-    mysql:datatype: CHAR(1)
     description: Band used to take this observation
     fits:tunit:
   - name: forced_PsfFlux_flag
@@ -7020,7 +7012,6 @@ tables:
     "@id": "#ForcedSourceOnDiaObject.band"
     datatype: char
     length: 1
-    mysql:datatype: CHAR(1)
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
     votable:arraysize: "*"
@@ -7295,7 +7286,6 @@ tables:
     "@id": "#ForcedSourceOnDiaObject.skymap"
     datatype: char
     length: 12
-    mysql:datatype: CHAR(12)
     description: Name of skymap used for coadd projection
     fits:tunit:
     tap:principal: 0
@@ -7349,7 +7339,6 @@ tables:
     description: Name of the band used to take the exposure where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
     ivoa:ucd: meta.id;instr.bandpass
     tap:principal: 1
@@ -7484,7 +7473,6 @@ tables:
     length: 32
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(32)
     fits:tunit:
     ivoa:ucd: meta.id;instr.filter
     tap:principal: 0
@@ -7496,7 +7484,6 @@ tables:
     description: Name of the band used to take the exposure where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
     ivoa:ucd: meta.id;instr.bandpass
     tap:principal: 1
@@ -7822,7 +7809,6 @@ tables:
     '@id': '#MatchesTruth.id'
     datatype: char
     length: 16
-    mysql:datatype: CHAR(16)
     tap:column_index: 999
     tap:principal: 0
     description: id for TruthSummary source. Potentially non-unique; use id_truth_type for JOINs.
@@ -7845,7 +7831,6 @@ tables:
     '@id': '#MatchesTruth.id_truth_type'
     datatype: char
     length: 18
-    mysql:datatype: CHAR(18)
     tap:column_index: 2
     tap:principal: 1
     description: Combination of TruthSummary id and truth_type fields, used for JOINs.
@@ -7906,7 +7891,6 @@ tables:
     '@id': '#TruthSummary.id_truth_type'
     datatype: char
     length: 22
-    mysql:datatype: CHAR(22)
     tap:column_index: 0
     tap:principal: 1
     description: Combination of id and truth_type fields, used for JOINs with MatchesTruth.
@@ -7915,7 +7899,6 @@ tables:
     '@id': '#TruthSummary.id'
     datatype: char
     length: 20
-    mysql:datatype: CHAR(20)
     tap:column_index: 1
     tap:principal: 1
     description: Unique object ID

--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -338,7 +338,6 @@ tables:
     datatype: char
     description: MPC or simulation designation of the moving object
     length: 20
-    mysql:datatype: CHAR(20)
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
     datatype: timestamp
@@ -392,7 +391,6 @@ tables:
     datatype: char
     description: Name of the band used to take the exposure where this source was measured
     length: 1
-    mysql:datatype: CHAR(1)
   - name: mag
     "@id": "#DiaSource.mag"
     datatype: float

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -338,7 +338,6 @@ tables:
     datatype: char
     description: MPC or simulation designation of the moving object
     length: 20
-    mysql:datatype: CHAR(20)
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
     datatype: timestamp
@@ -392,7 +391,6 @@ tables:
     datatype: char
     description: Name of the band used to take the exposure where this source was measured
     length: 1
-    mysql:datatype: CHAR(1)
   - name: mag
     "@id": "#DiaSource.mag"
     datatype: float

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -170,7 +170,6 @@ tables:
     datatype: char
     length: 1
     description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: refExtendedness
     "@id": "#Object.refExtendedness"
@@ -5815,7 +5814,6 @@ tables:
     datatype: char
     length: 1
     description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: detector
     "@id": "#Source.detector"
@@ -5827,7 +5825,6 @@ tables:
     datatype: char
     description: ID of physical filter, the filter associated with a particular instrument.
     length: 5
-    mysql:datatype: CHAR(5)
     fits:tunit:
   - name: visit
     "@id": "#Source.visit"
@@ -5850,7 +5847,6 @@ tables:
     length: 32
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(32)
     fits:tunit:
   - name: band
     '@id': '#Visit.band'
@@ -5859,7 +5855,6 @@ tables:
     description: Name of the band used to take the visit where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: ra
     '@id': '#Visit.ra'
@@ -5953,7 +5948,6 @@ tables:
     length: 32
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(32)
     fits:tunit:
   - name: band
     '@id': '#CcdVisit.band'
@@ -5962,7 +5956,6 @@ tables:
     description: Name of the band used to take the visit where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: ra
     '@id': '#CcdVisit.ra'

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -178,7 +178,6 @@ tables:
     datatype: char
     length: 1
     description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: refExtendedness
     "@id": "#Object.refExtendedness"
@@ -6813,7 +6812,6 @@ tables:
     datatype: char
     length: 1
     description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: detector
     "@id": "#Source.detector"
@@ -6825,7 +6823,6 @@ tables:
     datatype: char
     description: ID of physical filter, the filter associated with a particular instrument.
     length: 9
-    mysql:datatype: CHAR(9)
     fits:tunit:
   - name: visit
     "@id": "#Source.visit"
@@ -6879,7 +6876,6 @@ tables:
     "@id": "#ForcedSource.band"
     datatype: char
     length: 1
-    mysql:datatype: CHAR(1)
     description: Abstract filter that is not associated with a particular instrument
     fits:tunit:
   - name: ccdVisitId
@@ -7716,7 +7712,6 @@ tables:
     "@id": "#DiaSource.band"
     datatype: char
     length: 1
-    mysql:datatype: CHAR(1)
     description: Band used to take this observation.
     fits:tunit:
   - name: forced_PsfFlux_flag
@@ -8253,7 +8248,6 @@ tables:
     '@id': '#MatchesTruth.id'
     datatype: char
     length: 16
-    mysql:datatype: CHAR(16)
     description: id for truth_summary source.
   - name: truth_type
     '@id': '#MatchesTruth.truth_type'
@@ -8283,7 +8277,6 @@ tables:
     '@id': '#MatchesObject.match_id'
     datatype: char
     length: 16
-    mysql:datatype: CHAR(16)
     description: id of matched truth_summary source, if any
   - name: match_truth_type
     '@id': '#MatchesObject.match_truth_type'
@@ -8309,7 +8302,6 @@ tables:
     length: 32
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(32)
     fits:tunit:
   - name: band
     '@id': '#Visit.band'
@@ -8318,7 +8310,6 @@ tables:
     description: Name of the band used to take the visit where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: ra
     '@id': '#Visit.ra'
@@ -8412,7 +8403,6 @@ tables:
     length: 32
     description: ID of physical filter, the filter associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(32)
     fits:tunit:
   - name: band
     '@id': '#CcdVisit.band'
@@ -8421,7 +8411,6 @@ tables:
     description: Name of the band used to take the visit where this source was measured.
       Abstract filter that is not associated with a particular instrument.
     votable:arraysize: "*"
-    mysql:datatype: CHAR(1)
     fits:tunit:
   - name: ra
     '@id': '#CcdVisit.ra'


### PR DESCRIPTION
Removed all overrides from schemas for fixed length strings, similar to `mysql:datatype: CHAR(32)`. 

In all cases, there was an identical type definition of `char` or `string` on the column with the same length.