### PR TITLE
DM-50914: Use '--force-unbound-arraysize' flag when generating TAP_SCHEMA SQL output

### DIFF
--- a/tap-schema/build
+++ b/tap-schema/build
@@ -38,6 +38,7 @@ do
         --engine-url=mysql:// \
         --tap-schema-name=tap_schema \
         --tap-tables-postfix=11 \
+        --force-unbounded-arraysize \
         --output-file sql/`basename $file`.sql \
         $unique_flag \
         $file


### PR DESCRIPTION
Merge after https://github.com/lsst/felis/pull/144

Dependence on Felis development branch also needs to be dropped from `requirements.txt`.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
