### PR TITLE
DM-51549: Add obs_title to `ivoa.ObsCore`

### DIFF
--- a/docs/changes/DM-51549.dr.md
+++ b/docs/changes/DM-51549.dr.md
@@ -1,0 +1,1 @@
+Added obs_title to DP1 ObsCore

--- a/python/lsst/sdm/schemas/ivoa_obscore.yaml
+++ b/python/lsst/sdm/schemas/ivoa_obscore.yaml
@@ -26,6 +26,16 @@ tables:
     tap:column_index: 20
     tap:principal: 1
     tap:std: 1
+  - name: obs_title
+    description: Brief description of dataset in free format
+    ivoa:ucd: meta.title;obs
+    votable:utype: DataID.title
+    tap:std: 1
+    tap:principal: 1
+    tap:column_index: 225
+    ivoa:unit:
+    datatype: string
+    length: 256
   - name: facility_name
     description: The name of the facility, telescope, or space craft used for the
       observation
@@ -77,7 +87,7 @@ tables:
     description: ID for the Dataset given by the publisher
     votable:utype: Curation.publisherDID
     datatype: string
-    length: 256
+    length: 128
     nullable: false
     ivoa:ucd: meta.ref.ivoid
     tap:column_index: 260


### PR DESCRIPTION
Follows recent dax_obscore change that removed the need for the static addition of the obs_title column that was done in DP0.2

Also corrects length of `obs_publisher_did` to match Qserv column

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
