### PR TITLE
Added api_created column to the tap_schema tables table and changed id to column_id for columns table

### DIFF
--- a/docs/changes/DM-50252.sci.md
+++ b/docs/changes/DM-50252.sci.md
@@ -1,0 +1,1 @@
+Change id to column_id in tap_schema columns and Add api_created column to the tap_schema tables table

--- a/tap-schema/sql/0000_tap_schema11.sql
+++ b/tap-schema/sql/0000_tap_schema11.sql
@@ -63,6 +63,9 @@ create table tap_schema.tables11
         read_only_group  varchar(128),
         read_write_group varchar(128),
 
+-- extension: flag to indicate if a schema was created using a Tap service API
+        api_created     integer,
+
 	primary key (table_name),
 	foreign key (schema_name) references tap_schema.schemas11 (schema_name)
 )
@@ -109,7 +112,7 @@ create table tap_schema.columns11
 -- TAP-1.1 column_index
 	column_index   integer,
 -- extension: globally unique columnID for use as an XML ID attribute on the FIELD in VOTable output
-        id            varchar(32),
+        column_id            varchar(32),
 
 	primary key (table_name,column_name),
 	foreign key (table_name) references tap_schema.tables11 (table_name)


### PR DESCRIPTION
## Summary

Note: This reapplies previous changes that were reverted from https://github.com/lsst/sdm_schemas/pull/326

Upstream CADC repo for the TAP service has renamed the field id in table columns of TAP_SCHEMA to column_id

https://github.com/opencadc/tap/commit/5cc177da7e9b00e4a2a46d74e77312911551e92c

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [x] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [x] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated

Note: This may require some coordination since it's a backwards incompatible change (TAP needs updated version to match field name)
