### PR TITLE
DM-46895: Add missing ConsDB schemas

### DIFF
--- a/browser/cdb_latiss.md
+++ b/browser/cdb_latiss.md
@@ -1,7 +1,8 @@
 ---
 layout: schema
-title: Consolidated Database for LATISS
+title: ConsDB - LATISS
 schema: cdb_latiss
 sort-index: 50
 ---
-The Consolidated Database Schema for LATISS describes the tables and views available as fixed metadata to describe LATISS exposures, visits, and parts thereof.
+The Consolidated Database Schema for LATISS describes the tables and views available as fixed metadata to
+describe LATISS exposures, visits, and parts thereof.

--- a/browser/cdb_lsstcomcam.md
+++ b/browser/cdb_lsstcomcam.md
@@ -1,0 +1,7 @@
+---
+layout: schema
+title: ConsDB - LSSTComCam
+schema: cdb_lsstcomcam
+sort-index: 51
+---
+{{ site.data[page.schema].description }}

--- a/browser/cdb_lsstcomcamsim.md
+++ b/browser/cdb_lsstcomcamsim.md
@@ -1,7 +1,7 @@
 ---
 layout: schema
-title: Consolidated Database for LSSTComCamSim
+title: ConsDB - LSSTComCamSim
 schema: cdb_lsstcomcamsim
-sort-index: 51
+sort-index: 52
 ---
 The Consolidated Database Schema for LSSTComCamSim describes the tables and views available as fixed metadata to describe LSSTComCamSim exposures, visits, and parts thereof.

--- a/browser/cdb_startrackerfast.md
+++ b/browser/cdb_startrackerfast.md
@@ -1,0 +1,7 @@
+---
+layout: schema
+title: ConsDB - StarTrackerFast
+schema: cdb_startrackerfast
+sort-index: 53
+---
+{{ site.data[page.schema].description }}

--- a/browser/cdb_startrackernarrow.md
+++ b/browser/cdb_startrackernarrow.md
@@ -1,0 +1,7 @@
+---
+layout: schema
+title: ConsDB - StarTrackerNarrow
+schema: cdb_startrackernarrow
+sort-index: 54
+---
+{{ site.data[page.schema].description }}

--- a/browser/cdb_startrackerwide.md
+++ b/browser/cdb_startrackerwide.md
@@ -1,0 +1,7 @@
+---
+layout: schema
+title: ConsDB - StarTrackerWide
+schema: cdb_startrackerwide
+sort-index: 55
+---
+{{ site.data[page.schema].description }}


### PR DESCRIPTION
I added new markdown files to the schema browser for missing ConsDB schemas (`cdb_latiss` and `cdb_startracker*`), and I also updated the schema titles in the sidebar so they are shorter and more concise.