### PR TITLE
DM-46982: Add toggle for table pagination

### DIFF
--- a/browser/_layouts/schema.html
+++ b/browser/_layouts/schema.html
@@ -67,8 +67,8 @@
         <ul>
             <li><b>Updated:</b> {{ site.time | date: "%B %-d, %Y" }}</li>
         </ul>
-        <label style="margin: 20px;">
-          <input title="Enables table pagination of schema data when checked" type="checkbox" id="toggle-pagination"> Table Pagination
+        <label title="Enables table pagination of schema data when checked" style="margin: 20px;">
+          <input type="checkbox" id="toggle-pagination"> Paginate Tables
         </label>
         <ul>
           <li><a href=".">Schema Browser</a></li>

--- a/browser/_layouts/schema.html
+++ b/browser/_layouts/schema.html
@@ -12,13 +12,16 @@
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.7.1/js/buttons.html5.min.js"></script>
     <script>
     $(document).ready(function() {
+        var tables = [];
+        var isPaginationEnabled = $('#toggle-pagination').is(':checked');
+
         $('table.schema-table').each(function() {
             var table = $(this);
             var tableName = table.closest('section').find('h2').text().trim();
-            table.DataTable({
-                "pageLength": 10, // Set the default number of entries to show
+            var dataTable = table.DataTable({
+                "pageLength": isPaginationEnabled ? 10 : -1, // Set the default number of entries to show based on checkbox state
                 "order": [[5, 'asc'], [0, 'asc']], // Sort by TAP Column Index and then by Column Name
-                dom: 'Bfrtipl', // Add the buttons to the DataTable
+                dom: isPaginationEnabled ? 'Bfrtipl' : 'Bfrti', // Add the buttons to the DataTable and conditionally include pagination UI elements
                 buttons: [
                     {
                         extend: 'csvHtml5',
@@ -27,6 +30,28 @@
                         }
                     }
                 ]
+            });
+            tables.push(dataTable);
+        });
+
+        $('#toggle-pagination').change(function() {
+            var isChecked = $(this).is(':checked');
+            tables.forEach(function(dataTable) {
+                var table = dataTable.table().node();
+                $(table).DataTable().destroy(); // Destroy the existing DataTable instance
+                $(table).DataTable({
+                    "pageLength": isChecked ? 10 : -1, // Set the default number of entries to show based on checkbox state
+                    "order": [[5, 'asc'], [0, 'asc']], // Sort by TAP Column Index and then by Column Name
+                    dom: isChecked ? 'Bfrtipl' : 'Bfrti', // Add the buttons to the DataTable and conditionally include pagination UI elements
+                    buttons: [
+                        {
+                            extend: 'csvHtml5',
+                            filename: function() {
+                                return $(table).closest('section').find('h2').text().trim();
+                            }
+                        }
+                    ]
+                });
             });
         });
     });
@@ -56,6 +81,9 @@
         <ul>
           <li><a href="/v">Change version</a></li>
         </ul>
+        <label style="margin: 20px;">
+          <input type="checkbox" id="toggle-pagination" checked> Table Pagination
+        </label>
       </nav>
       <div id="content">
         <main class="main-content">

--- a/browser/_layouts/schema.html
+++ b/browser/_layouts/schema.html
@@ -67,6 +67,9 @@
         <ul>
             <li><b>Updated:</b> {{ site.time | date: "%B %-d, %Y" }}</li>
         </ul>
+        <label style="margin: 20px;">
+          <input title="Enables table pagination of schema data when checked" type="checkbox" id="toggle-pagination"> Table Pagination
+        </label>
         <ul>
           <li><a href=".">Schema Browser</a></li>
           <ul>
@@ -81,9 +84,6 @@
         <ul>
           <li><a href="/v">Change version</a></li>
         </ul>
-        <label style="margin: 20px;">
-          <input type="checkbox" id="toggle-pagination" checked> Table Pagination
-        </label>
       </nav>
       <div id="content">
         <main class="main-content">
@@ -110,7 +110,7 @@
                 {% for col in table.columns %}
                 <tr id="{{ col['@id'] | remove:'#' }}">
                   <td class="column-name">
-                  {{ col.name }}</a>
+                    <a href="{{ col['@id'] }}">{{ col.name }}</a>
                   </td>
                   <td>{{ col.datatype }}</td>
                   <td>{{ col['ivoa:unit'] | default: col['fits:tunit'] }}</td>

--- a/browser/_sass/style2.scss
+++ b/browser/_sass/style2.scss
@@ -2,11 +2,13 @@
 
 html {
 	height: 100%;
+    overflow: hidden;
 }
 
 body {
 	margin: 0;
 	height: 100%;
+    overflow: hidden;
 }
 
 a {
@@ -16,6 +18,7 @@ a {
 #container {
 	display: flex;
 	height: 100%;
+    overflow: hidden;
 }
 
 #sidebar {
@@ -23,7 +26,7 @@ a {
 	vertical-align: top;
 	height: 100%;
 	width: 20%;
-	overflow: auto;
+	overflow-y: auto;
 	padding-left: 1rem;
 }
 
@@ -49,7 +52,7 @@ a {
 	vertical-align: top;
 	height: 100%;
 	width: 80%;
-	overflow: auto;
+	overflow-y: auto;
 }
 
 .main-content {


### PR DESCRIPTION
This adds a checkbox for toggling table pagination, which is turned off by default.

Column anchor links are restored, too, and some minor changes were made to the stylesheet so that the page content fits in the viewport, eliminating the extra vertical scrollbar.