### PR TITLE
DM-44637: Remove unnecessary MySQL datatype overrides for string types

### DIFF
--- a/yml/apdb.yaml
+++ b/yml/apdb.yaml
@@ -2404,7 +2404,6 @@ tables:
     datatype: char
     length: 8
     description: Number or provisional designation (in packed form).
-    mysql:datatype: VARCHAR(8)
     ivoa:ucd: meta.id;src
   - name: mpcNumber
     "@id": "#MPCORB.mpcNumber"
@@ -2469,13 +2468,11 @@ tables:
     datatype: char
     length: 1
     description: Uncertainty parameter, U.
-    mysql:datatype: VARCHAR(1)
   - name: reference
     "@id": "#MPCORB.reference"
     datatype: char
     length: 9
     description: Reference.
-    mysql:datatype: VARCHAR(9)
   - name: nobs
     "@id": "#MPCORB.nobs"
     datatype: int
@@ -2508,20 +2505,17 @@ tables:
     length: 3
     description: Coarse indicator of perturbers (blank if unperturbed one-opposition.
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: pertsLong
     "@id": "#MPCORB.pertsLong"
     datatype: char
     length: 3
     description: Precise indicator of perturbers (blank if unperturbed one-opposition.
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: computer
     "@id": "#MPCORB.computer"
     datatype: char
     length: 10
     description: Computer name.
-    mysql:datatype: VARCHAR(10)
   - name: flags
     "@id": "#MPCORB.flags"
     datatype: int
@@ -2532,7 +2526,6 @@ tables:
     datatype: char
     length: 26
     description: Readable designation.
-    mysql:datatype: VARCHAR(26)
   - name: lastIncludedObservation
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float
@@ -2551,7 +2544,6 @@ tables:
     datatype: char
     length: 8
     description: Either the MPC provisional or permanent designation.
-    mysql:datatype: VARCHAR(8)
     ivoa:ucd: meta.id;src
   - name: mpcNumber
     "@id": "#MPCORBDESIGMAP.mpcNumber"
@@ -2562,7 +2554,6 @@ tables:
     datatype: char
     length: 8
     description: Other designation by which this object is known.
-    mysql:datatype: VARCHAR(8)
   - name: ssObjectId
     "@id": "#MPCORBDESIGMAP.ssObjectId"
     datatype: long

--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -612,7 +612,6 @@ tables:
     datatype: char
     length: 8
     description: 'MPCORB: Number or provisional designation (in packed form)'
-    mysql:datatype: VARCHAR(8)
     ivoa:ucd: meta.id;src
   - name: mpcNumber
     "@id": "#MPCORB.mpcNumber"
@@ -677,13 +676,11 @@ tables:
     datatype: char
     length: 1
     description: 'MPCORB: Uncertainty parameter, U'
-    mysql:datatype: VARCHAR(1)
   - name: reference
     "@id": "#MPCORB.reference"
     datatype: char
     length: 9
     description: 'MPCORB: Reference'
-    mysql:datatype: VARCHAR(9)
   - name: nobs
     "@id": "#MPCORB.nobs"
     datatype: int
@@ -718,20 +715,17 @@ tables:
     length: 3
     description: 'MPCORB: Coarse indicator of perturbers (blank if unperturbed one-opposition
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: pertsLong
     "@id": "#MPCORB.pertsLong"
     datatype: char
     length: 3
     description: 'MPCORB: Precise indicator of perturbers (blank if unperturbed one-opposition
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: computer
     "@id": "#MPCORB.computer"
     datatype: char
     length: 10
     description: 'MPCORB: Computer name'
-    mysql:datatype: VARCHAR(10)
   - name: flags
     "@id": "#MPCORB.flags"
     datatype: int
@@ -742,7 +736,6 @@ tables:
     datatype: char
     length: 26
     description: 'MPCORB: Readable designation'
-    mysql:datatype: VARCHAR(26)
   - name: lastIncludedObservation
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -594,7 +594,6 @@ tables:
     datatype: char
     length: 8
     description: 'MPCORB: Number or provisional designation (in packed form)'
-    mysql:datatype: VARCHAR(8)
     ivoa:ucd: meta.id;src
   - name: mpcNumber
     "@id": "#MPCORB.mpcNumber"
@@ -659,13 +658,11 @@ tables:
     datatype: char
     length: 1
     description: 'MPCORB: Uncertainty parameter, U'
-    mysql:datatype: VARCHAR(1)
   - name: reference
     "@id": "#MPCORB.reference"
     datatype: char
     length: 9
     description: 'MPCORB: Reference'
-    mysql:datatype: VARCHAR(9)
   - name: nobs
     "@id": "#MPCORB.nobs"
     datatype: int
@@ -700,20 +697,17 @@ tables:
     length: 3
     description: 'MPCORB: Coarse indicator of perturbers (blank if unperturbed one-opposition
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: pertsLong
     "@id": "#MPCORB.pertsLong"
     datatype: char
     length: 3
     description: 'MPCORB: Precise indicator of perturbers (blank if unperturbed one-opposition
       object)'
-    mysql:datatype: VARCHAR(3)
   - name: computer
     "@id": "#MPCORB.computer"
     datatype: char
     length: 10
     description: 'MPCORB: Computer name'
-    mysql:datatype: VARCHAR(10)
   - name: flags
     "@id": "#MPCORB.flags"
     datatype: int
@@ -724,7 +718,6 @@ tables:
     datatype: char
     length: 26
     description: 'MPCORB: Readable designation'
-    mysql:datatype: VARCHAR(26)
   - name: lastIncludedObservation
     "@id": "#MPCORB.lastIncludedObservation"
     datatype: float


### PR DESCRIPTION
APDB changes were confirmed with @andy-slac. No MySQL datatype overrides are needed at all for this schema.

The overrides were removed from the DP0.3 schemas based on them being deployed in Postgres and not MySQL.