### PR TITLE
DM-47403: Fix problems in GitHub build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,16 @@
 name: Build TAP Schema and Datalink
 
-on: push
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
 
     steps:
       - name: Check out repo

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          # Need to clone everything for the git tags.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__
 
 # LSST version
 python/lsst/sdm_schemas/version.py
+
+# SCons build
+config.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ datalink/*.zip
 build
 python/lsst_sdm_schemas.egg-info
 __pycache__
+
+# LSST version
+python/lsst/sdm_schemas/version.py

--- a/python/lsst/sdm_schemas/schemas/imsim.yaml
+++ b/python/lsst/sdm_schemas/schemas/imsim.yaml
@@ -8092,13 +8092,6 @@ tables:
     datatype: boolean
     description: This flag is set if a trailed source contains edge pixels.
     fits:tunit:
-  # - name: extendedness
-  #  "@id": "#DiaSource.extendedness"
-  #  datatype: double
-  #  description: A measure of extendedness, computed by comparing an object's moment-based traced radius to
-  #    the PSF moments. extendedness = 1 implies a high degree of confidence
-  #    that the source is extended. extendedness = 0 implies a high degree of confidence
-  #    that the source is point-like.
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
   description: this is forcedSourceOnDiaObjectTable_tract in the butler repo

--- a/tap-schema/build
+++ b/tap-schema/build
@@ -1,6 +1,21 @@
 #!/bin/bash -ex
 ENVIRONMENT="$1"
-GIT_TAG=`echo $GITHUB_REF | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'`
+
+echo "GITHUB_REF: $GITHUB_REF"
+if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+  # Tag
+  GIT_TAG=$(echo $GITHUB_REF | sed -E 's,refs/tags/,,')
+elif [[ "$GITHUB_REF" == refs/heads/* ]]; then
+  # Branch
+  GIT_TAG=$(echo $GITHUB_REF | sed -E 's,refs/heads/,,')
+elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
+  # Pull Request
+  GIT_TAG=$GITHUB_HEAD_REF
+fi
+
+GIT_TAG=$(echo $GIT_TAG | sed -E 's,/,-,g')
+echo "GIT_TAG: $GIT_TAG"
+
 shift
 
 # Generate SQL files from Felis yaml files

--- a/tap-schema/build
+++ b/tap-schema/build
@@ -17,6 +17,8 @@ done
 docker build . -t lsstsqre/tap-schema-$ENVIRONMENT:$GIT_TAG
 docker push lsstsqre/tap-schema-$ENVIRONMENT:$GIT_TAG
 
+echo "Pushed Docker image: lsstsqre/tap-schema-$ENVIRONMENT:$GIT_TAG"
+
 # Clean up any untracked files in the sql directory
 # between the different runs of this script.
 git clean -n


### PR DESCRIPTION
Fix issues in the build workflow:

1. Use the standard workflow trigger instead of `on: push`
2. Add `fetch-depth: 0` to checkout
3. Build and push Docker images on all triggers, including for user branches and merges to `main`
4. Update the `tap-schema/build` script so it creates Docker images with the proper names for all cases (tags, branches & PRs)

Miscellaneous changes:

1. Remove a commented-out column from `imsim`
2. Add lsst versions file and `config.log` to `.gitignore`
