### PR TITLE
Fix compare workflow

### DIFF
--- a/.github/workflows/compare.yaml
+++ b/.github/workflows/compare.yaml
@@ -54,6 +54,29 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base-ref
 
+      - name: Filter list of changed files
+        if: env.SCHEMA_FILES_CHANGED == 'true'
+        run: |
+          if [ -n "$CHANGED_FILES" ]; then
+            for file in $CHANGED_FILES; do
+              if [ ! -f "base-ref/${{ env.SCHEMA_DIR }}/$file" ]; then
+                echo "File $file not found in base ref, removing from list of changed files."
+                CHANGED_FILES=$(echo "$CHANGED_FILES" | sed "s|$file||")
+              fi
+              if [ ! -f "current-ref/${{ env.SCHEMA_DIR }}/$file" ]; then
+                echo "File $file not found in current ref, removing from list of changed files."
+                CHANGED_FILES=$(echo "$CHANGED_FILES" | sed "s|$file||")
+              fi
+            done
+            CHANGED_FILES=$(echo "$CHANGED_FILES" | tr -s ' ' | sed 's/^ //')
+            echo "Changed YAML files: $CHANGED_FILES"
+            echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+          fi
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No schema files changes were detected after filtering."
+            echo "SCHEMA_FILES_CHANGED=false" >> $GITHUB_ENV
+          fi
+
       - name: Run deepdiff comparison
         if: env.SCHEMA_FILES_CHANGED == 'true'
         run: |


### PR DESCRIPTION
This PR updates the `compare` workflow to make sure that the old and new versions of the schema exist before running the `diff` commands.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
