### PR TITLE
Fix typo in DP0.3 rms column description

### DIFF
--- a/yml/dp03_10yr.yaml
+++ b/yml/dp03_10yr.yaml
@@ -707,7 +707,7 @@ tables:
   - name: rms
     "@id": "#MPCORB.rms"
     datatype: float
-    description: 'MPCORB: r.m.s residual (")'
+    description: 'MPCORB: r.m.s residual'
     fits:tunit: arcsec
   - name: pertsShort
     "@id": "#MPCORB.pertsShort"

--- a/yml/dp03_1yr.yaml
+++ b/yml/dp03_1yr.yaml
@@ -689,7 +689,7 @@ tables:
   - name: rms
     "@id": "#MPCORB.rms"
     datatype: float
-    description: 'MPCORB: r.m.s residual (")'
+    description: 'MPCORB: r.m.s residual'
     fits:tunit: arcsec
   - name: pertsShort
     "@id": "#MPCORB.pertsShort"


### PR DESCRIPTION
Fix an apparent typo in the `rms` column of the DP0.3 schemas.