### PR TITLE
DM-44884: Remove DP0.1 tables from TAP_SCHEMA on idfint and idfdev

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -6,8 +6,8 @@
 ./build mock
 
 ./build idfprod-tap ../yml/dp02_dc2.yaml ../yml/dp01_dc2.yaml ../yml/dp02_obscore.yaml
-./build idfint-tap ../yml/dp02_dc2.yaml ../yml/dp01_dc2.yaml ../yml/dp02_obscore.yaml
-./build idfdev-tap ../yml/dp02_dc2.yaml ../yml/dp01_dc2.yaml ../yml/dp02_obscore.yaml
+./build idfint-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
+./build idfdev-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
 ./build usdf-prod-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
 ./build usdf-dev-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
 


### PR DESCRIPTION
Matches the current state of Qserv.

Preliminary to removing DP0.1 altogether.