### PR TITLE
DM-48279: Add nDiaSources to DiaObjectLast table

### DIFF
--- a/python/lsst/sdm_schemas/schemas/apdb.yaml
+++ b/python/lsst/sdm_schemas/schemas/apdb.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ApdbSchema"
 "@id": "#apdbSchema"
-version: "3.0.0"
+version: "4.0.0"
 description: The Alert Production Database (APDB) contains the catalogs resulting from
   image differencing during nightly Prompt Processing as well as the results of
   daily Solar System Processing.
@@ -2383,6 +2383,11 @@ tables:
     description: Covariance of pmDec and parallax.
     ivoa:ucd: stat.covariance
     fits:tunit: mas**2/yr
+  - name: nDiaSources
+    "@id": "#DiaObjectLast.nDiaSources"
+    datatype: int
+    nullable: false
+    description: Total number of DiaSources associated with this DiaObject.
   primaryKey: "#DiaObjectLast.diaObjectId"
 - name: MPCORB
   "@id": "#MPCORB"


### PR DESCRIPTION
Adds a column for `nDiaSources` to the `DiaObjectLast` table used by the APDB
## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm_schemas/schemas) directory:

- [x ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
