### PR TITLE
Validate the schemas before generating the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "  build - Build the schema browser site"
 	@echo "  run   - Serve the schema browser site"
 	@echo "  clean - Clean the schema browser site"
+	@echo "  check - Validate the schema files using Felis"
 
 # Install required Ruby gems (Ruby must be installed externally.)
 init:
@@ -21,8 +22,16 @@ init:
 run:
 	jekyll serve --watch
 
+# Validate the schema files using Felis
+check:
+	@command -v felis >/dev/null 2>&1 || { \
+		echo >&2 "felis command not found. Please install 'pip install lsst-felis'."; \
+		exit 1; \
+	}
+	@command felis validate yml/*.yaml
+
 # Build the site
-build:
+build: check
 	jekyll build
 
 # Cleanup local config and remove the generated site


### PR DESCRIPTION
Update the `Makefile` to validate the schemas before generating the site (doesn't effect CI where validation runs as a separate job).

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
