### PR TITLE
DM-45623: Make foreign key constraint names unique in cdb schemas

### DIFF
--- a/yml/cdb_latiss.yaml
+++ b/yml/cdb_latiss.yaml
@@ -302,13 +302,13 @@ tables:
   - "#exposure_flexdata.obs_id"
   - "#exposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
     columns: ["#exposure_flexdata.obs_id"]
     referencedColumns: ["#exposure.exposure_id"]
-  - name: fk_key
+  - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
@@ -410,7 +410,7 @@ tables:
   primaryKey:
   - "#ccdexposure_camera.ccdexposure_id"
   constraints:
-  - name: fk_ccdexposure_id
+  - name: fk_ccdexposure_camera_ccdexposure_id
     "@id": "#ccdexposure_camera.fk_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
@@ -437,13 +437,13 @@ tables:
   - "#ccdexposure_flexdata.obs_id"
   - "#ccdexposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdexposure_flexdata_obs_id
     "@id": "#ccdexposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
     columns: ["#ccdexposure_flexdata.obs_id"]
     referencedColumns: ["#ccdexposure.ccdexposure_id"]
-  - name: fk_key
+  - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
@@ -781,7 +781,7 @@ tables:
   primaryKey:
   - "#visit1_quicklook.visit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_visit1_quicklook_obs_id
     "@id": "#visit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
@@ -948,7 +948,7 @@ tables:
   primaryKey:
   - "#ccdvisit1_quicklook.ccdvisit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdvisit1_quicklook_obs_id
     "@id": "#ccdvisit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.

--- a/yml/cdb_lsstcomcam.yaml
+++ b/yml/cdb_lsstcomcam.yaml
@@ -290,13 +290,13 @@ tables:
   - "#exposure_flexdata.obs_id"
   - "#exposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
     columns: ["#exposure_flexdata.obs_id"]
     referencedColumns: ["#exposure.exposure_id"]
-  - name: fk_key
+  - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
@@ -398,7 +398,7 @@ tables:
   primaryKey:
   - "#ccdexposure_camera.ccdexposure_id"
   constraints:
-  - name: fk_ccdexposure_id
+  - name: fk_ccdexposure_camera_ccdexposure_id
     "@id": "#ccdexposure_camera.fk_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
@@ -425,13 +425,13 @@ tables:
   - "#ccdexposure_flexdata.obs_id"
   - "#ccdexposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdexposure_flexdata_obs_id
     "@id": "#ccdexposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
     columns: ["#ccdexposure_flexdata.obs_id"]
     referencedColumns: ["#ccdexposure.ccdexposure_id"]
-  - name: fk_key
+  - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
@@ -761,7 +761,7 @@ tables:
   primaryKey:
   - "#visit1_quicklook.visit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_visit1_quicklook_obs_id
     "@id": "#visit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
@@ -1176,7 +1176,7 @@ tables:
   primaryKey:
   - "#ccdvisit1_quicklook.ccdvisit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdvisit1_quicklook_obs_id
     "@id": "#ccdvisit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.

--- a/yml/cdb_lsstcomcamsim.yaml
+++ b/yml/cdb_lsstcomcamsim.yaml
@@ -290,13 +290,13 @@ tables:
   - "#exposure_flexdata.obs_id"
   - "#exposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
     columns: ["#exposure_flexdata.obs_id"]
     referencedColumns: ["#exposure.exposure_id"]
-  - name: fk_key
+  - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
@@ -398,7 +398,7 @@ tables:
   primaryKey:
   - "#ccdexposure_camera.ccdexposure_id"
   constraints:
-  - name: fk_ccdexposure_id
+  - name: fk_ccdexposure_camera_ccdexposure_id
     "@id": "#ccdexposure_camera.fk_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
@@ -425,7 +425,7 @@ tables:
   - "#ccdexposure_flexdata.obs_id"
   - "#ccdexposure_flexdata.key"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdexposure_flexdata_obs_id
     "@id": "#ccdexposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
@@ -761,7 +761,7 @@ tables:
   primaryKey:
   - "#visit1_quicklook.visit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_visit1_quicklook_obs_id
     "@id": "#visit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
@@ -1176,7 +1176,7 @@ tables:
   primaryKey:
   - "#ccdvisit1_quicklook.ccdvisit_id"
   constraints:
-  - name: fk_obs_id
+  - name: fk_ccdvisit1_quicklook_obs_id
     "@id": "#ccdvisit1_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.


### PR DESCRIPTION
Prepend table names to FK constraint names so that they are unique within the schema.