### PR TITLE
DM-48803: Add workflow for checking consistency of band columns

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -14,3 +14,8 @@ runs:
         python -m pip install --upgrade pip uv
         uv pip install --system -r requirements.txt
       shell: bash
+
+    - name: Install SDM Tools
+      run: |
+        uv pip install --system 'lsst-sdm-tools @ git+https://github.com/lsst/sdm_tools@main'
+      shell: bash

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -1,0 +1,16 @@
+name: "Setup Python"
+description: "Setup Python"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: "pip"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip uv
+        uv pip install --system -r requirements.txt
+      shell: bash

--- a/.github/workflows/check_band_columns.yaml
+++ b/.github/workflows/check_band_columns.yaml
@@ -1,0 +1,23 @@
+name: Check band columns
+
+on:
+  pull_request:
+
+jobs:
+
+  check_band_columns:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Setup python and install dependencies
+        uses: ./.github/actions/setup-python
+
+      - name: Set SDM Tools log Level
+        run: echo "export SDM_TOOLS_LOGLEVEL=WARNING" >> $GITHUB_ENV
+
+      - name: Check schema band columns (error on differences)
+        run: sdm-tools check-band-columns yml/{dp02*,dp03*,imsim,hsc,apdb}.yaml --reference-band i -e

--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -666,6 +666,7 @@ tables:
     "@id": "#DiaObject.u_psfFluxLinearIntercept"
     datatype: float
     description: Linear best fit Intercept of the u band fluxes.
+    fits:tunit: nJy
   - name: u_psfFluxMaxSlope
     "@id": "#DiaObject.u_psfFluxMaxSlope"
     datatype: float

--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -391,7 +391,7 @@ tables:
     datatype: float
     description: Standard deviation of the distribution of y_psfFlux.
     fits:tunit: nJy
-    ivoa:ucd: stat.error
+    ivoa:ucd: stat.stdev
   - name: y_psfFluxChi2
     "@id": "#DiaObject.y_psfFluxChi2"
     datatype: float

--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -1009,7 +1009,7 @@ tables:
   - name: y_psfFluxMaxSlope
     "@id": "#DiaObject.y_psfFluxMaxSlope"
     datatype: float
-    description: Maximum slope between y band flux obsevations max(delta_flux/delta_time)
+    description: Maximum slope between y band flux obsevations max(delta_flux/delta_time).
     fits:tunit: nJy/d
   - name: y_psfFluxErrMean
     "@id": "#DiaObject.y_psfFluxErrMean"

--- a/python/lsst/sdm/schemas/hsc.yaml
+++ b/python/lsst/sdm/schemas/hsc.yaml
@@ -759,8 +759,7 @@ tables:
   - name: g_iRound_flag
     "@id": "#Object.g_iRound_flag"
     datatype: boolean
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
+    description: General failure flag, set if anything went wrong. Measured on g-band.
   - name: g_i_flag
     "@id": "#Object.g_i_flag"
     datatype: boolean

--- a/python/lsst/sdm/schemas/imsim.yaml
+++ b/python/lsst/sdm/schemas/imsim.yaml
@@ -1042,7 +1042,7 @@ tables:
   - name: g_hsm_momentsPsf_flag
     "@id": "#Object.g_hsm_momentsPsf_flag"
     datatype: boolean
-    description: General failure flag, to be used in conjunction with g-band._iPSF_flag. Measured on g-band.
+    description: General failure flag, to be used in conjunction with g_iPSF_flag. Measured on g-band.
     fits:tunit:
   - name: g_kronFlux
     "@id": "#Object.g_kronFlux"


### PR DESCRIPTION
This PR adds a workflow for checking the consistency of band column definitions in the following schemas:

- dp02_dc2
- dp03*
- imsim
- hsc
- apdb

Several inconsistencies in a few of these schemas were fixed, so the check currently passes.

Introduction of any inconsistencies between band column definitions will cause the workflow and PR status check to fail.

----

~~The tools for checking the band columns are introduced by [this PR in sdm_tools](https://github.com/lsst/sdm_tools/pull/4), which needs to be merged before this one.~~

~~This PR will also need to be updated to use the `main` branch of sdm_tools in `requirements.txt` instead of a ticket branch.~~

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
