### PR TITLE
DM-46991: Drop calib_detected from Source schemas.

### DIFF
--- a/python/lsst/sdm_schemas/schemas/hsc.yaml
+++ b/python/lsst/sdm_schemas/schemas/hsc.yaml
@@ -5653,11 +5653,6 @@ tables:
     datatype: boolean
     description: Set if source was used in astrometric calibration
     fits:tunit:
-  - name: calib_detected
-    "@id": "#Source.calib_detected"
-    datatype: boolean
-    description: Source was detected as an icSource
-    fits:tunit:
   - name: calib_photometry_reserved
     "@id": "#Source.calib_photometry_reserved"
     datatype: boolean

--- a/python/lsst/sdm_schemas/schemas/imsim.yaml
+++ b/python/lsst/sdm_schemas/schemas/imsim.yaml
@@ -6705,11 +6705,6 @@ tables:
     datatype: boolean
     description: Set if source was used in astrometric calibration
     fits:tunit:
-  - name: calib_detected
-    "@id": "#Source.calib_detected"
-    datatype: boolean
-    description: Source was detected as an icSource
-    fits:tunit:
   - name: calib_photometry_reserved
     "@id": "#Source.calib_photometry_reserved"
     datatype: boolean


### PR DESCRIPTION
This flag no longer has any meaning in the new pipeline flow, as the step it represented was removed.