### PR TITLE
DM-44059: Remove length fields from timestamp columns

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -13,13 +13,11 @@ tables:
   - name: name
     "@id": "#metadata.name"
     datatype: text
-    length: 1024
     nullable: false
     description: Name or key for a metadata item.
   - name: value
     "@id": "#metadata.value"
     datatype: text
-    length: 65535
     nullable: false
     description: Content of the metadata item in string representation.
   primaryKey: "#metadata.name"

--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -37,17 +37,13 @@ tables:
   - name: validityStart
     "@id": "#DiaObject.validityStart"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Processing time when validity of this diaObject starts.
-    mysql:datatype: DATETIME
   - name: validityEnd
     "@id": "#DiaObject.validityEnd"
     datatype: timestamp
-    length: 6
     nullable: true
     description: Processing time when validity of this diaObject ends.
-    mysql:datatype: DATETIME
   - name: ra
     "@id": "#DiaObject.ra"
     datatype: double
@@ -1024,10 +1020,8 @@ tables:
   - name: lastNonForcedSource
     "@id": "#DiaObject.lastNonForcedSource"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Last time when non-forced DIASource was seen for this object.
-    mysql:datatype: DATETIME
   - name: nDiaSources
     "@id": "#DiaObject.nDiaSources"
     datatype: int
@@ -1391,10 +1385,8 @@ tables:
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
     datatype: timestamp
-    length: 6
     description: Time when this diaSource was reassociated from diaObject to ssObject
       (if such reassociation happens, otherwise NULL).
-    mysql:datatype: DATETIME
   - name: midpointMjdTai
     "@id": "#DiaSource.midpointMjdTai"
     datatype: double
@@ -2033,17 +2025,13 @@ tables:
   - name: time_processed
     "@id": "#DiaSource.time_processed"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Time when the image was processed and this DiaSource record was generated.
-    mysql:datatype: DATETIME
   - name: time_withdrawn
     "@id": "#DiaSource.time_withdrawn"
     datatype: timestamp
-    length: 6
     nullable: true
     description: Time when this record was marked invalid.
-    mysql:datatype: DATETIME
   - name: bboxSize
     "@id": "#DiaSource.bboxSize"
     datatype: long
@@ -2237,17 +2225,13 @@ tables:
   - name: time_processed
     "@id": "#DiaForcedSource.time_processed"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Time when this record was generated.
-    mysql:datatype: DATETIME
   - name: time_withdrawn
     "@id": "#DiaForcedSource.time_withdrawn"
     datatype: timestamp
-    length: 6
     nullable: true
     description: Time when this record was marked invalid.
-    mysql:datatype: DATETIME
   primaryKey:
   - "#DiaForcedSource.diaObjectId"
   - "#DiaForcedSource.visit"
@@ -2312,7 +2296,6 @@ tables:
   - name: lastNonForcedSource
     "@id": "#DiaObjectLast.lastNonForcedSource"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Last time when non-forced DIASource was seen for this object.
   - name: ra
@@ -2509,15 +2492,11 @@ tables:
   - name: arcStart
     "@id": "#MPCORB.arcStart"
     datatype: timestamp
-    length: 6
     description: Year of first observation (for multi-opposition objects).
-    mysql:datatype: DATETIME
   - name: arcEnd
     "@id": "#MPCORB.arcEnd"
     datatype: timestamp
-    length: 6
     description: Year of last observation (for multi-opposition objects).
-    mysql:datatype: DATETIME
   - name: rms
     "@id": "#MPCORB.rms"
     datatype: float

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -7411,7 +7411,6 @@ tables:
   - name: expMidpt
     '@id': '#Visit.expMidpt'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint time for exposure at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
@@ -7430,7 +7429,6 @@ tables:
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start time of the exposure at the fiducial center of the focal plane array,
       TAI, accurate to 10ms.
@@ -7570,7 +7568,6 @@ tables:
   - name: expMidpt
     '@id': '#CcdVisit.expMidpt'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint for exposure. TAI, accurate to 10ms.
     tap:principal: 0
@@ -7594,7 +7591,6 @@ tables:
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start of the exposure, TAI, accurate to 10ms.
     ivoa:ucd: time.start;obs.exposure

--- a/yml/hsc.yaml
+++ b/yml/hsc.yaml
@@ -5934,7 +5934,6 @@ tables:
   - name: midpoint
     '@id': '#Visit.midpoint'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint time of the visit at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
@@ -5948,7 +5947,6 @@ tables:
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start time of the visit at the fiducial center of the focal plane array,
       TAI, accurate to 10ms.
@@ -6043,7 +6041,6 @@ tables:
   - name: midpoint
     '@id': '#CcdVisit.midpoint'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint of this visit. TAI, accurate to 10ms.
   - name: midpointMjdTai
@@ -6060,7 +6057,6 @@ tables:
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start of the visit, TAI, accurate to 10ms.
   - name: obsStartMjdTai

--- a/yml/imsim.yaml
+++ b/yml/imsim.yaml
@@ -7791,10 +7791,9 @@ tables:
   - name: time_processed
     "@id": "#DiaSource.time_processed"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Time when the image was processed and this DiaSource record was generated.
-    mysql:datatype: DATETIME
+    mysql:datatype: DATETIME(6)
   - name: ixx
     "@id": "#DiaSource.ixx"
     datatype: double
@@ -8428,7 +8427,6 @@ tables:
   - name: midpoint
     '@id': '#Visit.midpoint'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint time for visit at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
@@ -8442,7 +8440,6 @@ tables:
   - name: obsStart
     '@id': '#Visit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start time of the visit at the fiducial center of the focal plane array,
       TAI, accurate to 10ms.
@@ -8537,7 +8534,6 @@ tables:
   - name: midpoint
     '@id': '#CcdVisit.midpoint'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Midpoint of the visit. TAI, accurate to 10ms.
   - name: midpointMjdTai
@@ -8554,7 +8550,6 @@ tables:
   - name: obsStart
     '@id': '#CcdVisit.obsStart'
     datatype: timestamp
-    length: 6
     mysql:datatype: DATETIME(6)
     description: Start of the visit, TAI, accurate to 10ms.
   - name: obsStartMjdTai


### PR DESCRIPTION
Removed length fields from timestamp columns to cleanup warning messages. 

These were unused anyways, since Felis does not consider this a sized type and would not use the argument when constructing the SQLAlchemy objects.

A few lengths were also removed from `text` columns in APDB, since Felis doesn't accept a length for this type any longer. My understanding is that since APDB does its own type handling for Cassandra, this should be an inconsequential change.