### PR TITLE
DM-51552: Add "visit+detector" foreign key relationships to DP1 schema

### DIFF
--- a/docs/changes/DM-51552.dr.md
+++ b/docs/changes/DM-51552.dr.md
@@ -1,0 +1,1 @@
+Added "visit+detector" composite key relationships to DP1 schema

--- a/python/lsst/sdm/schemas/dp1.yaml
+++ b/python/lsst/sdm/schemas/dp1.yaml
@@ -3,7 +3,7 @@ description: "Data Preview 1 contains image and catalog products from the
   Rubin Science Pipelines v29 processing of observations obtained with the
   LSST Commissioning Camera of seven ~1 square degree fields,
   over seven weeks in late 2024."
-version: 1.1.1
+version: 1.1.2
 tables:
 - name: Object
   description: "Descriptions of static astronomical objects (or the static aspects

--- a/python/lsst/sdm/schemas/dp1.yaml
+++ b/python/lsst/sdm/schemas/dp1.yaml
@@ -6638,6 +6638,60 @@ tables:
     referencedColumns:
     - '#CcdVisit.visitId'
     - '#CcdVisit.detector'
+- name: CoaddPatches
+  description: "Static information about the subset of tracts and patches from the standard
+    LSST skymap that apply to coadds in these catalogs"
+  tap:table_index: 70
+  columns:
+  - name: lsst_tract
+    description: "ID number of the top level, 'tract', within the standard LSST skymap"
+    nullable: false
+    ivoa:ucd: meta.id;obs.field
+    tap:std: 0
+    tap:principal: 1
+    ivoa:unit:
+    datatype: long
+    tap:column_index: 1
+  - name: lsst_patch
+    description: "ID number of the second level, 'patch', within the standard LSST skymap"
+    nullable: false
+    ivoa:ucd: meta.id.part;obs.field
+    tap:std: 0
+    tap:principal: 1
+    ivoa:unit:
+    datatype: long
+    tap:column_index: 2
+  - name: s_ra
+    description: "Central Spatial Position in ICRS; Right ascension"
+    nullable: false
+    ivoa:ucd: pos.eq.ra
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
+    tap:std: 1
+    tap:principal: 1
+    ivoa:unit: deg
+    datatype: double
+    tap:column_index: 3
+  - name: s_dec
+    description: "Central Spatial Position in ICRS; Declination"
+    nullable: false
+    ivoa:ucd: pos.eq.dec
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
+    tap:std: 1
+    tap:principal: 1
+    ivoa:unit: deg
+    datatype: double
+    tap:column_index: 4
+  - name: s_region
+    description: "Sky region covered by the coadd (expressed in ICRS frame)"
+    nullable: false
+    ivoa:ucd: pos.outline;obs.field
+    votable:utype: Char.SpatialAxis.Coverage.Support.Area
+    tap:std: 1
+    tap:principal: 1
+    ivoa:unit:
+    datatype: string
+    length: 512
+    tap:column_index: 5
 - name: Visit
   description: "Metadata about the pointings of the telescope,
     largely associated with the boresight of the LSSTComCam focal plane as a whole."
@@ -6943,6 +6997,12 @@ tables:
     - '#CcdVisit.visitId'
     referencedColumns:
     - '#Visit.visit'
+  - name: UNIQ_VisitDetector
+    description: Unique constraint on Visit and Detector.
+    '@type': Unique
+    columns:
+    - '#CcdVisit.visitId'
+    - '#CcdVisit.detector'
 - name: SSObject
   description: LSST-computed per-object quantities. 1:1 relationship with MPCORB.
   tap:table_index: 110

--- a/python/lsst/sdm/schemas/dp1.yaml
+++ b/python/lsst/sdm/schemas/dp1.yaml
@@ -5410,6 +5410,15 @@ tables:
     - '#Source.visit'
     referencedColumns:
     - '#Visit.visit'
+  - name: FK_Source_CcdVisit
+    '@type': ForeignKey
+    description: Link Source to its associated CcdVisit.
+    columns:
+    - '#Source.visit'
+    - '#Source.detector'
+    referencedColumns:
+    - '#CcdVisit.visitId'
+    - '#CcdVisit.detector'
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit images and
     difference images, based on and linked to the entries in the Object table. Point-source
@@ -5531,12 +5540,21 @@ tables:
     referencedColumns:
     - '#Object.objectId'
   - name: FK_ForcedSource_Visit
-    description: Link a ForcedSource to its associated visit
+    description: Link a ForcedSource to its associated visit.
     '@type': ForeignKey
     columns:
     - '#ForcedSource.visit'
     referencedColumns:
     - '#Visit.visit'
+  - name: FK_ForcedSource_CcdVisit
+    description: Link a ForcedSource to its associated CcdVisit.
+    '@type': ForeignKey
+    columns:
+    - '#ForcedSource.visit'
+    - '#ForcedSource.detector'
+    referencedColumns:
+    - '#CcdVisit.visitId'
+    - '#CcdVisit.detector'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -5900,6 +5918,15 @@ tables:
     - '#DiaSource.ssObjectId'
     referencedColumns:
     - '#SSObject.ssObjectId'
+  - name: FK_DiaSource_CcdVisit
+    description: Link a Diasource to its associated CcdVisit.
+    '@type': ForeignKey
+    columns:
+    - '#DiaSource.visit'
+    - '#DiaSource.detector'
+    referencedColumns:
+    - '#CcdVisit.visitId'
+    - '#CcdVisit.detector'
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -6602,60 +6629,15 @@ tables:
     - '#ForcedSourceOnDiaObject.visit'
     referencedColumns:
     - '#Visit.visit'
-- name: CoaddPatches
-  description: "Static information about the subset of tracts and patches from the standard
-    LSST skymap that apply to coadds in these catalogs"
-  tap:table_index: 70
-  columns:
-  - name: lsst_tract
-    description: "ID number of the top level, 'tract', within the standard LSST skymap"
-    nullable: false
-    ivoa:ucd: meta.id;obs.field
-    tap:std: 0
-    tap:principal: 1
-    ivoa:unit:
-    datatype: long
-    tap:column_index: 1
-  - name: lsst_patch
-    description: "ID number of the second level, 'patch', within the standard LSST skymap"
-    nullable: false
-    ivoa:ucd: meta.id.part;obs.field
-    tap:std: 0
-    tap:principal: 1
-    ivoa:unit:
-    datatype: long
-    tap:column_index: 2
-  - name: s_ra
-    description: "Central Spatial Position in ICRS; Right ascension"
-    nullable: false
-    ivoa:ucd: pos.eq.ra
-    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit: deg
-    datatype: double
-    tap:column_index: 3
-  - name: s_dec
-    description: "Central Spatial Position in ICRS; Declination"
-    nullable: false
-    ivoa:ucd: pos.eq.dec
-    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit: deg
-    datatype: double
-    tap:column_index: 4
-  - name: s_region
-    description: "Sky region covered by the coadd (expressed in ICRS frame)"
-    nullable: false
-    ivoa:ucd: pos.outline;obs.field
-    votable:utype: Char.SpatialAxis.Coverage.Support.Area
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit:
-    datatype: string
-    length: 512
-    tap:column_index: 5
+  - name: FK_ForcedSourceOnDiaObject_CcdVisit
+    description: Link a ForcedSourceOnDiaObject to its associated CcdVisit.
+    '@type': ForeignKey
+    columns:
+    - '#ForcedSourceOnDiaObject.visit'
+    - '#ForcedSourceOnDiaObject.detector'
+    referencedColumns:
+    - '#CcdVisit.visitId'
+    - '#CcdVisit.detector'
 - name: Visit
   description: "Metadata about the pointings of the telescope,
     largely associated with the boresight of the LSSTComCam focal plane as a whole."


### PR DESCRIPTION
~~This is branched off of #364 so should be merged after that PR.~~

- [x] Merge this first: https://github.com/lsst/felis/pull/152
- [x] The change to `requirements.txt` for using the Felis branch needs to be reverted before merging this PR.

I did not change the schema version yet.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [x] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [x] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins (unnecessary)
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
