### PR TITLE
DM-48979: Added api_created field to tap_schema.schemas table definition

### DIFF
--- a/tap-schema/sql/0000_tap_schema11.sql
+++ b/tap-schema/sql/0000_tap_schema11.sql
@@ -21,6 +21,9 @@ create table tap_schema.schemas11
         read_only_group  varchar(128),
         read_write_group varchar(128),
 
+-- extension: flag to indicate if a schema was created using a Tap service API
+        api_created     integer,
+
 	primary key (schema_name)
 )
 ;
@@ -37,6 +40,9 @@ create table tap_schema.schemas
         read_anon       integer,
         read_only_group  varchar(128),
         read_write_group varchar(128),
+
+-- extension: flag to indicate if a schema was created using a Tap service API
+        api_created     integer,
 
 	primary key (schema_name)
 )


### PR DESCRIPTION
## Summary

The CADC folks have added a required field named `api_created` to their `TAP_SCHEMA` definition for the schemas table which is then used internally and thus upgrading to newer versions (of cadc-dali) depend on this existing in our `TAP_SCHEMA`.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm_schemas/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
