### PR TITLE
Change build engine to mysql / Enable size column in TAP_SCHEMA columns

### DIFF
--- a/tap-schema/build
+++ b/tap-schema/build
@@ -9,7 +9,7 @@ shift
 schema_index=0
 for file in $@
 do
-    felis load-tap --tap-schema-index $schema_index --dry-run --engine-url=postgresql+psycopg2:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
+    felis load-tap --tap-schema-index $schema_index --dry-run --engine-url=mysql+mysqlconnector:// --tap-schema-name=tap_schema --tap-tables-postfix=11 $file > sql/`basename $file`.sql
     schema_index=$((schema_index+1))
 done
 

--- a/tap-schema/sql/0000_tap_schema11.sql
+++ b/tap-schema/sql/0000_tap_schema11.sql
@@ -250,44 +250,44 @@ insert into tap_schema.tables11 (schema_name,table_name,table_type,description,u
 ( 'tap_schema', 'tap_schema.key_columns', 'table', 'description of foreign key columns in this tableset', NULL, 104000)
 ;
 
-insert into tap_schema.columns11 (table_name,column_name,description,utype,ucd,unit,datatype,arraysize,xtype,principal,indexed,std, column_index) values
-( 'tap_schema.schemas', 'schema_name', 'schema name for reference to tap_schema.schemas', NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1 ),
-( 'tap_schema.schemas', 'utype', 'lists the utypes of schemas in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,2 ),
-( 'tap_schema.schemas', 'description', 'describes schemas in the tableset',               NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,3 ),
-( 'tap_schema.schemas', 'schema_index', 'recommended sort order when listing schemas',    NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,4 ),
+insert into tap_schema.columns11 (table_name,column_name,description,utype,ucd,unit,datatype,arraysize,xtype,principal,indexed,std, column_index, `size`) values
+( 'tap_schema.schemas', 'schema_name', 'schema name for reference to tap_schema.schemas', NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1, 64),
+( 'tap_schema.schemas', 'utype', 'lists the utypes of schemas in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,2, 512),
+( 'tap_schema.schemas', 'description', 'describes schemas in the tableset',               NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,3, 512),
+( 'tap_schema.schemas', 'schema_index', 'recommended sort order when listing schemas',    NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,4, NULL),
 
-( 'tap_schema.tables', 'schema_name', 'the schema this table belongs to',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,1 ),
-( 'tap_schema.tables', 'table_name', 'the fully qualified table name',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2 ),
-( 'tap_schema.tables', 'table_type', 'one of: table view',                                NULL, NULL, NULL, 'char', '8*', NULL, 1,0,1,3 ),
-( 'tap_schema.tables', 'utype', 'lists the utype of tables in the tableset',              NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,4 ),
-( 'tap_schema.tables', 'description', 'describes tables in the tableset',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,5 ),
-( 'tap_schema.tables', 'table_index', 'recommended sort order when listing tables',       NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,6 ),
+( 'tap_schema.tables', 'schema_name', 'the schema this table belongs to',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,1, 512),
+( 'tap_schema.tables', 'table_name', 'the fully qualified table name',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2, 64),
+( 'tap_schema.tables', 'table_type', 'one of: table view',                                NULL, NULL, NULL, 'char', '8*', NULL, 1,0,1,3, 8),
+( 'tap_schema.tables', 'utype', 'lists the utype of tables in the tableset',              NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,4, 512),
+( 'tap_schema.tables', 'description', 'describes tables in the tableset',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,5, 512),
+( 'tap_schema.tables', 'table_index', 'recommended sort order when listing tables',       NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,6, NULL),
 
-( 'tap_schema.columns', 'table_name', 'the table this column belongs to',                 NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1 ),
-( 'tap_schema.columns', 'column_name', 'the column name',                                 NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2 ),
-( 'tap_schema.columns', 'utype', 'lists the utypes of columns in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,3 ),
-( 'tap_schema.columns', 'ucd', 'lists the UCDs of columns in the tableset',               NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,4 ),
-( 'tap_schema.columns', 'unit', 'lists the unit used for column values in the tableset',  NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,5 ),
-( 'tap_schema.columns', 'description', 'describes the columns in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,6 ),
-( 'tap_schema.columns', 'datatype', 'lists the ADQL datatype of columns in the tableset', NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,7 ),
-( 'tap_schema.columns', 'arraysize', 'lists the size of variable-length columns in the tableset', NULL, NULL, NULL, 'char', '16*', NULL, 1,0,1,8 ),
-( 'tap_schema.columns', 'xtype', 'a DALI or custom extended type annotation',             NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,7 ),
+( 'tap_schema.columns', 'table_name', 'the table this column belongs to',                 NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1, 64),
+( 'tap_schema.columns', 'column_name', 'the column name',                                 NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2, 64),
+( 'tap_schema.columns', 'utype', 'lists the utypes of columns in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,3, 512),
+( 'tap_schema.columns', 'ucd', 'lists the UCDs of columns in the tableset',               NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,4, 64),
+( 'tap_schema.columns', 'unit', 'lists the unit used for column values in the tableset',  NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,5, 64),
+( 'tap_schema.columns', 'description', 'describes the columns in the tableset',           NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,6, 512),
+( 'tap_schema.columns', 'datatype', 'lists the ADQL datatype of columns in the tableset', NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,7, 64),
+( 'tap_schema.columns', 'arraysize', 'lists the size of variable-length columns in the tableset', NULL, NULL, NULL, 'char', '16*', NULL, 1,0,1,8, 16),
+( 'tap_schema.columns', 'xtype', 'a DALI or custom extended type annotation',             NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,7, 64),
 
-( 'tap_schema.columns', '"size"', 'deprecated: use arraysize', NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,9 ),
-( 'tap_schema.columns', 'principal', 'a principal column; 1 means 1, 0 means 0',      NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,10 ),
-( 'tap_schema.columns', 'indexed', 'an indexed column; 1 means 1, 0 means 0',         NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,11 ),
-( 'tap_schema.columns', 'std', 'a standard column; 1 means 1, 0 means 0',             NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,12 ),
-( 'tap_schema.columns', 'column_index', 'recommended sort order when listing columns of a table',  NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,13 ),
+( 'tap_schema.columns', '"size"', 'deprecated: use arraysize', NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,9, NULL),
+( 'tap_schema.columns', 'principal', 'a principal column; 1 means 1, 0 means 0',      NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,10, NULL),
+( 'tap_schema.columns', 'indexed', 'an indexed column; 1 means 1, 0 means 0',         NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,11, NULL),
+( 'tap_schema.columns', 'std', 'a standard column; 1 means 1, 0 means 0',             NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,12, NULL),
+( 'tap_schema.columns', 'column_index', 'recommended sort order when listing columns of a table',  NULL, NULL, NULL, 'int', NULL, NULL, 1,0,1,13, NULL),
 
-( 'tap_schema.keys', 'key_id', 'unique key to join to tap_schema.key_columns',            NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1 ),
-( 'tap_schema.keys', 'from_table', 'the table with the foreign key',                      NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2 ),
-( 'tap_schema.keys', 'target_table', 'the table with the primary key',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,3 ),
-( 'tap_schema.keys', 'utype', 'lists the utype of keys in the tableset',              NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,4 ),
-( 'tap_schema.keys', 'description', 'describes keys in the tableset',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,5 ),
+( 'tap_schema.keys', 'key_id', 'unique key to join to tap_schema.key_columns',            NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1, 64),
+( 'tap_schema.keys', 'from_table', 'the table with the foreign key',                      NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2, 64),
+( 'tap_schema.keys', 'target_table', 'the table with the primary key',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,3, 64),
+( 'tap_schema.keys', 'utype', 'lists the utype of keys in the tableset',              NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,4, 512),
+( 'tap_schema.keys', 'description', 'describes keys in the tableset',                 NULL, NULL, NULL, 'char', '512*', NULL, 1,0,1,5, 512),
 
-( 'tap_schema.key_columns', 'key_id', 'key to join to tap_schema.keys',                   NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1 ),
-( 'tap_schema.key_columns', 'from_column', 'column in the from_table',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2 ),
-( 'tap_schema.key_columns', 'target_column', 'column in the target_table',                NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,3 )
+( 'tap_schema.key_columns', 'key_id', 'key to join to tap_schema.keys',                   NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,1, 64),
+( 'tap_schema.key_columns', 'from_column', 'column in the from_table',                    NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,2, 64),
+( 'tap_schema.key_columns', 'target_column', 'column in the target_table',                NULL, NULL, NULL, 'char', '64*', NULL, 1,0,1,3, 64)
 ;
 
 insert into tap_schema.keys11 (key_id,from_table,target_table) values


### PR DESCRIPTION
**Summary**
Add size value to the TAP_SCHEMA column entries that get inserted. This addresses the issue where validators expect the "size" column to match the "arraysize" col. 
The second change is to modify the engine-url to "mysql+mysqlconnector", as the TAP_SCHEMA  database currently deployed is in MySQL, so the insert statements need to be produced for that as far as I can see. I noticed this after trying to add values for the size column, which produced invalid SQL statements.

**Jira issue:**
https://rubinobs.atlassian.net/browse/DM-44878

**How was this tested**
- Tested on data-dev, using a custom Docker image built locally.
- Test run using stilts taplint