### PR TITLE
DM-43728: Build usdf-prod-cdb image

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -21,3 +21,4 @@
 ./build usdf-dev-sso ../yml/dp03_10yr.yaml ../yml/dp03_1yr.yaml
 
 FELIS_UNIQUE_KEYS=1 ./build usdf-dev-cdb ../yml/cdb_*.yaml
+FELIS_UNIQUE_KEYS=1 ./build usdf-prod-cdb ../yml/cdb_*.yaml


### PR DESCRIPTION
This PR adds a `usdf-prod-cdb` image for ConsDB, intended for use on `usdf-rsp` and `usdf-rsp-int`.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
