### PR TITLE
DM-51557: Fix display of ivoa_obscore description on index page

### DIFF
--- a/browser/ivoa_obscore.md
+++ b/browser/ivoa_obscore.md
@@ -4,4 +4,7 @@ title: ObsTAP (image metadata, DP1+)
 schema: ivoa_obscore
 sort-index: 1
 ---
-{{ site.data[page.schema].description }}
+<!--{{ site.data[page.schema].description }}-->
+<p>
+ObsCore v1.1 attributes in ObsTAP realization
+</p>


### PR DESCRIPTION
For some mysterious reason, the description is not being inserted correctly, so this uses the schema description text verbatim for now.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
