### PR TITLE
DM-46158: Add workflow to perform schema comparisons and check for changes to deployed schemas

### DIFF
--- a/.github/workflows/compare.yaml
+++ b/.github/workflows/compare.yaml
@@ -1,0 +1,98 @@
+name: Compare Schemas for Changes
+
+on:
+  pull_request:
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          path: current-ref
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        working-directory: current-ref
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -r requirements.txt
+
+      - name: Set relative path to schema directory
+        run: |
+          echo "SCHEMA_DIR=python/lsst/sdm_schemas/schemas" >> $GITHUB_ENV
+
+      - name: Get list of changed YAML files
+        working-directory: current-ref
+        run: |
+          echo "Checking for changes compared with: ${{ github.event.pull_request.base.ref }}"
+          DIFF_OUTPUT=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD -- ${{ env.SCHEMA_DIR }})
+          CHANGED_FILES=$(echo "$DIFF_OUTPUT" | grep '\.yaml$' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No schema files changed."
+            echo "CHANGED_FILES=" >> $GITHUB_ENV
+            echo "SCHEMA_FILES_CHANGED=false" >> $GITHUB_ENV
+          else
+            CHANGED_FILES=$(echo "$CHANGED_FILES" | sed "s|^${{ env.SCHEMA_DIR }}/||" | tr '\n' ' ')
+            echo "Changed YAML files: $CHANGED_FILES"
+            echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+            echo "SCHEMA_FILES_CHANGED=true" >> $GITHUB_ENV
+          fi
+
+      - name: Check out PR base ref
+        if: env.SCHEMA_FILES_CHANGED == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base-ref
+
+      - name: Run deepdiff comparison
+        if: env.SCHEMA_FILES_CHANGED == 'true'
+        run: |
+          for file in ${{ env.CHANGED_FILES }}; do
+            echo "Comparing $file..."
+            BASE_FILE=base-ref/${{ env.SCHEMA_DIR }}/$file
+            CURRENT_FILE=current-ref/${{ env.SCHEMA_DIR }}/$file
+            felis --log-level ERROR diff -c deepdiff $BASE_FILE $CURRENT_FILE
+          done
+
+      - name: Run alembic comparison
+        if: env.SCHEMA_FILES_CHANGED == 'true'
+        run: |
+          for file in ${{ env.CHANGED_FILES }}; do
+            echo "Comparing $file..."
+            BASE_FILE=base-ref/${{ env.SCHEMA_DIR }}/$file
+            CURRENT_FILE=current-ref/${{ env.SCHEMA_DIR }}/$file
+            felis --log-level ERROR diff -c alembic $BASE_FILE $CURRENT_FILE
+          done
+
+      - name: Run alembic comparison on deployed schemas
+        if: env.SCHEMA_FILES_CHANGED == 'true'
+        run: |
+          ERROR_FLAG=0
+          DEPLOYED_SCHEMAS=$(cat current-ref/yml/deployed-schemas.txt)
+          for file in ${{ env.CHANGED_FILES }}; do
+            if echo "$DEPLOYED_SCHEMAS" | grep -q "^$file$"; then
+              echo "Comparing $file..."
+              BASE_FILE=base-ref/${{ env.SCHEMA_DIR }}/$file
+              CURRENT_FILE=current-ref/${{ env.SCHEMA_DIR }}/$file
+              if ! felis --log-level ERROR diff -E -c alembic $BASE_FILE $CURRENT_FILE; then
+                echo "Error comparing $file"
+                ERROR_FLAG=1
+              fi
+            else
+              echo "Skipping $file (not in deployed-schemas.txt)"
+            fi
+          done
+          if [ $ERROR_FLAG -ne 0 ]; then
+            echo "One or more schemas was changed."
+            exit 1
+          fi

--- a/python/lsst/sdm_schemas/schemas/deployed-schemas.txt
+++ b/python/lsst/sdm_schemas/schemas/deployed-schemas.txt
@@ -1,0 +1,4 @@
+dp02_dc2.yaml
+dp02_obscore.yaml
+dp03_10yr.yaml
+dp03_1yr.yaml


### PR DESCRIPTION
This PR adds a workflow that will check for changes in schemas using the `felis diff` command. One comparison is performed using the `deepdiff` comparator, which will show all changes, including ones to metadata fields, e.g., `ivoa_ucd`. Another comparison step will use `alembic`, which will only show updates that affect the relational data model.

Finally, a comparison using the `alembic` mode will be performed on each schema from a list of "deployed" schema YAML files (which is also added by this PR). An error will be raised if any of them have changed (`dp02_dc2`, etc.).

A preliminary step in the workflow uses `git diff` to detect which files were changed. Files which were not changed in the repository need not be checked.

----

~~Blocked by https://github.com/lsst/felis/pull/109~~

This is merged now. ^^^^