### PR TITLE
DM-43728: Build TAP_SCHEMA Docker images for ConsDB

### DIFF
--- a/tap-schema/build
+++ b/tap-schema/build
@@ -18,10 +18,18 @@ echo "GIT_TAG: $GIT_TAG"
 
 shift
 
+schema_files=$(for file in "$@"; do basename "$file"; done | tr '\n' ' ')
+echo "Building environment '$ENVIRONMENT' with schemas: $schema_files"
+
 # Generate SQL files from Felis yaml files
 # Place the SQL files in the sql directory, which gets
 # copied into the docker image.
 schema_index=0
+unique_flag=""
+if [ "$FELIS_UNIQUE_KEYS" == "1" ]; then
+    echo "Generating unique keys"
+    unique_flag="-u"
+fi
 for file in $@
 do
     felis load-tap-schema \
@@ -31,6 +39,7 @@ do
         --tap-schema-name=tap_schema \
         --tap-tables-postfix=11 \
         --output-file sql/`basename $file`.sql \
+        $unique_flag \
         $file
     schema_index=$((schema_index+1))
 done

--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -20,4 +20,4 @@
 ./build usdf-prod-sso ../yml/dp03_10yr.yaml ../yml/dp03_1yr.yaml
 ./build usdf-dev-sso ../yml/dp03_10yr.yaml ../yml/dp03_1yr.yaml
 
-./build usdf-dev-cdb ../yml/cdb_*.yaml
+FELIS_UNIQUE_KEYS=1 ./build usdf-dev-cdb ../yml/cdb_*.yaml

--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -20,3 +20,4 @@
 ./build usdf-prod-sso ../yml/dp03_10yr.yaml ../yml/dp03_1yr.yaml
 ./build usdf-dev-sso ../yml/dp03_10yr.yaml ../yml/dp03_1yr.yaml
 
+./build usdf-dev-cdb ../yml/cdb_*.yaml


### PR DESCRIPTION
This PR adds support for building a TAP_SCHEMA Docker image containing ConsDB schemas. The environment is called `usdf-dev-cdb` and intended for deployment on `usdf-rsp-dev`. 

A new feature in Felis was used to ensure that the `key_id` values for the `keys` and `key_columns` tables are unique by prepending the name of the schema to them. (This feature is activated only when building the ConsDB environment.)

Merge after https://github.com/lsst/felis/pull/136 which adds the new Felis feature.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
