### PR TITLE
DM-47069: Add EUPS config to sdm_schemas for resource path support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,9 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+
+scripts.BasicSConstruct(
+    "sdm_schemas",
+    disableCc=True,
+    noCfgFile=True,
+    versionModuleName="python/lsst/sdm_schemas/version.py"
+)

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,7 +1,7 @@
 install()
 {
+    default_install
     mkdir -p "$PREFIX"
     cp -a ./yml "$PREFIX"
     install_ups
 }
-

--- a/ups/sdm_schemas.table
+++ b/ups/sdm_schemas.table
@@ -1,0 +1,3 @@
+setupRequired(sconsUtils)
+
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
This adds `lsst.sdm_schemas` to the `PYTHONPATH` so that schemas are available using a resource path.