### PR TITLE
DM-43115: Add missing primary keys to DP0.2 schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Gemfile
 Gemfile.lock
 datalink/columns-principal.yaml
 datalink/*.zip
+
+.scratch

--- a/scripts/test/create-databases.sh
+++ b/scripts/test/create-databases.sh
@@ -9,12 +9,11 @@ fi
 # Initialize a variable to track if any command fails
 error_occurred=0
 
-# Create databases from YAML files. Drop existing databases since some of
-# the schema names are duplicated and also ignore constraints since many
-# schemas are missing required indices for FK constraints.
+# Create databases from YAML files, dropping existing databases since some
+# names are duplicated across files.
 for yaml_file in yml/*.yaml; do
     echo "Creating database from $yaml_file..."
-    felis --log-level ERROR create --drop --ignore-constraints "$yaml_file"
+    felis --log-level ERROR create --drop "$yaml_file"
     # Check if the felis command was successful
     if [ $? -ne 0 ]; then
         echo "Error: Failed to create database from $yaml_file"

--- a/yml/dp02_dc2.yaml
+++ b/yml/dp02_dc2.yaml
@@ -8,6 +8,7 @@ tables:
 - name: Object
   "@id": "#Object"
   description: "Properties of the astronomical objects detected and measured on the deep coadded images."
+  primaryKey: "#Object.objectId"
   tap:table_index: 1
   columns:
   - name: objectId
@@ -4990,6 +4991,7 @@ tables:
   "@id": "#Source"
   description: "Properties of detections on the single-epoch visit images, performed
     independently of the Object detections on coadded images."
+  primaryKey: "#Source.sourceId"
   tap:table_index: 2
   columns:
   - name: sourceId
@@ -5738,6 +5740,7 @@ tables:
     difference images, based on and linked to the entries in the Object table. Point-source
     PSF photometry is performed, based on coordinates from a reference band chosen for each
     Object and reported in the Object.refBand column."
+  primaryKey: "#ForcedSource.forcedSourceId"
   tap:table_index: 3
   columns:
   - name: forcedSourceId
@@ -6076,6 +6079,7 @@ tables:
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
     single-epoch difference images."
+  primaryKey: "#DiaObject.diaObjectId"
   tap:table_index: 4
   columns:
   - name: decl
@@ -6638,6 +6642,7 @@ tables:
 - name: DiaSource
   "@id": "#DiaSource"
   description: "Properties of transient-object detections on the single-epoch difference images."
+  primaryKey: "#DiaSource.diaSourceId"
   tap:table_index: 5
   columns:
   - name: apFlux
@@ -7006,6 +7011,7 @@ tables:
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
     DiaObject table."
+  primaryKey: "#ForcedSourceOnDiaObject.forcedSourceOnDiaObjectId"
   tap:table_index: 6
   columns:
   - name: band
@@ -7311,6 +7317,7 @@ tables:
   '@id': '#Visit'
   description: "Metadata about the pointings of the DC2 simulated survey,
     largely associated with the boresight of the entire focal plane."
+  primaryKey: "#Visit.visit"
   tap:table_index: 7
   columns:
   - name: visit
@@ -7444,6 +7451,7 @@ tables:
   '@id': '#CcdVisit'
   description: "Metadata about the 189 individual CCD images for each Visit in the
     DC2 simulated survey."
+  primaryKey: "#CcdVisit.ccdVisitId"
   tap:table_index: 8
   columns:
   - name: ccdVisitId
@@ -7872,6 +7880,10 @@ tables:
 - name: TruthSummary
   '@id': '#TruthSummary'
   description: Summary properties of objects from the DESC DC2 truth catalog, as described in arXiv:2101.04855. Includes the noiseless astrometric and photometric parameters.
+  # In practice, it is not clear whether the addition of truth_type is required to construct a unique
+  # primary key for this table.  Rather than take the time to investigate the situation, we are just accepting
+  # this as-is for DP0.2 (see also DM-43115).
+  primaryKey: "#TruthSummary.id_truth_type"
   tap:table_index: 10
   columns:
   - name: id_truth_type


### PR DESCRIPTION
This fixes errors with foreign key constraints when creating the database for the DP0.2 schema.

The `--ignore-constraints` flag was removed from the database creation script used in the Github workflows.