### PR TITLE
Temporarily change MatchesTruth.truth_type to an int from short

### DIFF
--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -7803,7 +7803,7 @@ tables:
     ivoa:ucd: meta.id.assoc
   - name: truth_type
     '@id': '#MatchesTruth.truth_type'
-    datatype: short
+    datatype: int
     tap:column_index: 999
     tap:principal: 0
     description: Type of TruthSummary source; 1 for galaxies, 2 for stars, and 3 for SNe


### PR DESCRIPTION
Fix portal bug with short not being handled correctly by Firefly plotting interface. It does not recognize short as a plottable data type.