### PR TITLE
Fix links in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Checklist
 
-When making changes to YAML files in the [schemas](../python/lsst/sdm_schemas/schemas) directory:
+When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm_schemas/schemas) directory:
 
-- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](../CONTRIBUTING.md)
-- [ ] Referred to the [documentation on specific schemas](../CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
+- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
+- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated


### PR DESCRIPTION
Prepend links in PR template with `/lsst/sdm_schemas/blob/main` so that they work correctly.