### PR TITLE
DM-51511 (patch): Rotate schema_index order to put DP1 first

### DIFF
--- a/tap-schema/build-all
+++ b/tap-schema/build-all
@@ -5,9 +5,9 @@
 #
 ./build mock
 
-./build idfprod-tap ../yml/dp02_dc2.yaml ../yml/dp1.yaml ../yml/ivoa_obscore.yaml
-./build idfint-tap ../yml/dp1.yaml ../yml/dp02_dc2.yaml ../yml/ivoa_obscore.yaml
-./build idfdev-tap ../yml/dp1.yaml ../yml/dp02_dc2.yaml ../yml/ivoa_obscore.yaml
+./build idfprod-tap ../yml/dp1.yaml ../yml/ivoa_obscore.yaml ../yml/dp02_dc2.yaml
+./build idfint-tap ../yml/dp1.yaml ../yml/ivoa_obscore.yaml ../yml/dp02_dc2.yaml
+./build idfdev-tap ../yml/dp1.yaml ../yml/ivoa_obscore.yaml ../yml/dp02_dc2.yaml
 ./build usdf-prod-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
 ./build usdf-dev-tap ../yml/dp02_dc2.yaml ../yml/dp02_obscore.yaml
 


### PR DESCRIPTION
Full order on all IDF Qserv-TAP instances is now DP1, ivoa, DP0.2

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
