### PR TITLE
DM-49406 Add a CDB schema for LSSTCam

### DIFF
--- a/python/lsst/sdm/schemas/cdb_lsstcam.yaml
+++ b/python/lsst/sdm/schemas/cdb_lsstcam.yaml
@@ -1,0 +1,1653 @@
+---
+name: cdb_lsstcam
+"@id": "#cdb_lsstcam"
+description: Consolidated Database for LSSTCam
+version:
+  current: "1.0.0"
+tables:
+- name: exposure
+  "@id": "#exposure"
+  primaryKey:
+  - "#exposure.day_obs"
+  - "#exposure.seq_num"
+  constraints:
+  - name: un_exposure_day_obs_seq_num
+    "@id": "#exposure.un_exposure_day_obs_seq_num"
+    "@type": Unique
+    description: Ensure day_obs plus seq_num is unique.
+    columns:
+    - "#exposure.day_obs"
+    - "#exposure.seq_num"
+  - name: un_exposure_exposure_id
+    "@id": "#exposure.un_exposure_exposure_id"
+    "@type": Unique
+    description: Ensure exposure_id is unique.
+    columns:
+    - "#exposure.exposure_id"
+  columns:
+  - name: exposure_id
+    "@id": "#exposure.exposure_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: exposure_name
+    "@id": "#exposure.exposure_name"
+    datatype: string
+    length: 20
+    nullable: false
+    description: Official name of the exposure.
+  - name: controller
+    "@id": "#exposure.controller"
+    datatype: string
+    length: 1
+    nullable: false
+    description: The abbreviation of the controller used for the observation (O, C).
+  - name: day_obs
+    "@id": "#exposure.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#exposure.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: physical_filter
+    "@id": "#exposure.physical_filter"
+    datatype: string
+    length: 32
+    description: ID of physical filter, the filter associated with a particular instrument.
+  - name: band
+    "@id": "#exposure.band"
+    datatype: string
+    length: 32
+    description: Name of the band used to take the exposure.  Abstract filter that is not associated with a particular instrument.
+  - name: s_ra
+    "@id": "#exposure.s_ra"
+    datatype: double
+    description: Central Spatial Position in ICRS; Right ascension of targeted focal plane center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.ra
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
+    ivoa:unit: deg
+  - name: s_dec
+    "@id": "#exposure.s_dec"
+    datatype: double
+    description: Central Spatial Position in ICRS; Declination of targeted focal plane center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.dec
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
+    ivoa:unit: deg
+  - name: sky_rotation
+    "@id": "#exposure.sky_rotation"
+    datatype: double
+    description: Targeted sky rotation angle.
+    ivoa:ucd: pos.posAng
+    ivoa:unit: deg
+  - name: azimuth_start
+    "@id": "#exposure.azimuth_start"
+    datatype: float
+    description: Azimuth of focal plane center at the start of the exposure.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: azimuth_end
+    "@id": "#exposure.azimuth_end"
+    datatype: float
+    description: Azimuth of focal plane center at the end of the exposure.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: azimuth
+    "@id": "#exposure.azimuth"
+    datatype: float
+    description: Azimuth of focal plane center at the middle of the exposure.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: altitude_start
+    "@id": "#exposure.altitude_start"
+    datatype: float
+    description: Altitude of focal plane center at the start of the exposure.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: altitude_end
+    "@id": "#exposure.altitude_end"
+    datatype: float
+    description: Altitude of focal plane center at the end of the exposure.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: altitude
+    "@id": "#exposure.altitude"
+    datatype: float
+    description: Altitude of focal plane center at the middle of the exposure.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: zenith_distance_start
+    "@id": "#exposure.zenith_distance_start"
+    datatype: float
+    description: Zenith distance at the start of the exposure.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: zenith_distance_end
+    "@id": "#exposure.zenith_distance_end"
+    datatype: float
+    description: Zenith distance at the end of the exposure.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: zenith_distance
+    "@id": "#exposure.zenith_distance"
+    datatype: float
+    description: Zenith distance at the middle of the exposure.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: airmass
+    "@id": "#exposure.airmass"
+    datatype: float
+    description: Airmass of the observed line of sight at the middle of the exposure.
+    ivoa:ucd: obs.airMass
+  - name: exp_midpt
+    "@id": "#exposure.exp_midpt"
+    datatype: timestamp
+    precision: 6
+    description: Midpoint time for exposure at the fiducial center of the focal plane.
+      array. TAI, accurate to 10ms.
+    ivoa:ucd: time.epoch
+  - name: exp_midpt_mjd
+    "@id": "#exposure.exp_midpt_mjd"
+    datatype: double
+    description: Midpoint time for exposure at the fiducial center of the focal plane.
+      array in MJD. TAI, accurate to 10ms.
+    ivoa:ucd: time.epoch
+    ivoa:unit: d
+  - name: obs_start
+    "@id": "#exposure.obs_start"
+    datatype: timestamp
+    precision: 6
+    description: Start time of the exposure at the fiducial center of the focal plane.
+      array, TAI, accurate to 10ms.
+    ivoa:ucd: time.start
+  - name: obs_start_mjd
+    "@id": "#exposure.obs_start_mjd"
+    datatype: double
+    description: Start of the exposure in MJD, TAI, accurate to 10ms.
+    ivoa:ucd: time.start
+    ivoa:unit: d
+  - name: obs_end
+    "@id": "#exposure.obs_end"
+    datatype: timestamp
+    precision: 6
+    description: End time of the exposure at the fiducial center of the focal plane.
+      array, TAI, accurate to 10ms.
+    ivoa:ucd: time.end
+  - name: obs_end_mjd
+    "@id": "#exposure.obs_end_mjd"
+    datatype: double
+    description: End of the exposure in MJD, TAI, accurate to 10ms.
+    ivoa:ucd: time.end
+    ivoa:unit: d
+  - name: exp_time
+    "@id": "#exposure.exp_time"
+    datatype: float
+    description: Spatially-averaged duration of exposure, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: shut_time
+    "@id": "#exposure.shut_time"
+    datatype: float
+    description: Spatially-averaged shutter-open duration, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: dark_time
+    "@id": "#exposure.dark_time"
+    datatype: float
+    description: Duration from last clear to readout, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: group_id
+    "@id": "#exposure.group_id"
+    datatype: string
+    length: 64
+    description: Identifier for the group that this exposure is part of.
+  - name: cur_index
+    "@id": "#exposure.cur_index"
+    datatype: int
+    description: Number (1-based) of the observation within its group.
+  - name: max_index
+    "@id": "#exposure.max_index"
+    datatype: int
+    description: Expected number of observations within the group.
+  - name: img_type
+    "@id": "#exposure.img_type"
+    datatype: string
+    length: 64
+    description: Type of exposure taken.
+  - name: emulated
+    "@id": "#exposure.emulated"
+    datatype: boolean
+    description: True if the exposure was taken in emulation mode.
+  - name: science_program
+    "@id": "#exposure.science_program"
+    datatype: string
+    length: 64
+    description: Science program.
+  - name: observation_reason
+    "@id": "#exposure.observation_reason"
+    datatype: string
+    length: 68
+    description: Reason for the observation.
+  - name: target_name
+    "@id": "#exposure.target_name"
+    datatype: string
+    length: 64
+    description: Target of the observation.
+  - name: air_temp
+    "@id": "#exposure.air_temp"
+    datatype: float
+    description: Outside air temperature in degC.
+    ivoa:ucd: phys.temperature
+  - name: pressure
+    "@id": "#exposure.pressure"
+    datatype: float
+    description: Outside air pressure.
+    ivoa:unit: Pa
+  - name: humidity
+    "@id": "#exposure.humidity"
+    datatype: float
+    description: Outside relative humidity.
+  - name: wind_speed
+    "@id": "#exposure.wind_speed"
+    datatype: float
+    description: Outside wind speed.
+    ivoa:unit: m/s
+  - name: wind_dir
+    "@id": "#exposure.wind_dir"
+    datatype: float
+    description: Wind direction.
+    ivoa:unit: deg
+  - name: dimm_seeing
+    "@id": "#exposure.dimm_seeing"
+    datatype: float
+    description: Seeing as measured by external DIMM (FWHM).
+    ivoa:unit: arcsec
+  - name: focus_z
+    "@id": "#exposure.focus_z"
+    datatype: float
+    description: Focus Z position.
+  - name: simulated
+    "@id": "#exposure.simulated"
+    datatype: boolean
+    description: Were any control system components simulated?
+  - name: vignette
+    "@id": "#exposure.vignette"
+    datatype: string
+    length: 10
+    description: "Instrument blocked from the sky: UNKNOWN, NO, PARTIALLY, FULLY."
+  - name: vignette_min
+    "@id": "#exposure.vignette_min"
+    datatype: string
+    length: 10
+    description: "Lowest amount of instrument vignetting detected during the exposure: UNKNOWN, NO, PARTIALLY, FULLY."
+  - name: s_region
+    "@id": "#exposure.s_region"
+    datatype: string
+    length: 1024
+    description: Sky region in STC-S format (https://www.ivoa.net/documents/STC-S/20130917/index.html).
+    ivoa:ucd: pos.outline;obs.field
+- name: exposure_flexdata
+  "@id": "#exposure_flexdata"
+  primaryKey:
+  - "#exposure_flexdata.day_obs"
+  - "#exposure_flexdata.seq_num"
+  - "#exposure_flexdata.key"
+  constraints:
+  - name: fk_exposure_flexdata_day_obs_seq_num
+    "@id": "#exposure_flexdata.fk_exposure_flexdata_day_obs_seq_num"
+    "@type": ForeignKey
+    description: Flex data day_obs must be an Exposure day_obs
+    columns: ["#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
+    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+  - name: fk_exposure_flexdata_obs_id
+    "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id"
+    "@type": ForeignKey
+    description: Flex data obs_id must be an Exposure exposure_id.
+    columns: ["#exposure_flexdata.obs_id"]
+    referencedColumns: ["#exposure.exposure_id"]
+  - name: fk_exposure_flexdata_key
+    "@id": "#exposure_flexdata.fk_exposure_flexdata_key"
+    "@type": ForeignKey
+    description: Flex data key must be listed in the schema.
+    columns: ["#exposure_flexdata.key"]
+    referencedColumns: ["#exposure_flexdata_schema.key"]
+  - name: un_exposure_flexdata_day_obs_seq_num_key
+    "@id": "#exposure_flexdata.un_exposure_flexdata_day_obs_seq_num_key"
+    "@type": Unique
+    description: Day obs + seq num + key must be unique.
+    columns:
+    - "#exposure_flexdata.day_obs"
+    - "#exposure_flexdata.seq_num"
+    - "#exposure_flexdata.key"
+  columns:
+  - name: obs_id
+    "@id": "#exposure_flexdata.obs_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: day_obs
+    "@id": "#exposure_flexdata.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#exposure_flexdata.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: key
+    "@id": "#exposure_flexdata.key"
+    datatype: string
+    length: 128
+    nullable: false
+    description: Name of key.
+  - name: value
+    "@id": "#exposure_flexdata.value"
+    datatype: text
+    description: Content of value as a string.
+- name: exposure_flexdata_schema
+  "@id": "#exposure_flexdata_schema"
+  primaryKey:
+  - "#exposure_flexdata_schema.key"
+  columns:
+  - name: key
+    "@id": "#exposure_flexdata_schema.key"
+    datatype: string
+    length: 128
+    nullable: false
+    description: Name of key.
+  - name: dtype
+    "@id": "#exposure_flexdata_schema.dtype"
+    datatype: string
+    length: 64
+    nullable: false
+    description: Name of the data type of the value, one of bool, int, float, str.
+  - name: doc
+    "@id": "#exposure_flexdata_schema.doc"
+    datatype: text
+    nullable: false
+    description: Documentation string.
+  - name: unit
+    "@id": "#exposure_flexdata_schema.unit"
+    datatype: string
+    length: 128
+    description: Unit for the value. Should be from the IVOA (https://www.ivoa.net/documents/VOUnits/) or astropy.
+  - name: ucd
+    "@id": "#exposure_flexdata_schema.ucd"
+    datatype: string
+    length: 128
+    description: IVOA Unified Content Descriptor (https://www.ivoa.net/documents/UCD1+/).
+- name: ccdexposure
+  "@id": "#ccdexposure"
+  primaryKey:
+  - "#ccdexposure.ccdexposure_id"
+  constraints:
+  - name: un_ccdexposure_ccdexposure_id
+    "@id": "#ccdexposure.un_ccdexposure_ccdexposure_id"
+    "@type": Unique
+    description: Ensure ccdexposure_id is unique.
+    columns:
+    - "#ccdexposure.ccdexposure_id"
+  - name: un_ccdexposure_day_obs_seq_num_detector
+    "@id": "#ccdexposure.un_ccdexposure_day_obs_seq_num_detector"
+    "@type": Unique
+    description: Ensure day_obs plus seq_num plus detector is unique.
+    columns:
+    - "#ccdexposure.day_obs"
+    - "#ccdexposure.seq_num"
+    - "#ccdexposure.detector"
+  - name: un_ccdexposure_exposure_id_detector
+    "@id": "#ccdexposure.un_ccdexposure_exposure_id_detector"
+    "@type": Unique
+    description: Ensure exposure_id plus detector is unique.
+    columns:
+    - "#ccdexposure.exposure_id"
+    - "#ccdexposure.detector"
+  - name: fk_ccdexposure_day_obs_seq_num
+    "@id": "#ccdexposure.fk_ccdexposure_day_obs_seq_num"
+    "@type": ForeignKey
+    description: day_obs must be in the Exposure table.
+    columns: ["#ccdexposure.day_obs", "#ccdexposure.seq_num"]
+    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+  - name: fk_ccdexposure_exposure_id
+    "@id": "#ccdexposure.fk_ccdexposure_exposure_id"
+    "@type": ForeignKey
+    description: exposure_id must be in the Exposure table.
+    columns: ["#ccdexposure.exposure_id"]
+    referencedColumns: ["#exposure.exposure_id"]
+  columns:
+  - name: ccdexposure_id
+    "@id": "#ccdexposure.ccdexposure_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+    ivoa:ucd: meta.id
+  - name: exposure_id
+    "@id": "#ccdexposure.exposure_id"
+    datatype: long
+    nullable: false
+    description: Identifier of the exposure.
+  - name: day_obs
+    "@id": "#ccdexposure.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#ccdexposure.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: detector
+    "@id": "#ccdexposure.detector"
+    datatype: int
+    nullable: false
+    description: Number of the detector in the focal plane.
+    ivoa:ucd: meta.id.part;instr.det
+  - name: s_region
+    "@id": "#ccdexposure.s_region"
+    datatype: string
+    length: 1024
+    description: Sky region in STC-S format (https://www.ivoa.net/documents/STC-S/20130917/index.html).
+    ivoa:ucd: pos.outline;obs.field
+- name: ccdexposure_camera
+  "@id": "#ccdexposure_camera"
+  primaryKey:
+  - "#ccdexposure_camera.ccdexposure_id"
+  constraints:
+  - name: fk_ccdexposure_camera_ccdexposure_id
+    "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id"
+    "@type": ForeignKey
+    description: exposure_id must be in the Exposure table.
+    columns: ["#ccdexposure_camera.ccdexposure_id"]
+    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+  columns:
+  - name: ccdexposure_id
+    "@id": "#ccdexposure_camera.ccdexposure_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: temp_set
+    "@id": "#ccdexposure_camera.ccd_temp_set"
+    datatype: float
+    description: Temperature setpoint of CCD in degC.
+  - name: ccd_temp
+    "@id": "#ccdexposure_camera.ccd_temp"
+    datatype: float
+    description: Temperature of CCD in degC.
+    ivoa:ucd: phys.temperature
+- name: ccdexposure_flexdata
+  "@id": "#ccdexposure_flexdata"
+  primaryKey:
+  - "#ccdexposure_flexdata.obs_id"
+  - "#ccdexposure_flexdata.key"
+  constraints:
+  - name: fk_ccdexposure_flexdata_obs_id
+    "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id"
+    "@type": ForeignKey
+    description: Flex data obs_id must be a CcdExposure ccdexposure_id.
+    columns: ["#ccdexposure_flexdata.obs_id"]
+    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+  - name: fk_ccdexposure_flexdata_key
+    "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_key"
+    "@type": ForeignKey
+    description: Flex data key must be listed in the schema.
+    columns: ["#ccdexposure_flexdata.key"]
+    referencedColumns: ["#ccdexposure_flexdata_schema.key"]
+  columns:
+  - name: obs_id
+    "@id": "#ccdexposure_flexdata.obs_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: key
+    "@id": "#ccdexposure_flexdata.key"
+    datatype: string
+    length: 128
+    nullable: false
+    description: Name of key.
+  - name: value
+    "@id": "#ccdexposure_flexdata.value"
+    datatype: text
+    description: Content of value as a string.
+- name: ccdexposure_flexdata_schema
+  "@id": "#ccdexposure_flexdata_schema"
+  primaryKey:
+  - "#ccdexposure_flexdata_schema.key"
+  columns:
+  - name: key
+    "@id": "#ccdexposure_flexdata_schema.key"
+    datatype: string
+    length: 128
+    nullable: false
+    description: Name of key.
+  - name: dtype
+    "@id": "#ccdexposure_flexdata_schema.dtype"
+    datatype: string
+    length: 64
+    nullable: false
+    description: Name of the data type of the value, one of bool, int, float, str.
+  - name: doc
+    "@id": "#ccdexposure_flexdata_schema.doc"
+    datatype: text
+    nullable: false
+    description: Documentation string.
+  - name: unit
+    "@id": "#ccdexposure_flexdata_schema.unit"
+    datatype: string
+    length: 128
+    description: Unit for the value. Should be from the IVOA (https://www.ivoa.net/documents/VOUnits/) or astropy.
+  - name: ucd
+    "@id": "#ccdexposure_flexdata_schema.ucd"
+    datatype: string
+    length: 128
+    description: IVOA Unified Content Descriptor (https://www.ivoa.net/documents/UCD1+/).
+- name: visit1
+  "@id": "#visit1"
+  primaryKey:
+  - "#visit1.day_obs"
+  - "#visit1.seq_num"
+  columns:
+  - name: visit_id
+    "@id": "#visit1.visit_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: exposure_name
+    "@id": "#visit1.exposure_name"
+    datatype: string
+    length: 20
+    nullable: false
+    description: Official name of the exposure mapped to this visit by the 1-to-1 visit system.
+  - name: controller
+    "@id": "#visit1.controller"
+    datatype: string
+    length: 1
+    nullable: false
+    description: The abbreviation of the controller used for the observation (O, C).
+  - name: day_obs
+    "@id": "#visit1.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#visit1.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: physical_filter
+    "@id": "#visit1.physical_filter"
+    datatype: string
+    length: 32
+    description: ID of physical filter, the filter associated with a particular instrument.
+  - name: band
+    "@id": "#visit1.band"
+    datatype: string
+    length: 32
+    description: Name of the band used to take the visit. Abstract filter that is not associated with a particular instrument.
+  - name: s_ra
+    "@id": "#visit1.s_ra"
+    datatype: double
+    description: Central Spatial Position in ICRS; Right ascension of targeted focal plane center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.ra
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
+    ivoa:unit: deg
+  - name: s_dec
+    "@id": "#visit1.s_dec"
+    datatype: double
+    description: Central Spatial Position in ICRS; Declination of targeted focal plane center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.dec
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
+    ivoa:unit: deg
+  - name: sky_rotation
+    "@id": "#visit1.sky_rotation"
+    datatype: double
+    description: Targeted sky rotation angle.
+    ivoa:ucd: pos.posAng
+    ivoa:unit: deg
+  - name: azimuth_start
+    "@id": "#visit1.azimuth_start"
+    datatype: float
+    description: Azimuth of focal plane center at the start of the visit.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: azimuth_end
+    "@id": "#visit1.azimuth_end"
+    datatype: float
+    description: Azimuth of focal plane center at the end of the visit.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: azimuth
+    "@id": "#visit1.azimuth"
+    datatype: float
+    description: Azimuth of focal plane center at the middle of the visit.
+    ivoa:ucd: pos.az.azi
+    ivoa:unit: deg
+  - name: altitude_start
+    "@id": "#visit1.altitude_start"
+    datatype: float
+    description: Altitude of focal plane center at the start of the visit.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: altitude_end
+    "@id": "#visit1.altitude_end"
+    datatype: float
+    description: Altitude of focal plane center at the end of the visit.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: altitude
+    "@id": "#visit1.altitude"
+    datatype: float
+    description: Altitude of focal plane center at the middle of the visit.
+    ivoa:ucd: pos.az.alt
+    ivoa:unit: deg
+  - name: zenith_distance_start
+    "@id": "#visit1.zenith_distance_start"
+    datatype: float
+    description: Zenith distance at the start of the visit.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: zenith_distance_end
+    "@id": "#visit1.zenith_distance_end"
+    datatype: float
+    description: Zenith distance at the end of the visit.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: zenith_distance
+    "@id": "#visit1.zenith_distance"
+    datatype: float
+    description: Zenith distance at the middle of the visit.
+    ivoa:ucd: pos.az.zd
+    ivoa:unit: deg
+  - name: airmass
+    "@id": "#visit1.airmass"
+    datatype: float
+    description: Airmass of the observed line of sight at the middle of the visit.
+    ivoa:ucd: obs.airMass
+  - name: exp_midpt
+    "@id": "#visit1.exp_midpt"
+    datatype: timestamp
+    precision: 6
+    description: Midpoint time for visit at the fiducial center of the focal plane.
+      array. TAI, accurate to 10ms.
+    ivoa:ucd: time.epoch
+  - name: exp_midpt_mjd
+    "@id": "#visit1.exp_midpt_mjd"
+    datatype: double
+    description: Midpoint time for visit at the fiducial center of the focal plane.
+      array in MJD. TAI, accurate to 10ms.
+    ivoa:ucd: time.epoch
+    ivoa:unit: d
+  - name: obs_start
+    "@id": "#visit1.obs_start"
+    datatype: timestamp
+    precision: 6
+    description: Start time of the visit at the fiducial center of the focal plane.
+      array, TAI, accurate to 10ms.
+    ivoa:ucd: time.start
+  - name: obs_start_mjd
+    "@id": "#visit1.obs_start_mjd"
+    datatype: double
+    description: Start of the visit in MJD, TAI, accurate to 10ms.
+    ivoa:ucd: time.start
+    ivoa:unit: d
+  - name: obs_end
+    "@id": "#visit1.obs_end"
+    datatype: timestamp
+    precision: 6
+    description: End time of the visit at the fiducial center of the focal plane.
+      array, TAI, accurate to 10ms.
+    ivoa:ucd: time.end
+  - name: obs_end_mjd
+    "@id": "#visit1.obs_end_mjd"
+    datatype: double
+    description: End of the visit in MJD, TAI, accurate to 10ms.
+    ivoa:ucd: time.end
+    ivoa:unit: d
+  - name: exp_time
+    "@id": "#visit1.exp_time"
+    datatype: float
+    description: Spatially-averaged duration of visit, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: shut_time
+    "@id": "#visit1.shut_time"
+    datatype: float
+    description: Spatially-averaged shutter-open duration, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: dark_time
+    "@id": "#visit1.dark_time"
+    datatype: float
+    description: Duration from last clear to readout, accurate to 10ms.
+    ivoa:ucd: time.interval
+    ivoa:unit: s
+  - name: group_id
+    "@id": "#visit1.group_id"
+    datatype: string
+    length: 64
+    description: Identifier for the group that this visit is part of.
+  - name: cur_index
+    "@id": "#visit1.cur_index"
+    datatype: int
+    description: Number (1-based) of the observation within its group.
+  - name: max_index
+    "@id": "#visit1.max_index"
+    datatype: int
+    description: Expected number of observations within the group.
+  - name: img_type
+    "@id": "#visit1.img_type"
+    datatype: string
+    length: 64
+    description: Type of visit taken.
+  - name: emulated
+    "@id": "#visit1.emulated"
+    datatype: boolean
+    description: True if the visit was taken in emulation mode.
+  - name: science_program
+    "@id": "#visit1.science_program"
+    datatype: string
+    length: 64
+    description: Science program.
+  - name: observation_reason
+    "@id": "#visit1.observation_reason"
+    datatype: string
+    length: 68
+    description: Reason for the observation.
+  - name: target_name
+    "@id": "#visit1.target_name"
+    datatype: string
+    length: 64
+    description: Target of the observation.
+  - name: air_temp
+    "@id": "#visit1.air_temp"
+    datatype: float
+    description: Outside air temperature in degC.
+    ivoa:ucd: phys.temperature
+  - name: pressure
+    "@id": "#visit1.pressure"
+    datatype: float
+    description: Outside air pressure.
+    ivoa:unit: Pa
+  - name: humidity
+    "@id": "#visit1.humidity"
+    datatype: float
+    description: Outside relative humidity.
+  - name: wind_speed
+    "@id": "#visit1.wind_speed"
+    datatype: float
+    description: Outside wind speed.
+    ivoa:unit: m/s
+  - name: wind_dir
+    "@id": "#visit1.wind_dir"
+    datatype: float
+    description: Wind direction.
+    ivoa:unit: deg
+  - name: dimm_seeing
+    "@id": "#visit1.dimm_seeing"
+    datatype: float
+    description: Seeing as measured by external DIMM (FWHM).
+    ivoa:unit: arcsec
+  - name: focus_z
+    "@id": "#visit1.focus_z"
+    datatype: float
+    description: Focus Z position.
+  - name: simulated
+    "@id": "#visit1.simulated"
+    datatype: boolean
+    description: Were any control system components simulated?
+  - name: vignette
+    "@id": "#visit1.vignette"
+    datatype: string
+    length: 10
+    description: "Instrument blocked from the sky: UNKNOWN, NO, PARTIALLY, FULLY."
+  - name: vignette_min
+    "@id": "#visit1.vignette_min"
+    datatype: string
+    length: 10
+    description: "Lowest amount of instrument vignetting detected during the visit: UNKNOWN, NO, PARTIALLY, FULLY."
+  - name: s_region
+    "@id": "#visit1.s_region"
+    datatype: string
+    length: 1024
+    description: Sky region in STC-S format (https://www.ivoa.net/documents/STC-S/20130917/index.html).
+    ivoa:ucd: pos.outline;obs.field
+- name: visit1_quicklook
+  "@id": "#visit1_quicklook"
+  primaryKey:
+  - "#visit1_quicklook.day_obs"
+  - "#visit1_quicklook.seq_num"
+  constraints:
+  - name: fk_visit1_quicklook_obs_id
+    "@id": "#visit1_quicklook.fk_visit1_quicklook_obs_id"
+    "@type": ForeignKey
+    description: Quicklook visit_id must be an Exposure exposure_id.
+    columns: ["#visit1_quicklook.visit_id"]
+    referencedColumns: ["#exposure.exposure_id"]
+  - name: fk_visit1_quicklook_day_obs_seq_num
+    "@id": "#visit1_quicklook.fk_visit1_quicklook_day_obs_seq_num"
+    "@type": ForeignKey
+    description: Quicklook day_obs must be an Exposure day_obs.
+    columns: ["#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
+    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+  columns:
+  - name: visit_id
+    "@id": "#visit1_quicklook.visit_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: day_obs
+    "@id": "#visit1_quicklook.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#visit1_quicklook.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: n_inputs
+    "@id": "#visit1_quicklook.n_inputs"
+    datatype: int
+    description: Number of CCDs used to compute the visit aggregates.
+    ivoa:unit: count
+  - name: pixel_scale_min
+    "@id": "#visit1_quicklook.pixel_scale_min"
+    datatype: float
+    description: Measured detector pixel scale (minimum across all detectors).
+    ivoa:unit: arcsec/pixel
+  - name: pixel_scale_max
+    "@id": "#visit1_quicklook.pixel_scale_max"
+    datatype: float
+    description: Measured detector pixel scale (maximum across all detectors).
+    ivoa:unit: arcsec/pixel
+  - name: pixel_scale_median
+    "@id": "#visit1_quicklook.pixel_scale_median"
+    datatype: float
+    description: Measured detector pixel scale (median across all detectors).
+    ivoa:unit: arcsec/pixel
+  - name: astrom_offset_mean_min
+    "@id": "#visit1_quicklook.astrom_offset_mean_min"
+    datatype: float
+    description: Mean offset of astrometric calibration matches (minimum across all detectors).
+    ivoa:unit: arcsec
+  - name: astrom_offset_mean_max
+    "@id": "#visit1_quicklook.astrom_offset_mean_max"
+    datatype: float
+    description: Mean offset of astrometric calibration matches (maximum across all detectors).
+    ivoa:unit: arcsec
+  - name: astrom_offset_mean_median
+    "@id": "#visit1_quicklook.astrom_offset_mean_median"
+    datatype: float
+    description: Mean offset of astrometric calibration matches (median across all detectors).
+    ivoa:unit: arcsec
+  - name: astrom_offset_std_min
+    "@id": "#visit1_quicklook.astrom_offset_std_min"
+    datatype: float
+    description: Standard deviation of offsets of astrometric calibration matches (minimum across all detectors).
+    ivoa:unit: arcsec
+  - name: astrom_offset_std_max
+    "@id": "#visit1_quicklook.astrom_offset_std_max"
+    datatype: float
+    description: Standard deviation of offsets of astrometric calibration matches (maximum across all detectors).
+    ivoa:unit: arcsec
+  - name: astrom_offset_std_median
+    "@id": "#visit1_quicklook.astrom_offset_std_median"
+    datatype: float
+    description: Standard deviation of offsets of astrometric calibration matches (median across all detectors).
+    ivoa:unit: arcsec
+  - name: eff_time_min
+    "@id": "#visit1_quicklook.eff_time_min"
+    datatype: float
+    description: Effective exposure time (minimum across all detectors).
+    ivoa:unit: s
+  - name: eff_time_max
+    "@id": "#visit1_quicklook.eff_time_max"
+    datatype: float
+    description: Effective exposure time (maximum across all detectors).
+    ivoa:unit: s
+  - name: eff_time_median
+    "@id": "#visit1_quicklook.eff_time_median"
+    datatype: float
+    description: Effective exposure time (median across all detectors).
+    ivoa:unit: s
+  - name: eff_time_psf_sigma_scale_min
+    "@id": "#visit1_quicklook.eff_time_psf_sigma_scale_min"
+    datatype: float
+    description: Scale factor for effective exposure time based on PSF sigma (minimum across all detectors).
+  - name: eff_time_psf_sigma_scale_max
+    "@id": "#visit1_quicklook.eff_time_psf_sigma_scale_max"
+    datatype: float
+    description: Scale factor for effective exposure time based on PSF sigma (maximum across all detectors).
+  - name: eff_time_psf_sigma_scale_median
+    "@id": "#visit1_quicklook.eff_time_psf_sigma_scale_median"
+    datatype: float
+    description: Scale factor for effective exposure time based on PSF sigma (median across all detectors).
+  - name: eff_time_sky_bg_scale_min
+    "@id": "#visit1_quicklook.eff_time_sky_bg_scale_min"
+    datatype: float
+    description: Scale factor for effective exposure time based on sky background (minimum across all detectors).
+  - name: eff_time_sky_bg_scale_max
+    "@id": "#visit1_quicklook.eff_time_sky_bg_scale_max"
+    datatype: float
+    description: Scale factor for effective exposure time based on sky background (maximum across all detectors).
+  - name: eff_time_sky_bg_scale_median
+    "@id": "#visit1_quicklook.eff_time_sky_bg_scale_median"
+    datatype: float
+    description: Scale factor for effective exposure time based on sky background (median across all detectors).
+  - name: eff_time_zero_point_scale_min
+    "@id": "#visit1_quicklook.eff_time_zero_point_scale_min"
+    datatype: float
+    description: Scale factor for effective exposure time based on zero point (minimum across all detectors).
+  - name: eff_time_zero_point_scale_max
+    "@id": "#visit1_quicklook.eff_time_zero_point_scale_max"
+    datatype: float
+    description: Scale factor for effective exposure time based on zero point (maximum across all detectors).
+  - name: eff_time_zero_point_scale_median
+    "@id": "#visit1_quicklook.eff_time_zero_point_scale_median"
+    datatype: float
+    description: Scale factor for effective exposure time based on zero point (median across all detectors).
+  - name: stats_mag_lim_min
+    "@id": "#visit1_quicklook.stats_mag_lim_min"
+    datatype: float
+    description: Magnitude limit at fixed SNR (default SNR=5) calculated from exposure summary stats (minimum across all detectors).
+    ivoa:unit: mag
+  - name: stats_mag_lim_max
+    "@id": "#visit1_quicklook.stats_mag_lim_max"
+    datatype: float
+    description: Magnitude limit at fixed SNR (default SNR=5) calculated from exposure summary stats (maximum across all detectors).
+    ivoa:unit: mag
+  - name: stats_mag_lim_median
+    "@id": "#visit1_quicklook.stats_mag_lim_median"
+    datatype: float
+    description: Magnitude limit at fixed SNR (default SNR=5) calculated from exposure summary stats (median across all detectors).
+    ivoa:unit: mag
+  - name: psf_ap_flux_delta_min
+    "@id": "#visit1_quicklook.psf_ap_flux_delta_min"
+    datatype: float
+    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels (minimum across all detectors).
+  - name: psf_ap_flux_delta_max
+    "@id": "#visit1_quicklook.psf_ap_flux_delta_max"
+    datatype: float
+    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels (maximum across all detectors).
+  - name: psf_ap_flux_delta_median
+    "@id": "#visit1_quicklook.psf_ap_flux_delta_median"
+    datatype: float
+    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels (median across all detectors).
+  - name: psf_ap_corr_sigma_scaled_delta_min
+    "@id": "#visit1_quicklook.psf_ap_corr_sigma_scaled_delta_min"
+    datatype: float
+    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels (minimum across all detectors).
+  - name: psf_ap_corr_sigma_scaled_delta_max
+    "@id": "#visit1_quicklook.psf_ap_corr_sigma_scaled_delta_max"
+    datatype: float
+    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels (maximum across all detectors).
+  - name: psf_ap_corr_sigma_scaled_delta_median
+    "@id": "#visit1_quicklook.psf_ap_corr_sigma_scaled_delta_median"
+    datatype: float
+    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels (median across all detectors).
+  - name: max_dist_to_nearest_psf_min
+    "@id": "#visit1_quicklook.max_dist_to_nearest_psf_min"
+    datatype: float
+    description: Maximum distance of an unmasked pixel to its nearest model PSF star (minimum across all detectors).
+    ivoa:unit: pixel
+  - name: max_dist_to_nearest_psf_max
+    "@id": "#visit1_quicklook.max_dist_to_nearest_psf_max"
+    datatype: float
+    description: Maximum distance of an unmasked pixel to its nearest model PSF star (maximum across all detectors).
+    ivoa:unit: pixel
+  - name: max_dist_to_nearest_psf_median
+    "@id": "#visit1_quicklook.max_dist_to_nearest_psf_median"
+    datatype: float
+    description: Maximum distance of an unmasked pixel to its nearest model PSF star (median across all detectors).
+    ivoa:unit: pixel
+  - name: mean_var_min
+    "@id": "#visit1_quicklook.mean_var_min"
+    datatype: float
+    description: Mean of the variance plane (minimum across all detectors).
+    ivoa:unit: count**2
+    ivoa:ucd: phot;phys.electron
+  - name: mean_var_max
+    "@id": "#visit1_quicklook.mean_var_max"
+    datatype: float
+    description: Mean of the variance plane (maximum across all detectors).
+    ivoa:unit: count**2
+    ivoa:ucd: phot;phys.electron
+  - name: mean_var_median
+    "@id": "#visit1_quicklook.mean_var_median"
+    datatype: float
+    description: Mean of the variance plane (median across all detectors).
+    ivoa:unit: count**2
+    ivoa:ucd: phot;phys.electron
+  - name: n_psf_star_min
+    "@id": "#visit1_quicklook.n_psf_star_min"
+    datatype: int
+    description: Number of stars used for PSF model (minimum across all detectors).
+    ivoa:unit: count
+  - name: n_psf_star_max
+    "@id": "#visit1_quicklook.n_psf_star_max"
+    datatype: int
+    description: Number of stars used for PSF model (maximum across all detectors).
+    ivoa:unit: count
+  - name: n_psf_star_median
+    "@id": "#visit1_quicklook.n_psf_star_median"
+    datatype: int
+    description: Number of stars used for PSF model (median across all detectors).
+    ivoa:unit: count
+  - name: n_psf_star_total
+    "@id": "#visit1_quicklook.n_psf_star_total"
+    datatype: int
+    description: Number of stars used for PSF model (total across all detectors).
+    ivoa:unit: count
+  - name: psf_area_min
+    "@id": "#visit1_quicklook.psf_area_min"
+    datatype: float
+    description: PSF area (minimum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_area_max
+    "@id": "#visit1_quicklook.psf_area_max"
+    datatype: float
+    description: PSF area (maximum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_area_median
+    "@id": "#visit1_quicklook.psf_area_median"
+    datatype: float
+    description: PSF area (median across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixx_min
+    "@id": "#visit1_quicklook.psf_ixx_min"
+    datatype: float
+    description: PSF Ixx moment (minimum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixx_max
+    "@id": "#visit1_quicklook.psf_ixx_max"
+    datatype: float
+    description: PSF Ixx moment (maximum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixx_median
+    "@id": "#visit1_quicklook.psf_ixx_median"
+    datatype: float
+    description: PSF Ixx moment (median across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixy_min
+    "@id": "#visit1_quicklook.psf_ixy_min"
+    datatype: float
+    description: PSF Ixy moment (minimum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixy_max
+    "@id": "#visit1_quicklook.psf_ixy_max"
+    datatype: float
+    description: PSF Ixy moment (maximum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_ixy_median
+    "@id": "#visit1_quicklook.psf_ixy_median"
+    datatype: float
+    description: PSF Ixy moment (median across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_iyy_min
+    "@id": "#visit1_quicklook.psf_iyy_min"
+    datatype: float
+    description: PSF Iyy moment (minimum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_iyy_max
+    "@id": "#visit1_quicklook.psf_iyy_max"
+    datatype: float
+    description: PSF Iyy moment (maximum across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_iyy_median
+    "@id": "#visit1_quicklook.psf_iyy_median"
+    datatype: float
+    description: PSF Iyy moment (median across all detectors).
+    ivoa:unit: pixel**2
+  - name: psf_sigma_min
+    "@id": "#visit1_quicklook.psf_sigma_min"
+    datatype: float
+    description: PSF sigma (minimum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_sigma_max
+    "@id": "#visit1_quicklook.psf_sigma_max"
+    datatype: float
+    description: PSF sigma (maximum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_sigma_median
+    "@id": "#visit1_quicklook.psf_sigma_median"
+    datatype: float
+    description: PSF sigma (median across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_e1_median_min
+    "@id": "#visit1_quicklook.psf_star_delta_e1_median_min"
+    datatype: float
+    description: Median E1 residual (starE1 - psfE1) for PSF stars (minimum across all detectors).
+  - name: psf_star_delta_e1_median_max
+    "@id": "#visit1_quicklook.psf_star_delta_e1_median_max"
+    datatype: float
+    description: Median E1 residual (starE1 - psfE1) for PSF stars (maximum across all detectors).
+  - name: psf_star_delta_e1_median_median
+    "@id": "#visit1_quicklook.psf_star_delta_e1_median_median"
+    datatype: float
+    description: Median E1 residual (starE1 - psfE1) for PSF stars (median across all detectors).
+  - name: psf_star_delta_e1_scatter_min
+    "@id": "#visit1_quicklook.psf_star_delta_e1_scatter_min"
+    datatype: float
+    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for PSF stars (minimum across all detectors).
+  - name: psf_star_delta_e1_scatter_max
+    "@id": "#visit1_quicklook.psf_star_delta_e1_scatter_max"
+    datatype: float
+    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for PSF stars (maximum across all detectors).
+  - name: psf_star_delta_e1_scatter_median
+    "@id": "#visit1_quicklook.psf_star_delta_e1_scatter_median"
+    datatype: float
+    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for PSF stars (median across all detectors).
+  - name: psf_star_delta_e2_median_min
+    "@id": "#visit1_quicklook.psf_star_delta_e2_median_min"
+    datatype: float
+    description: Median E2 residual (starE2 - psfE2) for PSF stars (minimum across all detectors).
+  - name: psf_star_delta_e2_median_max
+    "@id": "#visit1_quicklook.psf_star_delta_e2_median_max"
+    datatype: float
+    description: Median E2 residual (starE2 - psfE2) for PSF stars (maximum across all detectors).
+  - name: psf_star_delta_e2_median_median
+    "@id": "#visit1_quicklook.psf_star_delta_e2_median_median"
+    datatype: float
+    description: Median E2 residual (starE2 - psfE2) for PSF stars (median across all detectors).
+  - name: psf_star_delta_e2_scatter_min
+    "@id": "#visit1_quicklook.psf_star_delta_e2_scatter_min"
+    datatype: float
+    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for PSF stars (minimum across all detectors).
+  - name: psf_star_delta_e2_scatter_max
+    "@id": "#visit1_quicklook.psf_star_delta_e2_scatter_max"
+    datatype: float
+    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for PSF stars (maximum across all detectors).
+  - name: psf_star_delta_e2_scatter_median
+    "@id": "#visit1_quicklook.psf_star_delta_e2_scatter_median"
+    datatype: float
+    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for PSF stars (median across all detectors).
+  - name: psf_star_delta_size_median_min
+    "@id": "#visit1_quicklook.psf_star_delta_size_median_min"
+    datatype: float
+    description: Median size residual (starSize - psfSize) for PSF stars (minimum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_median_max
+    "@id": "#visit1_quicklook.psf_star_delta_size_median_max"
+    datatype: float
+    description: Median size residual (starSize - psfSize) for PSF stars (maximum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_median_median
+    "@id": "#visit1_quicklook.psf_star_delta_size_median_median"
+    datatype: float
+    description: Median size residual (starSize - psfSize) for PSF stars (median across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_scatter_min
+    "@id": "#visit1_quicklook.psf_star_delta_size_scatter_min"
+    datatype: float
+    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars (minimum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_scatter_max
+    "@id": "#visit1_quicklook.psf_star_delta_size_scatter_max"
+    datatype: float
+    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars (maximum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_scatter_median
+    "@id": "#visit1_quicklook.psf_star_delta_size_scatter_median"
+    datatype: float
+    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars (median across all detectors).
+    ivoa:unit: pixel
+  - name: psf_star_scaled_delta_size_scatter_min
+    "@id": "#visit1_quicklook.psf_star_scaled_delta_size_scatter_min"
+    datatype: float
+    description: Scatter (via MAD) of size residual scaled by median size squared (minimum across all detectors).
+  - name: psf_star_scaled_delta_size_scatter_max
+    "@id": "#visit1_quicklook.psf_star_scaled_delta_size_scatter_max"
+    datatype: float
+    description: Scatter (via MAD) of size residual scaled by median size squared (maximum across all detectors).
+  - name: psf_star_scaled_delta_size_scatter_median
+    "@id": "#visit1_quicklook.psf_star_scaled_delta_size_scatter_median"
+    datatype: float
+    description: Scatter (via MAD) of size residual scaled by median size squared (median across all detectors).
+  - name: psf_trace_radius_delta_min
+    "@id": "#visit1_quicklook.psf_trace_radius_delta_min"
+    datatype: float
+    description: Delta (max - min) of model PSF trace radius values evaluated on a grid of unmasked pixels (minimum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_trace_radius_delta_max
+    "@id": "#visit1_quicklook.psf_trace_radius_delta_max"
+    datatype: float
+    description: Delta (max - min) of model PSF trace radius values evaluated on a grid of unmasked pixels (maximum across all detectors).
+    ivoa:unit: pixel
+  - name: psf_trace_radius_delta_median
+    "@id": "#visit1_quicklook.psf_trace_radius_delta_median"
+    datatype: float
+    description: Delta (max - min) of model PSF trace radius values evaluated on a grid of unmasked pixels (median across all detectors).
+    ivoa:unit: pixel
+  - name: sky_bg_min
+    "@id": "#visit1_quicklook.sky_bg_min"
+    datatype: float
+    description: Average sky background (minimum across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: sky_bg_max
+    "@id": "#visit1_quicklook.sky_bg_max"
+    datatype: float
+    description: Average sky background (maximum across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: sky_bg_median
+    "@id": "#visit1_quicklook.sky_bg_median"
+    datatype: float
+    description: Average sky background (median across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: sky_noise_min
+    "@id": "#visit1_quicklook.sky_noise_min"
+    datatype: float
+    description: RMS noise of the sky background (minimum across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: sky_noise_max
+    "@id": "#visit1_quicklook.sky_noise_max"
+    datatype: float
+    description: RMS noise of the sky background (maximum across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: sky_noise_median
+    "@id": "#visit1_quicklook.sky_noise_median"
+    datatype: float
+    description: RMS noise of the sky background (median across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: seeing_zenith_500nm_min
+    "@id": "#visit1_quicklook.seeing_zenith_500nm_min"
+    datatype: double
+    description: Measured PSF sigma, corrected to 500nm and an airmass of 1 (minimum across all detectors).
+  - name: seeing_zenith_500nm_max
+    "@id": "#visit1_quicklook.seeing_zenith_500nm_max"
+    datatype: double
+    description: Measured PSF sigma, corrected to 500nm and an airmass of 1 (maximum across all detectors).
+  - name: seeing_zenith_500nm_median
+    "@id": "#visit1_quicklook.seeing_zenith_500nm_median"
+    datatype: double
+    description: Measured PSF sigma, corrected to 500nm and an airmass of 1 (median across all detectors).
+  - name: zero_point_min
+    "@id": "#visit1_quicklook.zero_point_min"
+    datatype: float
+    description: Photometric zero point (minimum across all detectors).
+    ivoa:unit: mag
+  - name: zero_point_max
+    "@id": "#visit1_quicklook.zero_point_max"
+    datatype: float
+    description: Photometric zero point (maximum across all detectors).
+    ivoa:unit: mag
+  - name: zero_point_median
+    "@id": "#visit1_quicklook.zero_point_median"
+    datatype: float
+    description: Photometric zero point (median across all detectors).
+    ivoa:unit: mag
+  - name: low_snr_source_count_min
+    "@id": "#visit1_quicklook.low_snr_source_count_min"
+    datatype: int
+    description: Count of low signal-to-noise-ratio sources (minimum across all detectors).
+    ivoa:unit: count
+  - name: low_snr_source_count_max
+    "@id": "#visit1_quicklook.low_snr_source_count_max"
+    datatype: int
+    description: Count of low signal-to-noise-ratio sources (maximum across all detectors).
+    ivoa:unit: count
+  - name: low_snr_source_count_median
+    "@id": "#visit1_quicklook.low_snr_source_count_median"
+    datatype: int
+    description: Count of low signal-to-noise-ratio sources (median across all detectors).
+    ivoa:unit: count
+  - name: low_snr_source_count_total
+    "@id": "#visit1_quicklook.low_snr_source_count_total"
+    datatype: int
+    description: Count of low signal-to-noise-ratio sources (total across all detectors).
+    ivoa:unit: count
+  - name: high_snr_source_count_min
+    "@id": "#visit1_quicklook.high_snr_source_count_min"
+    datatype: int
+    description: Count of high signal-to-noise-ratio sources (minimum across all detectors).
+    ivoa:unit: count
+  - name: high_snr_source_count_max
+    "@id": "#visit1_quicklook.high_snr_source_count_max"
+    datatype: int
+    description: Count of high signal-to-noise-ratio sources (maximum across all detectors).
+    ivoa:unit: count
+  - name: high_snr_source_count_median
+    "@id": "#visit1_quicklook.high_snr_source_count_median"
+    datatype: int
+    description: Count of high signal-to-noise-ratio sources (median across all detectors).
+    ivoa:unit: count
+  - name: high_snr_source_count_total
+    "@id": "#visit1_quicklook.high_snr_source_count_total"
+    datatype: int
+    description: Count of high signal-to-noise-ratio sources (total across all detectors).
+    ivoa:unit: count
+- name: exposure_quicklook
+  "@id": "#exposure_quicklook"
+  primaryKey:
+  - "#exposure_quicklook.day_obs"
+  - "#exposure_quicklook.seq_num"
+  constraints:
+  - name: fk_exposure_quicklook_day_obs_seq_num
+    "@id": "#exposure_quicklook.fk_exposure_quicklook_day_obs_seq_num"
+    "@type": ForeignKey
+    description: Quicklook day_obs must be an Exposure day_obs.
+    columns: ["#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
+    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+  - name: fk_exposure_quicklook_obs_id
+    "@id": "#exposure_quicklook.fk_exposure_quicklook_obs_id"
+    "@type": ForeignKey
+    description: Quicklook exposure_id must be an Exposure id.
+    columns: ["#exposure_quicklook.exposure_id"]
+    referencedColumns: ["#exposure.exposure_id"]
+  columns:
+  - name: exposure_id
+    "@id": "#exposure_quicklook.exposure_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: day_obs
+    "@id": "#exposure_quicklook.day_obs"
+    datatype: int
+    nullable: false
+    description: Day of observation.
+    ivoa:ucd: meta.id.part
+  - name: seq_num
+    "@id": "#exposure_quicklook.seq_num"
+    datatype: int
+    nullable: false
+    description: Sequence number.
+    ivoa:ucd: meta.id.part
+  - name: postisr_pixel_median_median
+    "@id": "#exposure_quicklook.postisr_pixel_median_median"
+    datatype: float
+    description: Median postISR pixel value (median across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: postisr_pixel_median_mean
+    "@id": "#exposure_quicklook.postisr_pixel_median_mean"
+    datatype: float
+    description: Median postISR pixel value (mean across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: postisr_pixel_median_max
+    "@id": "#exposure_quicklook.postisr_pixel_median_max"
+    datatype: float
+    description: Median postISR pixel value (max across all detectors).
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron
+  - name: mount_motion_image_degradation
+    "@id": "#exposure_quicklook.mount_motion_image_degradation"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Image degradation due to mount motion.
+  - name: mount_motion_image_degradation_az
+    "@id": "#exposure_quicklook.mount_motion_image_degradation_az"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Image degradation due to mount motion in azimuth.
+  - name: mount_motion_image_degradation_rot
+    "@id": "#exposure_quicklook.mount_motion_image_degradation_rotator"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Image degradation due to rotator jitter.
+  - name: mount_jitter_rms
+    "@id": "#exposure_quicklook.mount_jitter_rms"
+    datatype: float
+    ivoa:unit: arcsec
+    description: RMS mount jitter.
+  - name: mount_jitter_rms_az
+    "@id": "#exposure_quicklook.mount_jitter_rms_az"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Azimuth RMS mount jitter.
+  - name: mount_jitter_rms_el
+    "@id": "#exposure_quicklook.mount_jitter_rms_el"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Elevation RMS mount jitter.
+  - name: mount_jitter_rms_rot
+    "@id": "#exposure_quicklook.mount_jitter_rms_rotator"
+    datatype: float
+    ivoa:unit: arcsec
+    description: Rotator RMS mount jitter.
+- name: ccdvisit1
+  "@id": "#ccdvisit1"
+  primaryKey:
+  - "#ccdvisit1.ccdvisit_id"
+  columns:
+  - name: ccdvisit_id
+    "@id": "#ccdvisit1.ccdvisit_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+    ivoa:ucd: meta.id
+  - name: visit_id
+    "@id": "#ccdvisit1.visit_id"
+    datatype: long
+    nullable: false
+    description: Identifier of the visit.
+    ivoa:ucd: meta.id.part
+  - name: detector
+    "@id": "#ccdvisit1.detector"
+    datatype: int
+    nullable: false
+    description: Number of the detector in the focal plane.
+    ivoa:ucd: meta.id.part;instr.det
+  - name: s_region
+    "@id": "#ccdvisit1.s_region"
+    datatype: string
+    length: 1024
+    description: Sky region in STC-S format (https://www.ivoa.net/documents/STC-S/20130917/index.html).
+    ivoa:ucd: pos.outline;obs.field
+- name: ccdvisit1_quicklook
+  "@id": "#ccdvisit1_quicklook"
+  primaryKey:
+  - "#ccdvisit1_quicklook.ccdvisit_id"
+  constraints:
+  - name: fk_ccdvisit1_quicklook_obs_id
+    "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_obs_id"
+    "@type": ForeignKey
+    description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.
+    columns: ["#ccdvisit1_quicklook.ccdvisit_id"]
+    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+  columns:
+  - name: ccdvisit_id
+    "@id": "#ccdvisit1_quicklook.ccdvisit_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: s_ra
+    "@id": "#ccdvisit1_quicklook.s_ra"
+    datatype: double
+    description: Central Spatial Position in ICRS; Computed right ascension of CCD center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.ra
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
+    ivoa:unit: deg
+  - name: s_dec
+    "@id": "#ccdvisit1_quicklook.s_dec"
+    datatype: double
+    description: Central Spatial Position in ICRS; Computed declination of CCD center.
+    tap:std: 1
+    ivoa:ucd: pos.eq.dec
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
+    ivoa:unit: deg
+  - name: zenith_distance
+    "@id": "#ccdvisit1_quicklook.zenith_distance"
+    datatype: float
+    description: Zenith distance at observation mid-point.
+  - name: photometric_calib
+    "@id": "#ccdvisit1_quicklook.photometric_calib"
+    datatype: float
+    description: Conversion from DN to nanojansky.
+    ivoa:unit: nJy/count
+  - name: psf_sigma
+    "@id": "#ccdvisit1_quicklook.psf_sigma"
+    datatype: float
+    description: PSF model second-moments determinant radius (center of chip).
+  - name: sky_bg
+    "@id": "#ccdvisit1_quicklook.sky_bg"
+    datatype: float
+    description: Average sky background.
+  - name: sky_noise
+    "@id": "#ccdvisit1_quicklook.sky_noise"
+    datatype: float
+    description: RMS noise of the sky background.
+  - name: zero_point
+    "@id": "#ccdvisit1_quicklook.zero_point"
+    datatype: float
+    description: Photometric zero point.
+  - name: seeing_zenith_500nm
+    "@id": "#ccdvisit1_quicklook.seeing_zenith_500nm"
+    datatype: double
+    description: Measured PSF sigma, corrected to 500nm and an airmass of 1.
+  - name: pixel_scale
+    "@id": "#ccdvisit1_quicklook.pixel_scale"
+    datatype: float
+    description: Measured detector pixel scale.
+    ivoa:unit: arcsec/pixel
+  - name: astrom_offset_mean
+    "@id": "#ccdvisit1_quicklook.astrom_offset_mean"
+    datatype: float
+    description: Mean offset of astrometric calibration matches.
+    ivoa:unit: arcsec
+  - name: astrom_offset_std
+    "@id": "#ccdvisit1_quicklook.astrom_offset_std"
+    datatype: float
+    description: Standard deviation of offsets of astrometric calibration matches.
+    ivoa:unit: arcsec
+  - name: eff_time
+    "@id": "#ccdvisit1_quicklook.eff_time"
+    datatype: float
+    description: Effective exposure time calculated from PSF sigma, sky background, and zero point.
+    ivoa:unit: s
+  - name: eff_time_psf_sigma_scale
+    "@id": "#ccdvisit1_quicklook.eff_time_psf_sigma_scale"
+    datatype: float
+    description: Scale factor for effective exposure time based on PSF sigma.
+  - name: eff_time_sky_bg_scale
+    "@id": "#ccdvisit1_quicklook.eff_time_sky_bg_scale"
+    datatype: float
+    description: Scale factor for effective exposure time based on sky background.
+  - name: eff_time_zero_point_scale
+    "@id": "#ccdvisit1_quicklook.eff_time_zero_point_scale"
+    datatype: float
+    description: Scale factor for effective exposure time based on zero point.
+  - name: stats_mag_lim
+    "@id": "#ccdvisit1_quicklook.stats_mag_lim"
+    datatype: float
+    description: Magnitude limit at fixed SNR (default SNR=5) calculated from exposure summary stats.
+    ivoa:unit: mag
+  - name: mean_var
+    "@id": "#ccdvisit1_quicklook.mean_var"
+    datatype: float
+    description: Mean of the variance plane.
+  - name: n_psf_star
+    "@id": "#ccdvisit1_quicklook.n_psf_star"
+    datatype: int
+    description: Number of stars used for PSF model.
+    ivoa:unit: count
+  - name: psf_area
+    "@id": "#ccdvisit1_quicklook.psf_area"
+    datatype: float
+    description: PSF area.
+  - name: psf_ixx
+    "@id": "#ccdvisit1_quicklook.psf_ixx"
+    datatype: float
+    description: PSF Ixx moment.
+  - name: psf_ixy
+    "@id": "#ccdvisit1_quicklook.psf_ixy"
+    datatype: float
+    description: PSF Ixy moment.
+  - name: psf_iyy
+    "@id": "#ccdvisit1_quicklook.psf_iyy"
+    datatype: float
+    description: PSF Iyy moment.
+  - name: psf_star_delta_e1_median
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_e1_median"
+    datatype: float
+    description: Median E1 residual (starE1 - psfE1) for PSF stars.
+  - name: psf_star_delta_e2_median
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_e2_median"
+    datatype: float
+    description: Median E2 residual (starE2 - psfE2) for PSF stars.
+  - name: psf_star_delta_e1_scatter
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_e1_scatter"
+    datatype: float
+    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for PSF stars.
+  - name: psf_star_delta_e2_scatter
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_e2_scatter"
+    datatype: float
+    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for PSF stars.
+  - name: psf_star_delta_size_median
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_size_median"
+    datatype: float
+    description: Median size residual (starSize - psfSize) for PSF stars.
+    ivoa:unit: pixel
+  - name: psf_star_delta_size_scatter
+    "@id": "#ccdvisit1_quicklook.psf_star_delta_size_scatter"
+    datatype: float
+    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars.
+    ivoa:unit: pixel
+  - name: psf_star_scaled_delta_size_scatter
+    "@id": "#ccdvisit1_quicklook.psf_star_scaled_delta_size_scatter"
+    datatype: float
+    description: Scatter (via MAD) of size residual scaled by median size squared.
+  - name: psf_trace_radius_delta
+    "@id": "#ccdvisit1_quicklook.psf_trace_radius_delta"
+    datatype: float
+    description: Delta (max - min) of model PSF trace radius values evaluated on a grid of unmasked pixels.
+    ivoa:unit: pixel
+  - name: psf_ap_flux_delta
+    "@id": "#ccdvisit1_quicklook.psf_ap_flux_delta"
+    datatype: float
+    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels.
+  - name: psf_ap_corr_sigma_scaled_delta
+    "@id": "#ccdvisit1_quicklook.psf_ap_corr_sigma_scaled_delta"
+    datatype: float
+    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels.
+  - name: max_dist_to_nearest_psf
+    "@id": "#ccdvisit1_quicklook.max_dist_to_nearest_psf"
+    datatype: float
+    description: Maximum distance of an unmasked pixel to its nearest model PSF star.
+    ivoa:unit: pixel
+- name: ccdexposure_quicklook
+  "@id": "#ccdexposure_quicklook"
+  primaryKey:
+  - "#ccdexposure_quicklook.ccdexposure_id"
+  constraints:
+  - name: fk_ccdexposure_quicklook_obs_id
+    "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_obs_id"
+    "@type": ForeignKey
+    description: Quicklook ccdexposure_id must be a CcdExposure ccdexposure_id.
+    columns: ["#ccdexposure_quicklook.ccdexposure_id"]
+    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+  columns:
+  - name: ccdexposure_id
+    "@id": "#ccdexposure_quicklook.ccdexposure_id"
+    datatype: long
+    nullable: false
+    description: Unique identifier.
+  - name: postisr_pixel_median
+    "@id": "#ccdexposure_quicklook.postisr_pixel_median"
+    datatype: float
+    description: Median postISR pixel value.
+    ivoa:unit: count
+    ivoa:ucd: phot;phys.electron


### PR DESCRIPTION
This PR adds a schema for LSSTCam in the consolidated database. The schema is a direct copy of LSSTComCam for now, but divergence should be expected down the road.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [X] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [X] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
