### PR TITLE
DM-53837: Replace column definitions in DRP schemas with references to a base schema

### DIFF
--- a/docs/changes/DM-53837.sci.md
+++ b/docs/changes/DM-53837.sci.md
@@ -1,0 +1,1 @@
+Added `drp_base.yaml` and convert `imsim.yaml`, `hsc.yaml`, and `lsstcam.yaml` to reference its column definitions.

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -1,0 +1,8401 @@
+name: drp_base
+description: Base schema for defining Data Release Processing column definitions.
+version: 0.1.0
+tables:
+- name: Object
+  description: Descriptions of static astronomical objects (or the static aspects
+    of variable and slowly-moving objects) detected and measured on coadds.
+  columns:
+  - name: coord_dec
+    description: Fiducial ICRS Declination of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: coord_decErr
+    description: Error in fiducial ICRS Declination of centroid
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: coord_flag
+    description: General Failure Flag. Reference band.
+    datatype: boolean
+  - name: coord_ra
+    description: Fiducial ICRS Right Ascension of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: coord_raErr
+    description: Error in fiducial ICRS Right Ascension of centroid
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: coord_ra_dec_Cov
+    description: Covariance between fiducial ICRS Right Ascension and Declination
+      of centroid
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec;meta.main
+    ivoa:unit: deg**2
+  - name: deblend_blendId
+    description: Unique ID of the deconvolved parent source that this source was deblended
+      from.
+    datatype: long
+  - name: deblend_blendNChild
+    description: Number of children in the deconvolved parent source that this source
+      was deblended from.
+    datatype: int
+  - name: deblend_chi2
+    description: Chi^2 of the source after deblending.
+    datatype: float
+  - name: deblend_parentNChild
+    description: Number of children in deblended from the parent footprint.
+    datatype: int
+    tap:principal: 1
+  - name: deblend_parentNPeaks
+    description: Number of peaks the parent footprint has (even if the deblender failed
+      or skipped this blend)
+    datatype: int
+  - name: deblend_peak_center_x
+    description: x-coordinate of the peak after source detection
+    datatype: int
+    ivoa:unit: pixel
+  - name: deblend_peak_center_y
+    description: y-coordinate of the peak after source detection
+    datatype: int
+    ivoa:unit: pixel
+  - name: detect_fromBlend
+    description: This source is deblended from a parent with more than one child.
+    datatype: boolean
+    tap:principal: 1
+  - name: detect_isDeblendedModelSource
+    description: True if source has no children and is in the inner region of a coadd
+      patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter
+      (see config.pseudoFilterList) and is a deblended child
+    datatype: boolean
+  - name: detect_isIsolated
+    description: This source is not a part of a blend.
+    datatype: boolean
+    tap:principal: 1
+  - name: ebv
+    description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
+    datatype: float
+    ivoa:unit: mag
+  - name: exponential_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the multiband exponential model.
+    datatype: float
+  - name: exponential_dec
+    description: Centroid (declination) from the multiband exponential model fit.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: exponential_decErr
+    description: Error on the centroid (declination) from the multiband exponential
+      model fit.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: exponential_delta_lnL_fit_linear
+    description: The ln-likelihood of the best model non-linear fit parameters minus
+      the ln-likelihood of a subsequent linear least squares fit.
+    datatype: float
+  - name: exponential_delta_lnL_fit_ps
+    description: The ln-likelihood of the best-fit exponential model minus the ln-likelihood
+      of a point source with the same centroid and PSF model.
+    datatype: float
+  - name: exponential_n_eval_jac
+    description: Number of Jacobian evaluations for the multiband exponential model
+      fit.
+    datatype: int
+  - name: exponential_n_iter
+    description: Number of iterations in the non-linear fit for the multiband exponential
+      model.
+    datatype: int
+  - name: exponential_no_data_flag
+    description: Flag set when there is insufficient data to fit for the multiband
+      exponential model.
+    datatype: boolean
+  - name: exponential_ra
+    description: Centroid (right ascension) from the multiband exponential model fit.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: exponential_raErr
+    description: Error on the centroid (right ascension) from the multiband exponential
+      model fit.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: exponential_ra_dec_Cov
+    description: Covariance between right ascension and declination from the multiband
+      exponential model fit.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: exponential_reff_major
+    description: Effective radius (major axis) from the multiband Sersic model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: arcsec
+  - name: exponential_reff_minor
+    description: Effective radius (minor axis) from the multiband Sersic model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: arcsec
+  - name: exponential_reff_x
+    description: Effective radius (x-axis) from the multiband exponential model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: pixel
+  - name: exponential_reff_xErr
+    description: Error on the effective radius (x-axis) from the multiband exponential
+      model fit.
+    datatype: float
+    ivoa:unit: pixel
+  - name: exponential_reff_y
+    description: Effective radius (y-axis) from the multiband exponential model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: pixel
+  - name: exponential_reff_yErr
+    description: Error on the effective radius (y-axis) from the multiband exponential
+      model fit.
+    datatype: float
+    ivoa:unit: pixel
+  - name: exponential_rho
+    description: Ellipse rho (correlation coefficient) from the multiband exponential
+      model fit.
+    datatype: float
+  - name: exponential_rhoErr
+    description: Error on ellipse rho (correlation coefficient) from the multiband
+      exponential model fit.
+    datatype: float
+  - name: exponential_theta
+    description: Position angle of the multiband Sersic fit ellipse.
+    datatype: float
+  - name: exponential_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      multiband exponential model.
+    datatype: boolean
+  - name: footprintArea
+    description: Number of pixels in the sources detection footprint. Reference band.
+    datatype: int
+    ivoa:unit: pixel
+  - name: g_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_apFlux_flag
+    description: Duplicate of g_ap12Flux_flag.
+    datatype: boolean
+  - name: g_apFlux_flag_apertureTruncated
+    description: Duplicate of g_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: g_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of g_ap12Flux_flag_sincCoeffsTruncated. Measured on g-band.
+    datatype: boolean
+  - name: g_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
+    datatype: float
+  - name: g_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      g-band.
+    datatype: boolean
+  - name: g_cModelFlux
+    description: Flux from the final CModel fit. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModelMag
+    description: AB magnitude of cModelFlux. Forced on g-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: g_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on g-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: g_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on g-band.
+    datatype: float
+  - name: g_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on g-band.
+    datatype: float
+  - name: g_cModel_expFlux
+    description: Flux from the exponential fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on g-band.
+    datatype: float
+  - name: g_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      g-band.
+    datatype: boolean
+  - name: g_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on g-band.
+    datatype: float
+  - name: g_calib_astrometry_used
+    description: Propagated from sources. Measured on g-band.
+    datatype: boolean
+  - name: g_calib_photometry_used
+    description: Propagated from sources. Measured on g-band.
+    datatype: boolean
+  - name: g_calib_psf_candidate
+    description: Propagated from sources. Measured on g-band.
+    datatype: boolean
+  - name: g_calib_psf_reserved
+    description: Propagated from sources. Measured on g-band.
+    datatype: boolean
+  - name: g_calib_psf_used
+    description: Propagated from sources. Measured on g-band.
+    datatype: boolean
+  - name: g_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on g-band.
+    datatype: boolean
+  - name: g_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: g_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the g-band.
+    datatype: float
+  - name: g_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: g_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: g_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: g_dec
+    description: Position in declination, measured on g-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: g_decErr
+    description: Error in declination, measured on g-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: g_epoch
+    description: Mean epoch of the object in the g-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: g_exponentialFlux
+    description: g-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_exponentialFluxErr
+    description: Error on the g-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on g-band.
+    datatype: float
+  - name: g_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on g-band.
+    datatype: float
+  - name: g_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on g-band.
+    datatype: boolean
+  - name: g_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on g-band.
+    datatype: boolean
+  - name: g_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on g-band.
+    datatype: float
+  - name: g_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on g-band.
+    datatype: float
+  - name: g_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on g-band.
+    datatype: float
+  - name: g_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on g-band.
+    datatype: boolean
+  - name: g_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on g-band.
+    datatype: float
+  - name: g_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on g-band.
+    datatype: boolean
+  - name: g_i_flag
+    description: General failure flag, set if anything went wrong. Measured on g-band.
+    datatype: boolean
+  - name: g_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on g-band.
+    datatype: int
+  - name: g_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on g-band.
+    datatype: boolean
+  - name: g_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on g-band.
+    datatype: boolean
+  - name: g_ixx
+    description: Gaussian-weighted adaptive moments. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_ixy
+    description: Gaussian-weighted adaptive moments. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_iyy
+    description: Gaussian-weighted adaptive moments. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on g-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: g_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on g-band.
+    datatype: boolean
+  - name: g_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on g-band.
+    datatype: float
+  - name: g_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
+    datatype: float
+  - name: g_moments_flag
+    description: Failure flag for moments (g-band)
+    datatype: boolean
+  - name: g_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (g-band)
+    datatype: float
+  - name: g_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (g-band)
+    datatype: float
+  - name: g_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (g-band)
+    datatype: boolean
+  - name: g_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (g-band)
+    datatype: float
+  - name: g_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (g-band)
+    datatype: float
+  - name: g_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (g-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_moments_psf_flag
+    description: Failure flag for PSF moments (g-band)
+    datatype: boolean
+  - name: g_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (g-band)
+    datatype: float
+  - name: g_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (g-band)
+    datatype: float
+  - name: g_moments_psf_trace
+    description: Moments-based trace radius of the PSF (g-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_moments_trace
+    description: Moments-based trace radius (g-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: g_pixelFlags_bad
+    description: Deprecated; only set when there is no g-band data.
+    datatype: boolean
+  - name: g_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_edge
+    description: Deprecated; only set when there is no g-band data.
+    datatype: boolean
+  - name: g_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_offimage
+    description: Deprecated; only set when there is no g-band data.
+    datatype: boolean
+  - name: g_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on g-band.
+    datatype: boolean
+  - name: g_pixelFlags_suspect
+    description: Deprecated; only set when there is no g-band data.
+    datatype: boolean
+  - name: g_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no g-band data.
+    datatype: boolean
+  - name: g_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on g-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_psfFlux_area
+    description: Effective area of PSF. Forced on g-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: g_psfFlux_flag
+    description: General Failure Flag. Forced on g-band.
+    datatype: boolean
+  - name: g_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on g-band.
+    datatype: boolean
+  - name: g_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on g-band.
+    datatype: boolean
+  - name: g_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on g-band.
+    datatype: boolean
+  - name: g_psfMag
+    description: AB magnitude of the g-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: g_psfMagErr
+    description: Uncertainty in magnitudes of the g-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: g_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (g-band).
+    datatype: float
+  - name: g_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (g-band).
+    datatype: float
+  - name: g_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (g-band).
+    datatype: float
+  - name: g_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (g-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: g_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (g-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: g_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (g-band).
+    datatype: float
+  - name: g_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (g-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: g_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (g-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: g_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (g-band).
+    datatype: int
+  - name: g_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (g-band).
+    datatype: boolean
+  - name: g_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (g-band).
+    datatype: boolean
+  - name: g_ra
+    description: Position in right ascension, measured on g-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: g_raErr
+    description: Error in right ascension, measured on g-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: g_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on g-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: g_sersicFlux
+    description: g-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_sersicFluxErr
+    description: Error on the g-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on g-band.
+    datatype: float
+  - name: g_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on g-band.
+    datatype: boolean
+  - name: griz_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
+    datatype: float
+  - name: i_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_apFlux_flag
+    description: Duplicate of i_ap12Flux_flag.
+    datatype: boolean
+  - name: i_apFlux_flag_apertureTruncated
+    description: Duplicate of i_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: i_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of i_ap12Flux_flag_sincCoeffsTruncated. Measured on i-band.
+    datatype: boolean
+  - name: i_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
+    datatype: float
+  - name: i_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      i-band.
+    datatype: boolean
+  - name: i_cModelFlux
+    description: Flux from the final CModel fit. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModelMag
+    description: AB magnitude of cModelFlux. Forced on i-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: i_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on i-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: i_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on i-band.
+    datatype: float
+  - name: i_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on i-band.
+    datatype: float
+  - name: i_cModel_expFlux
+    description: Flux from the exponential fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on i-band.
+    datatype: float
+  - name: i_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      i-band.
+    datatype: boolean
+  - name: i_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on i-band.
+    datatype: float
+  - name: i_calib_astrometry_used
+    description: Propagated from sources. Measured on i-band.
+    datatype: boolean
+  - name: i_calib_photometry_used
+    description: Propagated from sources. Measured on i-band.
+    datatype: boolean
+  - name: i_calib_psf_candidate
+    description: Propagated from sources. Measured on i-band.
+    datatype: boolean
+  - name: i_calib_psf_reserved
+    description: Propagated from sources. Measured on i-band.
+    datatype: boolean
+  - name: i_calib_psf_used
+    description: Propagated from sources. Measured on i-band.
+    datatype: boolean
+  - name: i_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on i-band.
+    datatype: boolean
+  - name: i_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: i_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the i-band.
+    datatype: float
+  - name: i_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: i_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: i_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: i_dec
+    description: Position in declination, measured on i-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: i_decErr
+    description: Error in declination, measured on i-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: i_epoch
+    description: Mean epoch of the object in the i-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: i_exponentialFlux
+    description: i-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_exponentialFluxErr
+    description: Error on the i-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on i-band.
+    datatype: float
+  - name: i_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on i-band.
+    datatype: float
+  - name: i_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on i-band.
+    datatype: boolean
+  - name: i_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on i-band.
+    datatype: boolean
+  - name: i_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on i-band.
+    datatype: float
+  - name: i_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on i-band.
+    datatype: float
+  - name: i_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on i-band.
+    datatype: float
+  - name: i_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on i-band.
+    datatype: boolean
+  - name: i_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on i-band.
+    datatype: float
+  - name: i_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on i-band.
+    datatype: boolean
+  - name: i_i_flag
+    description: General failure flag, set if anything went wrong. Measured on i-band.
+    datatype: boolean
+  - name: i_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on i-band.
+    datatype: int
+  - name: i_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on i-band.
+    datatype: boolean
+  - name: i_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on i-band.
+    datatype: boolean
+  - name: i_ixx
+    description: Gaussian-weighted adaptive moments. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_ixy
+    description: Gaussian-weighted adaptive moments. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_iyy
+    description: Gaussian-weighted adaptive moments. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on i-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: i_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on i-band.
+    datatype: boolean
+  - name: i_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on i-band.
+    datatype: float
+  - name: i_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
+    datatype: float
+  - name: i_moments_flag
+    description: Failure flag for moments (i-band)
+    datatype: boolean
+  - name: i_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (i-band)
+    datatype: float
+  - name: i_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (i-band)
+    datatype: float
+  - name: i_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (i-band)
+    datatype: boolean
+  - name: i_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (i-band)
+    datatype: float
+  - name: i_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (i-band)
+    datatype: float
+  - name: i_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (i-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_moments_psf_flag
+    description: Failure flag for PSF moments (i-band)
+    datatype: boolean
+  - name: i_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (i-band)
+    datatype: float
+  - name: i_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (i-band)
+    datatype: float
+  - name: i_moments_psf_trace
+    description: Moments-based trace radius of the PSF (i-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_moments_trace
+    description: Moments-based trace radius (i-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: i_pixelFlags_bad
+    description: Deprecated; only set when there is no i-band data.
+    datatype: boolean
+  - name: i_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_edge
+    description: Deprecated; only set when there is no i-band data.
+    datatype: boolean
+  - name: i_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_offimage
+    description: Deprecated; only set when there is no i-band data.
+    datatype: boolean
+  - name: i_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on i-band.
+    datatype: boolean
+  - name: i_pixelFlags_suspect
+    description: Deprecated; only set when there is no i-band data.
+    datatype: boolean
+  - name: i_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no i-band data.
+    datatype: boolean
+  - name: i_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on i-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_psfFlux_area
+    description: Effective area of PSF. Forced on i-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: i_psfFlux_flag
+    description: General Failure Flag. Forced on i-band.
+    datatype: boolean
+  - name: i_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on i-band.
+    datatype: boolean
+  - name: i_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on i-band.
+    datatype: boolean
+  - name: i_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on i-band.
+    datatype: boolean
+  - name: i_psfMag
+    description: AB magnitude of the i-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: i_psfMagErr
+    description: Uncertainty in magnitudes of the i-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: i_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (i-band).
+    datatype: float
+  - name: i_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (i-band).
+    datatype: float
+  - name: i_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (i-band).
+    datatype: float
+  - name: i_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (i-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: i_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (i-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: i_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (i-band).
+    datatype: float
+  - name: i_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (i-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: i_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (i-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: i_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (i-band).
+    datatype: int
+  - name: i_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (i-band).
+    datatype: boolean
+  - name: i_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (i-band).
+    datatype: boolean
+  - name: i_ra
+    description: Position in right ascension, measured on i-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: i_raErr
+    description: Error in right ascension, measured on i-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: i_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on i-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: i_sersicFlux
+    description: i-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_sersicFluxErr
+    description: Error on the i-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on i-band.
+    datatype: float
+  - name: i_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on i-band.
+    datatype: boolean
+  - name: objectId
+    description: Unique id. Unique ObjectID
+    datatype: long
+    ivoa:ucd: meta.id;src
+    tap:principal: 1
+  - name: parentObjectId
+    description: Unique ID of parent source. Reference band.
+    datatype: long
+    tap:principal: 1
+  - name: patch
+    description: Skymap patch ID
+    datatype: long
+    tap:principal: 1
+  - name: r_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_apFlux_flag
+    description: Duplicate of r_ap12Flux_flag.
+    datatype: boolean
+  - name: r_apFlux_flag_apertureTruncated
+    description: Duplicate of r_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: r_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of r_ap12Flux_flag_sincCoeffsTruncated. Measured on r-band.
+    datatype: boolean
+  - name: r_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
+    datatype: float
+  - name: r_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      r-band.
+    datatype: boolean
+  - name: r_cModelFlux
+    description: Flux from the final CModel fit. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModelMag
+    description: AB magnitude of cModelFlux. Forced on r-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: r_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on r-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: r_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on r-band.
+    datatype: float
+  - name: r_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on r-band.
+    datatype: float
+  - name: r_cModel_expFlux
+    description: Flux from the exponential fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on r-band.
+    datatype: float
+  - name: r_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      r-band.
+    datatype: boolean
+  - name: r_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on r-band.
+    datatype: float
+  - name: r_calib_astrometry_used
+    description: Propagated from sources. Measured on r-band.
+    datatype: boolean
+  - name: r_calib_photometry_used
+    description: Propagated from sources. Measured on r-band.
+    datatype: boolean
+  - name: r_calib_psf_candidate
+    description: Propagated from sources. Measured on r-band.
+    datatype: boolean
+  - name: r_calib_psf_reserved
+    description: Propagated from sources. Measured on r-band.
+    datatype: boolean
+  - name: r_calib_psf_used
+    description: Propagated from sources. Measured on r-band.
+    datatype: boolean
+  - name: r_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on r-band.
+    datatype: boolean
+  - name: r_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: r_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the r-band.
+    datatype: float
+  - name: r_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: r_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: r_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: r_dec
+    description: Position in declination, measured on r-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: r_decErr
+    description: Error in declination, measured on r-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: r_epoch
+    description: Mean epoch of the object in the r-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: r_exponentialFlux
+    description: r-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_exponentialFluxErr
+    description: Error on the r-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on r-band.
+    datatype: float
+  - name: r_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on r-band.
+    datatype: float
+  - name: r_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on r-band.
+    datatype: boolean
+  - name: r_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on r-band.
+    datatype: boolean
+  - name: r_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on r-band.
+    datatype: float
+  - name: r_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on r-band.
+    datatype: float
+  - name: r_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on r-band.
+    datatype: float
+  - name: r_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on r-band.
+    datatype: boolean
+  - name: r_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on r-band.
+    datatype: float
+  - name: r_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on r-band.
+    datatype: boolean
+  - name: r_i_flag
+    description: General failure flag, set if anything went wrong. Measured on r-band.
+    datatype: boolean
+  - name: r_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on r-band.
+    datatype: int
+  - name: r_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on r-band.
+    datatype: boolean
+  - name: r_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on r-band.
+    datatype: boolean
+  - name: r_ixx
+    description: Gaussian-weighted adaptive moments. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_ixy
+    description: Gaussian-weighted adaptive moments. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_iyy
+    description: Gaussian-weighted adaptive moments. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on r-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: r_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on r-band.
+    datatype: boolean
+  - name: r_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on r-band.
+    datatype: float
+  - name: r_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
+    datatype: float
+  - name: r_moments_flag
+    description: Failure flag for moments (r-band)
+    datatype: boolean
+  - name: r_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (r-band)
+    datatype: float
+  - name: r_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (r-band)
+    datatype: float
+  - name: r_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (r-band)
+    datatype: boolean
+  - name: r_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (r-band)
+    datatype: float
+  - name: r_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (r-band)
+    datatype: float
+  - name: r_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (r-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_moments_psf_flag
+    description: Failure flag for PSF moments (r-band)
+    datatype: boolean
+  - name: r_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (r-band)
+    datatype: float
+  - name: r_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (r-band)
+    datatype: float
+  - name: r_moments_psf_trace
+    description: Moments-based trace radius of the PSF (r-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_moments_trace
+    description: Moments-based trace radius (r-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: r_pixelFlags_bad
+    description: Deprecated; only set when there is no r-band data.
+    datatype: boolean
+  - name: r_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_edge
+    description: Deprecated; only set when there is no r-band data.
+    datatype: boolean
+  - name: r_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_offimage
+    description: Deprecated; only set when there is no r-band data.
+    datatype: boolean
+  - name: r_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on r-band.
+    datatype: boolean
+  - name: r_pixelFlags_suspect
+    description: Deprecated; only set when there is no r-band data.
+    datatype: boolean
+  - name: r_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no r-band data.
+    datatype: boolean
+  - name: r_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on r-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_psfFlux_area
+    description: Effective area of PSF. Forced on r-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: r_psfFlux_flag
+    description: General Failure Flag. Forced on r-band.
+    datatype: boolean
+  - name: r_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on r-band.
+    datatype: boolean
+  - name: r_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on r-band.
+    datatype: boolean
+  - name: r_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on r-band.
+    datatype: boolean
+  - name: r_psfMag
+    description: AB magnitude of the r-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: r_psfMagErr
+    description: Uncertainty in magnitudes of the r-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: r_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (r-band).
+    datatype: float
+  - name: r_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (r-band).
+    datatype: float
+  - name: r_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (r-band).
+    datatype: float
+  - name: r_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (r-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: r_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (r-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: r_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (r-band).
+    datatype: float
+  - name: r_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (r-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: r_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (r-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: r_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (r-band).
+    datatype: int
+  - name: r_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (r-band).
+    datatype: boolean
+  - name: r_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (r-band).
+    datatype: boolean
+  - name: r_ra
+    description: Position in right ascension, measured on r-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: r_raErr
+    description: Error in right ascension, measured on r-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: r_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on r-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: r_sersicFlux
+    description: r-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_sersicFluxErr
+    description: Error on the r-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on r-band.
+    datatype: float
+  - name: r_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on r-band.
+    datatype: boolean
+  - name: refBand
+    description: Reference band - parameters measured on coadds of this band were
+      used for multi-band forced photometry
+    datatype: char
+    length: 1
+    tap:principal: 1
+  - name: refExtendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Reference band.
+    datatype: float
+    tap:principal: 1
+  - name: refSizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Reference band.
+    datatype: float
+    tap:principal: 1
+  - name: sersic_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the multiband Sersic model.
+    datatype: float
+  - name: sersic_dec
+    description: Centroid (declination) from the multiband Sersic model fit.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: sersic_decErr
+    description: Error on the centroid (declination) from the multiband Sersic model
+      fit.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: sersic_index
+    description: Sersic profile index parameter from the multiband Sersic model fit.
+    datatype: float
+  - name: sersic_indexErr
+    description: Error on the Sersic profile index parameter from the multiband Sersic
+      model fit.
+    datatype: float
+  - name: sersic_n_eval_jac
+    description: Number of Jacobian evaluations for the multiband Sersic model fit.
+    datatype: int
+  - name: sersic_n_iter
+    description: Number of iterations in the non-linear fit for the multiband Sersic
+      model.
+    datatype: int
+  - name: sersic_no_data_flag
+    description: Flag set when there is insufficient data to fit for the multiband
+      Sersic model.
+    datatype: boolean
+  - name: sersic_ra
+    description: Centroid (right ascension) from the multiband Sersic model fit.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: sersic_raErr
+    description: Error on the centroid (right ascension) from the multiband Sersic
+      model fit.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: sersic_ra_dec_Cov
+    description: Covariance between right ascension and declination from the multiband
+      Sersic model fit.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: sersic_reff_major
+    description: Effective radius (major axis) from the multiband Sersic model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: arcsec
+  - name: sersic_reff_minor
+    description: Effective radius (minor axis) from the multiband Sersic model fit,
+      prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: arcsec
+  - name: sersic_reff_x
+    description: Effective radius (x-axis) from the multiband Sersic model fit, prior
+      to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: pixel
+  - name: sersic_reff_xErr
+    description: Error on the effective radius (x-axis) from the multiband Sersic
+      model fit.
+    datatype: float
+    ivoa:unit: pixel
+  - name: sersic_reff_y
+    description: Effective radius (y-axis) from the multiband Sersic model fit, prior
+      to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature
+      by default).
+    datatype: float
+    ivoa:unit: pixel
+  - name: sersic_reff_yErr
+    description: Error on the effective radius (y-axis) from the multiband Sersic
+      model fit.
+    datatype: float
+    ivoa:unit: pixel
+  - name: sersic_rho
+    description: Ellipse rho (correlation coefficient) from the multiband Sersic model
+      fit.
+    datatype: float
+  - name: sersic_rhoErr
+    description: Error on ellipse rho (correlation coefficient) from the multiband
+      Sersic model fit.
+    datatype: float
+  - name: sersic_theta
+    description: Position angle of the multiband Sersic fit ellipse.
+    datatype: float
+  - name: sersic_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      multiband Sersic model.
+    datatype: boolean
+  - name: shape_flag
+    description: General failure flag, set if anything went wrong. Reference band.
+    datatype: boolean
+  - name: shape_xx
+    description: Gaussian-weighted adaptive moments. Reference band.
+    datatype: float
+    ivoa:unit: pixel**2
+    tap:principal: 1
+  - name: shape_xy
+    description: Gaussian-weighted adaptive moments. Reference band.
+    datatype: float
+    ivoa:unit: pixel**2
+    tap:principal: 1
+  - name: shape_yy
+    description: Gaussian-weighted adaptive moments. Reference band.
+    datatype: float
+    ivoa:unit: pixel**2
+    tap:principal: 1
+  - name: tract
+    description: Skymap tract ID
+    datatype: long
+    tap:principal: 1
+  - name: u_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_apFlux_flag
+    description: Duplicate of u_ap12Flux_flag.
+    datatype: boolean
+  - name: u_apFlux_flag_apertureTruncated
+    description: Duplicate of u_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: u_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of u_ap12Flux_flag_sincCoeffsTruncated. Measured on u-band.
+    datatype: boolean
+  - name: u_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on u-band.
+    datatype: float
+  - name: u_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      u-band.
+    datatype: boolean
+  - name: u_cModelFlux
+    description: Flux from the final CModel fit. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModelMag
+    description: AB magnitude of cModelFlux. Forced on u-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: u_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on u-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: u_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on u-band.
+    datatype: float
+  - name: u_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on u-band.
+    datatype: float
+  - name: u_cModel_expFlux
+    description: Flux from the exponential fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on u-band.
+    datatype: float
+  - name: u_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      u-band.
+    datatype: boolean
+  - name: u_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on u-band.
+    datatype: float
+  - name: u_calib_astrometry_used
+    description: Propagated from sources. Measured on u-band.
+    datatype: boolean
+  - name: u_calib_photometry_used
+    description: Propagated from sources. Measured on u-band.
+    datatype: boolean
+  - name: u_calib_psf_candidate
+    description: Propagated from sources. Measured on u-band.
+    datatype: boolean
+  - name: u_calib_psf_reserved
+    description: Propagated from sources. Measured on u-band.
+    datatype: boolean
+  - name: u_calib_psf_used
+    description: Propagated from sources. Measured on u-band.
+    datatype: boolean
+  - name: u_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on u-band.
+    datatype: boolean
+  - name: u_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: u_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the u-band.
+    datatype: float
+  - name: u_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: u_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: u_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: u_dec
+    description: Position in declination, measured on u-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: u_decErr
+    description: Error in declination, measured on u-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: u_epoch
+    description: Mean epoch of the object in the u-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: u_exponentialFlux
+    description: u-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_exponentialFluxErr
+    description: Error on the u-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on u-band.
+    datatype: float
+  - name: u_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on u-band.
+    datatype: float
+  - name: u_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on u-band.
+    datatype: boolean
+  - name: u_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on u-band.
+    datatype: boolean
+  - name: u_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on u-band.
+    datatype: float
+  - name: u_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on u-band.
+    datatype: float
+  - name: u_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on u-band.
+    datatype: float
+  - name: u_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on u-band.
+    datatype: boolean
+  - name: u_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on u-band.
+    datatype: float
+  - name: u_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on u-band.
+    datatype: boolean
+  - name: u_i_flag
+    description: General failure flag, set if anything went wrong. Measured on u-band.
+    datatype: boolean
+  - name: u_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on u-band.
+    datatype: int
+  - name: u_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on u-band.
+    datatype: boolean
+  - name: u_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on u-band.
+    datatype: boolean
+  - name: u_ixx
+    description: Gaussian-weighted adaptive moments. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_ixy
+    description: Gaussian-weighted adaptive moments. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_iyy
+    description: Gaussian-weighted adaptive moments. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on u-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: u_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on u-band.
+    datatype: boolean
+  - name: u_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on u-band.
+    datatype: float
+  - name: u_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes.
+    datatype: float
+  - name: u_moments_flag
+    description: Failure flag for moments (u-band)
+    datatype: boolean
+  - name: u_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (u-band)
+    datatype: float
+  - name: u_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (u-band)
+    datatype: float
+  - name: u_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (u-band)
+    datatype: boolean
+  - name: u_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (u-band)
+    datatype: float
+  - name: u_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (u-band)
+    datatype: float
+  - name: u_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (u-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_moments_psf_flag
+    description: Failure flag for PSF moments (u-band)
+    datatype: boolean
+  - name: u_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (u-band)
+    datatype: float
+  - name: u_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (u-band)
+    datatype: float
+  - name: u_moments_psf_trace
+    description: Moments-based trace radius of the PSF (u-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_moments_trace
+    description: Moments-based trace radius (u-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: u_pixelFlags_bad
+    description: Deprecated; only set when there is no u-band data.
+    datatype: boolean
+  - name: u_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_edge
+    description: Deprecated; only set when there is no u-band data.
+    datatype: boolean
+  - name: u_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_offimage
+    description: Deprecated; only set when there is no u-band data.
+    datatype: boolean
+  - name: u_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on u-band.
+    datatype: boolean
+  - name: u_pixelFlags_suspect
+    description: Deprecated; only set when there is no u-band data.
+    datatype: boolean
+  - name: u_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no u-band data.
+    datatype: boolean
+  - name: u_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on u-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_psfFlux_area
+    description: Effective area of PSF. Forced on u-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: u_psfFlux_flag
+    description: General Failure Flag. Forced on u-band.
+    datatype: boolean
+  - name: u_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on u-band.
+    datatype: boolean
+  - name: u_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on u-band.
+    datatype: boolean
+  - name: u_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on u-band.
+    datatype: boolean
+  - name: u_psfMag
+    description: AB magnitude of the u-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: u_psfMagErr
+    description: Uncertainty in magnitudes of the u-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: u_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (u-band).
+    datatype: float
+  - name: u_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (u-band).
+    datatype: float
+  - name: u_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (u-band).
+    datatype: float
+  - name: u_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (u-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: u_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (u-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: u_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (u-band).
+    datatype: float
+  - name: u_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (u-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: u_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (u-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: u_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (u-band).
+    datatype: int
+  - name: u_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (u-band).
+    datatype: boolean
+  - name: u_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (u-band).
+    datatype: boolean
+  - name: u_ra
+    description: Position in right ascension, measured on u-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: u_raErr
+    description: Error in right ascension, measured on u-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: u_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on u-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: u_sersicFlux
+    description: u-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_sersicFluxErr
+    description: Error on the u-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on u-band.
+    datatype: float
+  - name: u_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on u-band.
+    datatype: boolean
+  - name: y_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_apFlux_flag
+    description: Duplicate of y_ap12Flux_flag.
+    datatype: boolean
+  - name: y_apFlux_flag_apertureTruncated
+    description: Duplicate of y_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: y_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of y_ap12Flux_flag_sincCoeffsTruncated. Measured on y-band.
+    datatype: boolean
+  - name: y_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
+    datatype: float
+  - name: y_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      y-band.
+    datatype: boolean
+  - name: y_cModelFlux
+    description: Flux from the final CModel fit. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModelMag
+    description: AB magnitude of cModelFlux. Forced on y-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: y_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on y-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: y_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on y-band.
+    datatype: float
+  - name: y_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on y-band.
+    datatype: float
+  - name: y_cModel_expFlux
+    description: Flux from the exponential fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on y-band.
+    datatype: float
+  - name: y_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      y-band.
+    datatype: boolean
+  - name: y_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on y-band.
+    datatype: float
+  - name: y_calib_astrometry_used
+    description: Propagated from sources. Measured on y-band.
+    datatype: boolean
+  - name: y_calib_photometry_used
+    description: Propagated from sources. Measured on y-band.
+    datatype: boolean
+  - name: y_calib_psf_candidate
+    description: Propagated from sources. Measured on y-band.
+    datatype: boolean
+  - name: y_calib_psf_reserved
+    description: Propagated from sources. Measured on y-band.
+    datatype: boolean
+  - name: y_calib_psf_used
+    description: Propagated from sources. Measured on y-band.
+    datatype: boolean
+  - name: y_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on y-band.
+    datatype: boolean
+  - name: y_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: y_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the y-band.
+    datatype: float
+  - name: y_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: y_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: y_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: y_dec
+    description: Position in declination, measured on y-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: y_decErr
+    description: Error in declination, measured on y-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: y_epoch
+    description: Mean epoch of the object in the y-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: y_exponentialFlux
+    description: y-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_exponentialFluxErr
+    description: Error on the y-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on y-band.
+    datatype: float
+  - name: y_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on y-band.
+    datatype: float
+  - name: y_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on y-band.
+    datatype: boolean
+  - name: y_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on y-band.
+    datatype: boolean
+  - name: y_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on y-band.
+    datatype: float
+  - name: y_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on y-band.
+    datatype: float
+  - name: y_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on y-band.
+    datatype: float
+  - name: y_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on y-band.
+    datatype: boolean
+  - name: y_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on y-band.
+    datatype: float
+  - name: y_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on y-band.
+    datatype: boolean
+  - name: y_i_flag
+    description: General failure flag, set if anything went wrong. Measured on y-band.
+    datatype: boolean
+  - name: y_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on y-band.
+    datatype: int
+  - name: y_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on y-band.
+    datatype: boolean
+  - name: y_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on y-band.
+    datatype: boolean
+  - name: y_ixx
+    description: Gaussian-weighted adaptive moments. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_ixy
+    description: Gaussian-weighted adaptive moments. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_iyy
+    description: Gaussian-weighted adaptive moments. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on y-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: y_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on y-band.
+    datatype: boolean
+  - name: y_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on y-band.
+    datatype: float
+  - name: y_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
+    datatype: float
+  - name: y_moments_flag
+    description: Failure flag for moments (y-band)
+    datatype: boolean
+  - name: y_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (y-band)
+    datatype: float
+  - name: y_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (y-band)
+    datatype: float
+  - name: y_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (y-band)
+    datatype: boolean
+  - name: y_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (y-band)
+    datatype: float
+  - name: y_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (y-band)
+    datatype: float
+  - name: y_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (y-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_moments_psf_flag
+    description: Failure flag for PSF moments (y-band)
+    datatype: boolean
+  - name: y_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (y-band)
+    datatype: float
+  - name: y_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (y-band)
+    datatype: float
+  - name: y_moments_psf_trace
+    description: Moments-based trace radius of the PSF (y-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_moments_trace
+    description: Moments-based trace radius (y-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: y_pixelFlags_bad
+    description: Deprecated; only set when there is no y-band data.
+    datatype: boolean
+  - name: y_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_edge
+    description: Deprecated; only set when there is no y-band data.
+    datatype: boolean
+  - name: y_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_offimage
+    description: Deprecated; only set when there is no y-band data.
+    datatype: boolean
+  - name: y_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on y-band.
+    datatype: boolean
+  - name: y_pixelFlags_suspect
+    description: Deprecated; only set when there is no y-band data.
+    datatype: boolean
+  - name: y_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no y-band data.
+    datatype: boolean
+  - name: y_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on y-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_psfFlux_area
+    description: Effective area of PSF. Forced on y-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: y_psfFlux_flag
+    description: General Failure Flag. Forced on y-band.
+    datatype: boolean
+  - name: y_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on y-band.
+    datatype: boolean
+  - name: y_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on y-band.
+    datatype: boolean
+  - name: y_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on y-band.
+    datatype: boolean
+  - name: y_psfMag
+    description: AB magnitude of the y-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: y_psfMagErr
+    description: Uncertainty in magnitudes of the y-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: y_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (y-band).
+    datatype: float
+  - name: y_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (y-band).
+    datatype: float
+  - name: y_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (y-band).
+    datatype: float
+  - name: y_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (y-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: y_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (y-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: y_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (y-band).
+    datatype: float
+  - name: y_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (y-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: y_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (y-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: y_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (y-band).
+    datatype: int
+  - name: y_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (y-band).
+    datatype: boolean
+  - name: y_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (y-band).
+    datatype: boolean
+  - name: y_ra
+    description: Position in right ascension, measured on y-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: y_raErr
+    description: Error in right ascension, measured on y-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: y_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on y-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: y_sersicFlux
+    description: y-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_sersicFluxErr
+    description: Error on the y-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on y-band.
+    datatype: float
+  - name: y_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on y-band.
+    datatype: boolean
+  - name: z_ap03Flux
+    description: Flux within 3.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap03Flux_flag
+    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap06Flux
+    description: Flux within 6.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap06Flux_flag
+    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap09Flux
+    description: Flux within 9.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap09Flux_flag
+    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap12Flux
+    description: Flux within 12.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap12Flux_flag
+    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap17Flux
+    description: Flux within 17.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap17Flux_flag
+    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap25Flux
+    description: Flux within 25.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap25Flux_flag
+    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap35Flux
+    description: Flux within 35.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap35Flux_flag
+    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap50Flux
+    description: Flux within 50.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap50Flux_flag
+    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_ap70Flux
+    description: Flux within 70.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_ap70Flux_flag
+    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_apFlux_flag
+    description: Duplicate of z_ap12Flux_flag.
+    datatype: boolean
+  - name: z_apFlux_flag_apertureTruncated
+    description: Duplicate of z_ap12Flux_flag_apertureTruncated.
+    datatype: boolean
+  - name: z_apFlux_flag_sincCoeffsTruncated
+    description: Duplicate of z_ap12Flux_flag_sincCoeffsTruncated. Measured on z-band.
+    datatype: boolean
+  - name: z_blendedness
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
+    datatype: float
+  - name: z_blendedness_flag
+    description: Flag set for any failure in the blendedness algorithm. Measured on
+      z-band.
+    datatype: boolean
+  - name: z_cModelFlux
+    description: Flux from the final CModel fit. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModelMag
+    description: AB magnitude of cModelFlux. Forced on z-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: z_cModelMagErr
+    description: Uncertainty in magnitudes on cModelFlux. Forced on z-band.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: z_cModel_chi2
+    description: -ln(likelihood) (chi^2) in CModel fit. Measured on z-band.
+    datatype: float
+  - name: z_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModel_dev_reff_major
+    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_cModel_dev_reff_minor
+    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_cModel_dev_theta
+    description: Position angle of the de Vaucouleurs fit ellipse. Measured on z-band.
+    datatype: float
+  - name: z_cModel_expFlux
+    description: Flux from the exponential fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_cModel_exp_reff_major
+    description: Half-light ellipse of the exponential fit (major axis). Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_cModel_exp_reff_minor
+    description: Half-light ellipse of the exponential fit (minor axis). Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_cModel_exp_theta
+    description: Position angle of the exponential fit ellipse. Measured on z-band.
+    datatype: float
+  - name: z_cModel_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_cModel_flag_apCorr
+    description: Flag set if unable to aperture-correct the CModel flux. Forced on
+      z-band.
+    datatype: boolean
+  - name: z_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Forced on z-band.
+    datatype: float
+  - name: z_calib_astrometry_used
+    description: Propagated from sources. Measured on z-band.
+    datatype: boolean
+  - name: z_calib_photometry_used
+    description: Propagated from sources. Measured on z-band.
+    datatype: boolean
+  - name: z_calib_psf_candidate
+    description: Propagated from sources. Measured on z-band.
+    datatype: boolean
+  - name: z_calib_psf_reserved
+    description: Propagated from sources. Measured on z-band.
+    datatype: boolean
+  - name: z_calib_psf_used
+    description: Propagated from sources. Measured on z-band.
+    datatype: boolean
+  - name: z_centroid_flag
+    description: Flag set for any failure in the centroid algorithm. Measured on z-band.
+    datatype: boolean
+  - name: z_deblend_blendedness
+    description: Blendedness in the deconvolved scarlet space.
+    datatype: float
+  - name: z_deblend_dataCoverage
+    description: Fraction of data that contained good data, ie. 1 - number of no data
+      pixels/total number of pixels in the z-band.
+    datatype: float
+  - name: z_deblend_fluxOverlap
+    description: The total flux from neighboring objects that overlaps with this sources
+      footprint in the deconvolved space.
+    datatype: float
+  - name: z_deblend_fluxOverlapFraction
+    description: Fraction of flux from neighbors / source flux in the deconvolved
+      footprint.
+    datatype: float
+  - name: z_deblend_zeroFlux
+    description: True when there was no flux attributed to this object after flux
+      redistribution in the deblender.
+    datatype: boolean
+  - name: z_dec
+    description: Position in declination, measured on z-band.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: z_decErr
+    description: Error in declination, measured on z-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: z_epoch
+    description: Mean epoch of the object in the z-band coadd in MJD TAI
+    datatype: double
+    ivoa:unit: d
+  - name: z_exponentialFlux
+    description: z-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_exponentialFluxErr
+    description: Error on the z-band flux from the multiband exponential model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on z-band.
+    datatype: float
+  - name: z_extendedness_flag
+    description: Flag set for any failure in the flux-ratio extendedness. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_free_cModelFlux
+    description: Flux from the final CModel fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModelFluxErr
+    description: Flux uncertainty from the final CModel fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModelFlux_flag
+    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_free_cModelFlux_inner
+    description: Flux within the fit region, with no extrapolation. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModel_devFlux
+    description: Flux from the de Vaucouleurs fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModel_devFluxErr
+    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModel_expFlux
+    description: Flux from the exponential fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModel_expFluxErr
+    description: Flux uncertainty from the exponential fit. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_cModel_fracDev
+    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component.
+      Measured on z-band.
+    datatype: float
+  - name: z_free_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_free_psfFlux_flag
+    description: Flag set if the unforced PSF flux failed in this band for any reason.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_gaap0p7Flux
+    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaap0p7FluxErr
+    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaap1p0Flux
+    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to
+      a Gaussian PSF larger than the original by a factor of 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaap1p0FluxErr
+    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying
+      the seeing by 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaapFlux_flag
+    description: Flag set for any failure in the GAaP photometry. Forced on z-band.
+    datatype: boolean
+  - name: z_gaapFlux_flag_edge
+    description: Source is too close to the edge. Forced on z-band.
+    datatype: boolean
+  - name: z_gaapPsfFlux
+    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian
+      PSF larger than the original by a factor of 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaapPsfFluxErr
+    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
+      by 1.15. Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_hsmShapeRegauss_e1
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on z-band.
+    datatype: float
+  - name: z_hsmShapeRegauss_e2
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on z-band.
+    datatype: float
+  - name: z_hsmShapeRegauss_flag
+    description: Flag set for any failure with the Regaussianziation shapes. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_hsmShapeRegauss_sigma
+    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization
+      algorithm. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_03
+    description: HSM higher-order moment 03 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_04
+    description: HSM higher-order moment 04 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_12
+    description: HSM higher-order moment 12 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_13
+    description: HSM higher-order moment 13 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_21
+    description: HSM higher-order moment 21 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_22
+    description: HSM higher-order moment 22 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_30
+    description: HSM higher-order moment 30 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_31
+    description: HSM higher-order moment 31 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_40
+    description: HSM higher-order moment 40 measured on the PSF model at the position
+      of the object. Measured on z-band.
+    datatype: float
+  - name: z_hsm_momentsPsf_flag
+    description: Flag set for any failure in the HSM higher-order moment on the PSF
+      model. Measured on z-band.
+    datatype: boolean
+  - name: z_hsm_moments_03
+    description: HSM higher-order moment 03. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_04
+    description: HSM higher-order moment 04. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_12
+    description: HSM higher-order moment 12. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_13
+    description: HSM higher-order moment 13. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_21
+    description: HSM higher-order moment 21. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_22
+    description: HSM higher-order moment 22. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_30
+    description: HSM higher-order moment 30. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_31
+    description: HSM higher-order moment 31. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_40
+    description: HSM higher-order moment 40. Measured on z-band.
+    datatype: float
+  - name: z_hsm_moments_flag
+    description: Flag set for any failure in the HSM higher-order moments. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_iPSF_flag
+    description: Flag set for any failure in the PSF model moments. Measured on z-band.
+    datatype: boolean
+  - name: z_i_flag
+    description: General failure flag, set if anything went wrong. Measured on z-band.
+    datatype: boolean
+  - name: z_inputCount
+    description: Number of images contributing at center, not including any clipping.
+      Forced on z-band.
+    datatype: int
+  - name: z_inputCount_flag
+    description: Flag set for any failure in computing the number of inputs. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_inputCount_flag_noInputs
+    description: No coadd inputs were recorded. Forced on z-band.
+    datatype: boolean
+  - name: z_invalidPsfFlag
+    description: This object has an invalid PSF (usually no inputs). Measured on z-band.
+    datatype: boolean
+  - name: z_ixx
+    description: Gaussian-weighted adaptive moments. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_ixxPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_ixy
+    description: Gaussian-weighted adaptive moments. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_ixyPSF
+    description: Gaussian-weighted adaptive moments. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_iyy
+    description: Gaussian-weighted adaptive moments. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_iyyPSF
+    description: Gaussian-weighted adaptive moments of the PSF model at the position
+      of this object. Measured on z-band.
+    datatype: float
+    ivoa:unit: pixel**2
+  - name: z_kronFlux
+    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured
+      on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_kronFluxErr
+    description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_kronFlux_flag
+    description: Flag set for any failure in the Kron photometry. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_bad_radius
+    description: Bad Kron radius. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_bad_shape
+    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_bad_shape_no_psf
+    description: Bad shape and no PSF. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_edge
+    description: Bad measurement due to image edge. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_no_fallback_radius
+    description: No minimum radius and no PSF provided. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_no_minimum_radius
+    description: Minimum radius could not enforced, no minimum value or PSF. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_small_radius
+    description: Measured Kron radius was smaller than that of the PSF. Measured on
+      z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_used_minimum_radius
+    description: Used the minimum radius for the Kron radius. Measured on z-band.
+    datatype: boolean
+  - name: z_kronFlux_flag_used_psf_radius
+    description: Kron radius fell back to being derived from the PSF radius. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_kronRad
+    description: Kron radius (sqrt(a*b)).  Measured on z-band.
+    datatype: float
+  - name: z_model_extendedness
+    description: Model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
+    datatype: float
+  - name: z_moments_flag
+    description: Failure flag for moments (z-band)
+    datatype: boolean
+  - name: z_moments_g1
+    description: Moments-based G1 shear ellipticity parameter (z-band)
+    datatype: float
+  - name: z_moments_g2
+    description: Moments-based G2 shear ellipticity parameter (z-band)
+    datatype: float
+  - name: z_moments_psf_debiased_flag
+    description: Failure flag for the debiased PSF moments (z-band)
+    datatype: boolean
+  - name: z_moments_psf_debiased_g1
+    description: Moments-based G1 ellipticity of the PSF, debiased (z-band)
+    datatype: float
+  - name: z_moments_psf_debiased_g2
+    description: Moments-based G2 ellipticity of the PSF, debiased (z-band)
+    datatype: float
+  - name: z_moments_psf_debiased_trace
+    description: Moments-based trace radius of the PSF, debiased (z-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_moments_psf_flag
+    description: Failure flag for PSF moments (z-band)
+    datatype: boolean
+  - name: z_moments_psf_g1
+    description: Moments-based G1 ellipticity of of the PSF (z-band)
+    datatype: float
+  - name: z_moments_psf_g2
+    description: Moments-based G2 ellipticity of of the PSF (z-band)
+    datatype: float
+  - name: z_moments_psf_trace
+    description: Moments-based trace radius of the PSF (z-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_moments_trace
+    description: Moments-based trace radius (z-band)
+    datatype: float
+    ivoa:unit: arcsec
+  - name: z_pixelFlags_bad
+    description: Deprecated; only set when there is no z-band data.
+    datatype: boolean
+  - name: z_pixelFlags_clipped
+    description: Artifacts were rejected by warp comparison in this object's footprint.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_clippedCenter
+    description: Artifacts were rejected by warp comparison in this object's center.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_cr
+    description: A cosmic ray was detected and interpolated in this object's footprint.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_crCenter
+    description: A cosmic ray was detected and interpolated in this object's center.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_edge
+    description: Deprecated; only set when there is no z-band data.
+    datatype: boolean
+  - name: z_pixelFlags_inexact_psf
+    description: The PSF model is discontinuous in this object's footprint. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_inexact_psfCenter
+    description: The PSF model is discontinuosu near this object's center. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_interpolated
+    description: An interpolated pixel contributed to the coadd in this object's footprint.
+      Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_interpolatedCenter
+    description: An interpolated pixel contributed to the coadd near this object's
+      center. Measured on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_nodata
+    description: No pixel data was available in this band for this object. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_offimage
+    description: Deprecated; only set when there is no z-band data.
+    datatype: boolean
+  - name: z_pixelFlags_saturated
+    description: Saturated pixels were rejected from this object's footprint, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_saturatedCenter
+    description: Saturated pixels were rjected from near this object's center, but
+      would otherwise have contributed more than 10% of at least one pixel. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_sensor_edge
+    description: A detector boundary passed through this object's footprint. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_sensor_edgeCenter
+    description: A detector boundary passed close to this object's center. Measured
+      on z-band.
+    datatype: boolean
+  - name: z_pixelFlags_suspect
+    description: Deprecated; only set when there is no z-band data.
+    datatype: boolean
+  - name: z_pixelFlags_suspectCenter
+    description: Deprecated; only set when there is no z-band data.
+    datatype: boolean
+  - name: z_psfFlux
+    description: Flux derived from using the PSF model as a weight function. Forced
+      on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_psfFluxErr
+    description: Flux uncertainty derived from using the PSF model as a weight function.
+      Forced on z-band.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_psfFlux_area
+    description: Effective area of PSF. Forced on z-band.
+    datatype: float
+    ivoa:unit: pixel
+  - name: z_psfFlux_flag
+    description: General Failure Flag. Forced on z-band.
+    datatype: boolean
+  - name: z_psfFlux_flag_apCorr
+    description: Flag set if unable to aperture-correct the PSF flux. Forced on z-band.
+    datatype: boolean
+  - name: z_psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model. Forced on z-band.
+    datatype: boolean
+  - name: z_psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit. Forced
+      on z-band.
+    datatype: boolean
+  - name: z_psfMag
+    description: AB magnitude of the z-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: z_psfMagErr
+    description: Uncertainty in magnitudes of the z-band psfFlux.
+    datatype: float
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: z_psfModel_TwoGaussian_chi2_reduced
+    description: Reduced chi-squared of the best-fit model parameters (chi divided
+      the number of data points) for the two-Gaussian PSF model (z-band).
+    datatype: float
+  - name: z_psfModel_TwoGaussian_gauss1_fluxfrac
+    description: Fraction of the total flux (normalized to unity) of the first Gaussian
+      component in the two-Gaussian PSF model (z-band).
+    datatype: float
+  - name: z_psfModel_TwoGaussian_gauss1_rho
+    description: Ellipse rho (correlation coefficient) of the first Gaussian component
+      in the two-Gaussian PSF model (z-band).
+    datatype: float
+  - name: z_psfModel_TwoGaussian_gauss1_sigma_x
+    description: Standard deviation of the first Gaussian component (x-axis) in the
+      two-Gaussian PSF model (z-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: z_psfModel_TwoGaussian_gauss1_sigma_y
+    description: Standard deviation of the first Gaussian component (y-axis) in the
+      two-Gaussian PSF model (z-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: z_psfModel_TwoGaussian_gauss2_rho
+    description: Ellipse rho (correlation coefficient) of the second Gaussian component
+      in the two-Gaussian PSF model (z-band).
+    datatype: float
+  - name: z_psfModel_TwoGaussian_gauss2_sigma_x
+    description: Standard deviation of the second Gaussian component (x-axis) in the
+      two-Gaussian PSF model (z-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: z_psfModel_TwoGaussian_gauss2_sigma_y
+    description: Standard deviation of the second Gaussian component (y-axis) in the
+      two-Gaussian PSF model (z-band).
+    datatype: float
+    ivoa:unit: pixel
+  - name: z_psfModel_TwoGaussian_n_iter
+    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
+      model (z-band).
+    datatype: int
+  - name: z_psfModel_TwoGaussian_no_inputs_flag
+    description: Flag set for objects not fit because there were no coadd PSF inputs
+      for the two-Gaussian PSF model (z-band).
+    datatype: boolean
+  - name: z_psfModel_TwoGaussian_unknown_flag
+    description: Flag set for failures with an unexpected or unknown cause for the
+      two-Gaussian PSF model (z-band).
+    datatype: boolean
+  - name: z_ra
+    description: Position in right ascension, measured on z-band.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: z_raErr
+    description: Error in right ascension, measured on z-band.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: z_ra_dec_Cov
+    description: Covariance between right ascension and declination, measured on z-band.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: z_sersicFlux
+    description: z-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_sersicFluxErr
+    description: Error on the z-band flux from the multiband Sersic model fit.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_sizeExtendedness
+    description: Moments-based measure of whether an object is point-like (0) or extended
+      (1). Measured on z-band.
+    datatype: float
+  - name: z_sizeExtendedness_flag
+    description: Flag set for any failure in the moments-based extendedness. Measured
+      on z-band.
+    datatype: boolean
+- name: Source
+  description: Properties of detections on the single-epoch visit images, performed
+    independently of the Object detections on coadded images.
+  columns:
+  - name: ap03Flux
+    description: Flux within 3.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap03FluxErr
+    description: Flux uncertainty within 3.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap03Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap06Flux
+    description: Flux within 6.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap06FluxErr
+    description: Flux uncertainty within 6.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap06Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap09Flux
+    description: Flux within 9.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap09FluxErr
+    description: Flux uncertainty within 9.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap09Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap12Flux
+    description: Flux within 12.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap12FluxErr
+    description: Flux uncertainty within 12.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap12Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap17Flux
+    description: Flux within 17.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap17FluxErr
+    description: Flux uncertainty within 17.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap17Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap25Flux
+    description: Flux within 25.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap25FluxErr
+    description: Flux uncertainty within 25.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap25Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap35Flux
+    description: Flux within 35.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap35FluxErr
+    description: Flux uncertainty within 35.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap35Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap50Flux
+    description: Flux within 50.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap50FluxErr
+    description: Flux uncertainty within 50.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap50Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: ap70Flux
+    description: Flux within 70.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap70FluxErr
+    description: Flux uncertainty within 70.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: ap70Flux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: apFlux_12_0_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: apFlux_12_0_flag_apertureTruncated
+    description: Aperture did not fit within measurement image
+    datatype: boolean
+  - name: apFlux_12_0_flag_sincCoeffsTruncated
+    description: Full sinc coefficient image did not fit within measurement image
+    datatype: boolean
+  - name: apFlux_12_0_instFlux
+    description: Flux within 12.0-pixel aperture
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_12_0_instFluxErr
+    description: 1-sigma flux uncertainty
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_17_0_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: apFlux_17_0_instFlux
+    description: Flux within 17.0-pixel aperture
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_17_0_instFluxErr
+    description: 1-sigma flux uncertainty
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_35_0_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: apFlux_35_0_instFlux
+    description: Flux within 35.0-pixel aperture
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_35_0_instFluxErr
+    description: 1-sigma flux uncertainty
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_50_0_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: apFlux_50_0_instFlux
+    description: Flux within 50.0-pixel aperture
+    datatype: double
+    ivoa:unit: count
+  - name: apFlux_50_0_instFluxErr
+    description: 1-sigma flux uncertainty
+    datatype: double
+    ivoa:unit: count
+  - name: band
+    description: Name of the band used to take the exposure where this source was
+      measured. Abstract filter that is not associated with a particular instrument
+    datatype: char
+    length: 1
+  - name: blendedness_abs
+    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
+      on the absolute value of the pixels to try to obtain a de-noised value.  See
+      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
+    datatype: double
+  - name: blendedness_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: blendedness_flag_noCentroid
+    description: Object has no centroid
+    datatype: boolean
+  - name: blendedness_flag_noShape
+    description: Object has no shape
+    datatype: boolean
+  - name: calibFlux
+    description: Flux within 12.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: calibFluxErr
+    description: Flux uncertainty within 12.0-pixel aperture
+    datatype: double
+    ivoa:unit: nJy
+  - name: calib_astrometry_used
+    description: Set if source was used in astrometric calibration
+    datatype: boolean
+  - name: calib_photometry_reserved
+    description: Set if source was reserved from photometric calibration
+    datatype: boolean
+  - name: calib_photometry_used
+    description: Set if source was used in photometric calibration
+    datatype: boolean
+  - name: calib_psf_candidate
+    description: Flag set if the source was a candidate for PSF determination, as
+      determined by the star selector.
+    datatype: boolean
+  - name: calib_psf_reserved
+    description: Set if source was reserved from PSF determination
+    datatype: boolean
+  - name: calib_psf_used
+    description: Flag set if the source was actually used for PSF determination, as
+      determined by the
+    datatype: boolean
+  - name: centroid_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: centroid_flag_almostNoSecondDerivative
+    description: Almost vanishing second derivative
+    datatype: boolean
+  - name: centroid_flag_badError
+    description: Error on x and/or y position is NaN
+    datatype: boolean
+  - name: centroid_flag_edge
+    description: Object too close to edge
+    datatype: boolean
+  - name: centroid_flag_noSecondDerivative
+    description: Vanishing second derivative
+    datatype: boolean
+  - name: centroid_flag_notAtMaximum
+    description: Object is not at a maximum
+    datatype: boolean
+  - name: centroid_flag_resetToPeak
+    description: Set if CentroidChecker reset the centroid
+    datatype: boolean
+  - name: coord_dec
+    description: Fiducial ICRS Declination of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: coord_ra
+    description: Fiducial ICRS Right Ascension of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: deblend_deblendedAsPsf
+    description: Deblender thought this source looked like a PSF
+    datatype: boolean
+  - name: deblend_hasStrayFlux
+    description: This source was assigned some stray flux
+    datatype: boolean
+  - name: deblend_masked
+    description: Parent footprint was predominantly masked
+    datatype: boolean
+  - name: deblend_nChild
+    description: Number of children this object has (defaults to 0)
+    datatype: int
+  - name: deblend_parentTooBig
+    description: Parent footprint covered too many pixels
+    datatype: boolean
+  - name: deblend_patchedTemplate
+    description: This source was near an image edge and the deblender used patched
+      edge-handling.
+    datatype: boolean
+  - name: deblend_rampedTemplate
+    description: This source was near an image edge and the deblender used ramp edge-handling.
+    datatype: boolean
+  - name: deblend_skipped
+    description: Deblender skipped this source
+    datatype: boolean
+  - name: deblend_tooManyPeaks
+    description: Source had too many peaks; only the brightest were included
+    datatype: boolean
+  - name: dec
+    description: Position in declination.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: decErr
+    description: Error in declination.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: detector
+    description: Id of the detector where this source was measured.
+    datatype: short
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+  - name: extendedness
+    description: Flux-ratio measure of whether an object is point-like (0) or extended
+      (1).
+    datatype: double
+  - name: extendedness_flag
+    description: Set to 1 for any fatal failure.
+    datatype: boolean
+  - name: footprintArea_value
+    description: Number of pixels in the sources detection footprint.
+    datatype: int
+    ivoa:unit: pixel
+  - name: gaussianFlux
+    description: Flux from Gaussian Flux algorithm
+    datatype: double
+    ivoa:unit: nJy
+  - name: gaussianFluxErr
+    description: Flux uncertainty from Gaussian Flux algorithm
+    datatype: double
+    ivoa:unit: nJy
+  - name: gaussianFlux_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: hsmPsfMoments_flag
+    description: General failure flag, set if anything went wrong
+    datatype: boolean
+  - name: hsmPsfMoments_flag_no_pixels
+    description: No pixels to measure
+    datatype: boolean
+  - name: hsmPsfMoments_flag_not_contained
+    description: Center not contained in footprint bounding box
+    datatype: boolean
+  - name: hsmPsfMoments_flag_parent_source
+    description: Parent source, ignored
+    datatype: boolean
+  - name: hsmShapeRegauss_flag
+    description: General failure flag, set if anything went wrong
+    datatype: boolean
+  - name: hsmShapeRegauss_flag_galsim
+    description: GalSim failure
+    datatype: boolean
+  - name: hsmShapeRegauss_flag_no_pixels
+    description: No pixels to measure
+    datatype: boolean
+  - name: hsmShapeRegauss_flag_not_contained
+    description: Center not contained in footprint bounding box
+    datatype: boolean
+  - name: hsmShapeRegauss_flag_parent_source
+    description: Parent source, ignored
+    datatype: boolean
+  - name: iDebiasedPSF_flag
+    description: General failure flag, set if anything went wrong
+    datatype: boolean
+  - name: iDebiasedPSF_flag_edge
+    description: Variance undefined outside image edge
+    datatype: boolean
+  - name: iDebiasedPSF_flag_galsim
+    description: GalSim failure
+    datatype: boolean
+  - name: iDebiasedPSF_flag_no_pixels
+    description: No pixels to measure
+    datatype: boolean
+  - name: iDebiasedPSF_flag_not_contained
+    description: Center not contained in footprint bounding box
+    datatype: boolean
+  - name: iDebiasedPSF_flag_parent_source
+    description: Parent source, ignored
+    datatype: boolean
+  - name: invalidPsfFlag
+    description: Source has an invalid psf.
+    datatype: boolean
+  - name: ixx
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ixxDebiasedPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ixxPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ixy
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ixyDebiasedPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ixyPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: iyy
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: iyyDebiasedPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: iyyPSF
+    description: HSM moments
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: jacobian_flag
+    description: Set to 1 for any fatal failure
+    datatype: boolean
+  - name: jacobian_value
+    description: Jacobian correction
+    datatype: double
+  - name: localBackground_flag
+    description: General Failure Flag
+    datatype: boolean
+  - name: localBackground_flag_noGoodPixels
+    description: No good pixels in the annulus
+    datatype: boolean
+  - name: localBackground_flag_noPsf
+    description: No PSF provided
+    datatype: boolean
+  - name: localBackground_instFlux
+    description: Background in annulus around source
+    datatype: double
+    ivoa:unit: count
+  - name: localBackground_instFluxErr
+    description: 1-sigma flux uncertainty
+    datatype: double
+    ivoa:unit: count
+  - name: normCompTophatFlux_flag
+    description: General failure flag for normCompTophatFlux.
+    datatype: boolean
+  - name: normCompTophatFlux_instFlux
+    description: Normalized compensated tophat flux for calibration
+    datatype: double
+    ivoa:unit: count
+  - name: normCompTophatFlux_instFluxErr
+    description: 1-sigma flux uncertainty on normCompTophatFlux_instFlux
+    datatype: double
+    ivoa:unit: count
+  - name: parentSourceId
+    description: Unique ID of parent source
+    datatype: long
+  - name: physical_filter
+    description: ID of physical filter, the filter associated with a particular instrument.
+    datatype: char
+    length: 9
+    votable:arraysize: '9'
+  - name: pixelFlags_bad
+    description: Bad pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_cr
+    description: Cosmic ray in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_crCenter
+    description: Cosmic ray in the Source center
+    datatype: boolean
+  - name: pixelFlags_edge
+    description: Source is on the edge of an exposure region (masked EDGE)
+    datatype: boolean
+  - name: pixelFlags_interpolated
+    description: Interpolated pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_interpolatedCenter
+    description: Interpolated pixel in the Source center
+    datatype: boolean
+  - name: pixelFlags_nodata
+    description: Source is outside usable exposure region (masked NO_DATA)
+    datatype: boolean
+  - name: pixelFlags_offimage
+    description: Source center is off image
+    datatype: boolean
+  - name: pixelFlags_saturated
+    description: Saturated pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_saturatedCenter
+    description: Saturated pixel in the Source center
+    datatype: boolean
+  - name: pixelFlags_suspect
+    description: Sources footprint includes suspect pixels
+    datatype: boolean
+  - name: pixelFlags_suspectCenter
+    description: Sources center is close to suspect pixels
+    datatype: boolean
+  - name: psfFlux
+    description: Flux derived from linear least-squares fit of psf model forced on
+      the calexp
+    datatype: double
+    ivoa:unit: nJy
+  - name: psfFluxErr
+    description: Uncertainty on the flux derived from linear least-squares fit of
+      psf model forced on the calexp
+    datatype: double
+    ivoa:unit: nJy
+  - name: psfFlux_apCorr
+    description: Aperture correction applied to base_PsfFlux
+    datatype: double
+  - name: psfFlux_apCorrErr
+    description: Standard deviation of aperture correction applied to base_PsfFlux
+    datatype: double
+  - name: psfFlux_area
+    description: Effective area of PSF
+    datatype: float
+    ivoa:unit: pixel
+  - name: psfFlux_flag
+    description: Failure to derive linear least-squares fit of psf model forced on
+      the calexp
+    datatype: boolean
+  - name: psfFlux_flag_apCorr
+    description: Set if unable to aperture correct base_PsfFlux
+    datatype: boolean
+  - name: psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model
+    datatype: boolean
+  - name: psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit
+    datatype: boolean
+  - name: ra
+    description: Position in right ascension.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: raErr
+    description: Error in right ascension.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: ra_dec_Cov
+    description: Covariance between right ascension and declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: sizeExtendedness
+    description: Moments-based measure of a source to be a galaxy.
+    datatype: double
+  - name: sizeExtendedness_flag
+    description: Set to 1 for any fatal failure.
+    datatype: boolean
+  - name: sky
+    description: Background in annulus around source
+    datatype: double
+    ivoa:unit: nJy
+  - name: skyErr
+    description: Background in annulus around source
+    datatype: double
+    ivoa:unit: nJy
+  - name: sky_source
+    description: Sky objects.
+    datatype: boolean
+  - name: sourceId
+    description: Unique id. Unique Source ID. Primary Key.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: variance_flag
+    description: Set for any fatal failure
+    datatype: boolean
+  - name: variance_flag_emptyFootprint
+    description: Set to True when the footprint has no usable pixels
+    datatype: boolean
+  - name: variance_value
+    description: Variance at object position
+    datatype: double
+  - name: visit
+    description: Id of the visit where this source was measured.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+  - name: x
+    description: Centroid from Sdss Centroid algorithm
+    datatype: double
+    ivoa:unit: pixel
+  - name: xErr
+    description: 1-sigma uncertainty on x position
+    datatype: float
+    ivoa:unit: pixel
+  - name: y
+    description: Centroid from Sdss Centroid algorithm
+    datatype: double
+    ivoa:unit: pixel
+  - name: yErr
+    description: 1-sigma uncertainty on y position
+    datatype: float
+    ivoa:unit: pixel
+- name: ForcedSource
+  description: Forced-photometry measurements on individual single-epoch visit images
+    and difference images, based on and linked to the entries in the Object table.
+    Point-source PSF photometry is performed, based on coordinates from a reference
+    band chosen for each Object and reported in the Object.refBand column.
+  columns:
+  - name: band
+    description: Abstract filter that is not associated with a particular instrument
+    datatype: char
+    length: 1
+    tap:principal: 1
+  - name: coord_dec
+    description: Fiducial ICRS Declination of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: coord_ra
+    description: Fiducial ICRS Right Ascension of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: detector
+    description: Id of the detector where this source was measured.
+    datatype: short
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+  - name: diff_PixelFlags_nodataCenter
+    description: Source center is outside usable region on image difference (masked
+      NO_DATA)
+    datatype: boolean
+  - name: invalidPsfFlag
+    description: Source has an invalid PSF.
+    datatype: boolean
+  - name: objectId
+    description: Unique Object ID. Primary Key of the Object Table
+    datatype: long
+    tap:principal: 1
+  - name: parentObjectId
+    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
+    datatype: long
+  - name: patch
+    description: Skymap patch ID
+    datatype: long
+  - name: pixelFlags_bad
+    description: Bad pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_cr
+    description: Cosmic ray in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_crCenter
+    description: Cosmic ray in the Source center
+    datatype: boolean
+  - name: pixelFlags_edge
+    description: Source is on the edge of an exposure region (masked EDGE)
+    datatype: boolean
+  - name: pixelFlags_interpolated
+    description: Interpolated pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_interpolatedCenter
+    description: Interpolated pixel in the Source center
+    datatype: boolean
+  - name: pixelFlags_nodata
+    description: Source is outside usable exposure region (masked NO_DATA)
+    datatype: boolean
+  - name: pixelFlags_saturated
+    description: Saturated pixel in the Source footprint
+    datatype: boolean
+  - name: pixelFlags_saturatedCenter
+    description: Saturated pixel in the Source center
+    datatype: boolean
+  - name: pixelFlags_suspect
+    description: Sources footprint includes suspect pixels
+    datatype: boolean
+  - name: pixelFlags_suspectCenter
+    description: Sources center is close to suspect pixels
+    datatype: boolean
+  - name: psfDiffFlux
+    description: Flux derived from linear least-squares fit of psf model forced on
+      the image difference
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfDiffFluxErr
+    description: Uncertainty on the flux derived from linear least-squares fit of
+      psf model forced on the image difference
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfDiffFlux_flag
+    description: Failure to derive linear least-squares fit of psf model forced on
+      the image difference
+    datatype: boolean
+  - name: psfFlux
+    description: Flux derived from linear least-squares fit of psf model forced on
+      the calexp
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfFluxErr
+    description: Uncertainty on the flux derived from linear least-squares fit of
+      psf model forced on the calexp
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfFlux_flag
+    description: Failure to derive linear least-squares fit of psf model forced on
+      the calexp
+    datatype: boolean
+  - name: tract
+    description: Skymap tract ID
+    datatype: long
+  - name: visit
+    description: Id of the visit where this source was measured.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+- name: DiaSource
+  description: Properties of transient-object detections on the single-epoch difference
+    images.
+  columns:
+  - name: apFlux
+    description: Flux in a 12 pixel radius aperture on the difference image.
+    datatype: float
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: apFluxErr
+    description: Estimated uncertainty of apFlux.
+    datatype: float
+    ivoa:ucd: stat.error;phot.count
+    ivoa:unit: nJy
+  - name: apFlux_flag
+    description: General aperture flux algorithm failure flag; set if anything went
+      wrong when measuring aperture fluxes. Another apFlux flag field should also
+      be set to provide more information.
+    datatype: boolean
+    nullable: false
+  - name: apFlux_flag_apertureTruncated
+    description: Aperture did not fit within measurement image.
+    datatype: boolean
+    nullable: false
+  - name: band
+    description: Filter band this source was observed with.
+    datatype: char
+    length: 1
+  - name: bboxSize
+    description: Size of the square bounding box that fully contains the detection
+      footprint.
+    datatype: long
+    nullable: false
+    ivoa:unit: pixel
+  - name: centroid_flag
+    description: General centroid algorithm failure flag; set if anything went wrong
+      when fitting the centroid. Another centroid flag field should also be set to
+      provide more information.
+    datatype: boolean
+    nullable: false
+  - name: coord_dec
+    description: Fiducial ICRS Declination of centroid used for database indexing.
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: coord_ra
+    description: Fiducial ICRS Right Ascension of centroid used for database indexing.
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: dec
+    description: Declination coordinate of the center of this diaSource.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: decErr
+    description: Error in declination.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+  - name: detector
+    description: Id of the detector where this diaSource was measured.
+    datatype: short
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+  - name: diaObjectId
+    description: Id of the diaObject this source was associated with, if any. If not,
+      it is set to 0
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: diaSourceId
+    description: Unique identifier of this DiaSource.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+  - name: dipoleAngle
+    description: Maximum likelihood fit of the angle between the meridian through
+      the centroid and the dipole direction (bearing, from negative to positive lobe).
+    datatype: double
+    ivoa:ucd: pos.posAng
+    ivoa:unit: deg
+  - name: dipoleChi2
+    description: Chi^2 statistic of the model fit.
+    datatype: double
+    ivoa:ucd: stat.fit.chi2
+  - name: dipoleFitAttempted
+    description: Attempted to fit a dipole model to this source.
+    datatype: boolean
+    nullable: false
+  - name: dipoleFluxDiff
+    description: Maximum likelihood value for the difference of absolute fluxes of
+      the two lobes for a dipole model.
+    datatype: double
+    ivoa:unit: nJy
+  - name: dipoleFluxDiffErr
+    description: Uncertainty of dipoleFluxDiff.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: dipoleLength
+    description: Maximum likelihood value for the lobe separation in dipole model.
+    datatype: double
+    ivoa:ucd: pos.angDistance
+    ivoa:unit: arcsec
+  - name: dipoleMeanFlux
+    description: Maximum likelihood value for the mean absolute flux of the two lobes
+      for a dipole model.
+    datatype: double
+    ivoa:unit: nJy
+  - name: dipoleMeanFluxErr
+    description: Uncertainty of dipoleMeanFlux.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: dipoleNdata
+    description: The number of data points (pixels) used to fit the model.
+    datatype: long
+    nullable: false
+  - name: extendedness
+    description: A measure of extendedness, computed by comparing an object's moment-based
+      trace radius to the PSF moments. extendedness = 1 implies a high degree of confidence
+      that the source is extended. extendedness = 0 implies a high degree of confidence
+      that the source is point-like.
+    datatype: double
+  - name: forced_PsfFlux_flag
+    description: Forced PSF photometry on science image failed. Another forced_PsfFlux
+      flag field should also be set to provide more information.
+    datatype: boolean
+    nullable: false
+  - name: forced_PsfFlux_flag_edge
+    description: Forced PSF flux on science image was too close to the edge of the
+      image to use the full PSF model.
+    datatype: boolean
+    nullable: false
+  - name: forced_PsfFlux_flag_noGoodPixels
+    description: Forced PSF flux not enough non-rejected pixels in data to attempt
+      the fit.
+    datatype: boolean
+    nullable: false
+  - name: glint_trail
+    description: This flag is set if the source is part of a glint trail.
+    datatype: boolean
+    nullable: false
+  - name: isDipole
+    description: Source well fit by a dipole.
+    datatype: boolean
+    nullable: false
+  - name: isNegative
+    description: Source was detected as significantly negative.
+    datatype: boolean
+    nullable: false
+  - name: ixx
+    description: Adaptive second moment of the source intensity.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: ixxPSF
+    description: Adaptive second moment for the PSF.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: ixy
+    description: Adaptive second moment of the source intensity.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: ixyPSF
+    description: Adaptive second moment for the PSF.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: iyy
+    description: Adaptive second moment of the source intensity.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: iyyPSF
+    description: Adaptive second moment for the PSF.
+    datatype: double
+    ivoa:unit: nJy.arcsec**2
+  - name: midpointMjdTai
+    description: Effective mid-visit time for this diaSource, expressed as Modified
+      Julian Date, International Atomic Time.
+    datatype: double
+    nullable: false
+    ivoa:ucd: time.epoch
+    ivoa:unit: d
+  - name: parentDiaSourceId
+    description: Id of the parent diaSource this diaSource has been deblended from,
+      if any.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: pixelFlags
+    description: General pixel flags failure; set if anything went wrong when setting
+      pixels flags from this footprint's mask. This implies that some pixelFlags for
+      this source may be incorrectly set to False.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_bad
+    description: Bad pixel in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_cr
+    description: Cosmic ray in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_crCenter
+    description: Cosmic ray in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_edge
+    description: Some of the source footprint is outside usable exposure region (masked
+      EDGE or centroid off image).
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_injected
+    description: Injection in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_injectedCenter
+    description: Injection in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_injected_template
+    description: Template injection in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_injected_templateCenter
+    description: Template injection in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_interpolated
+    description: Interpolated pixel in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_interpolatedCenter
+    description: Interpolated pixel in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_nodata
+    description: NO_DATA pixel in the source footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_nodataCenter
+    description: NO_DATA pixel in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_offimage
+    description: DiaSource center is off image.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_saturated
+    description: Saturated pixel in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_saturatedCenter
+    description: Saturated pixel in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_streak
+    description: Streak in the DiaSource footprint.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_streakCenter
+    description: Streak in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_suspect
+    description: DiaSource's footprint includes suspect pixels.
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_suspectCenter
+    description: Suspect pixel in the 3x3 region around the centroid.
+    datatype: boolean
+    nullable: false
+  - name: psfChi2
+    description: Chi^2 statistic of the point source model fit.
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: psfFlux
+    description: Flux for Point Source model. Note this actually measures the flux
+      difference between the template and the visit image.
+    datatype: float
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: psfFluxErr
+    description: Uncertainty of psfFlux.
+    datatype: float
+    ivoa:unit: nJy
+  - name: psfFlux_flag
+    description: Failure to derive linear least-squares fit of psf model. Another
+      psfFlux flag field should also be set to provide more information.
+    datatype: boolean
+    nullable: false
+  - name: psfFlux_flag_edge
+    description: Object was too close to the edge of the image to use the full PSF
+      model.
+    datatype: boolean
+    nullable: false
+  - name: psfFlux_flag_noGoodPixels
+    description: Not enough non-rejected pixels in data to attempt the fit.
+    datatype: boolean
+    nullable: false
+  - name: psfNdata
+    description: The number of data points (pixels) used to fit the point source model.
+    datatype: int
+    nullable: false
+    ivoa:unit: pixel
+  - name: ra
+    description: Right ascension coordinate of the center of this diaSource.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: raErr
+    description: Error in right ascension.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+  - name: ra_dec_Cov
+    description: Covariance between right ascension and declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+  - name: reliability
+    description: Probability (0-1) that the diaSource is astrophysical, derived from
+      a machine learning model.
+    datatype: float
+  - name: scienceFlux
+    description: Forced photometry flux for a point source model measured on the visit
+      image centered at DiaSource position.
+    datatype: float
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: scienceFluxErr
+    description: Estimated uncertainty of scienceFlux.
+    datatype: float
+    ivoa:ucd: stat.error;phot.count
+    ivoa:unit: nJy
+  - name: shape_flag
+    description: General source shape algorithm failure flag; set if anything went
+      wrong when measuring the shape. Another shape flag field should also be set
+      to provide more information.
+    datatype: boolean
+    nullable: false
+  - name: shape_flag_no_pixels
+    description: No pixels to measure shape.
+    datatype: boolean
+    nullable: false
+  - name: shape_flag_not_contained
+    description: Center not contained in footprint bounding box.
+    datatype: boolean
+    nullable: false
+  - name: shape_flag_parent_source
+    description: This source is a parent source; we should only be measuring on deblended
+      children in difference imaging.
+    datatype: boolean
+    nullable: false
+  - name: snr
+    description: The signal-to-noise ratio at which this source was detected in the
+      difference image. Ratio of apFlux/apFluxErr.
+    datatype: double
+    ivoa:ucd: stat.snr
+  - name: ssObjectId
+    description: Id of the ssObject this source was associated with, if any. If not,
+      it is set to 0
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: templateFlux
+    description: Forced photometry flux for a point source model measured on the template
+      image centered at the DiaSource position.
+    datatype: float
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: templateFluxErr
+    description: Uncertainty of templateFlux.
+    datatype: float
+    ivoa:ucd: stat.error;phot.count
+    ivoa:unit: nJy
+  - name: timeProcessedMjdTai
+    description: Time when the image was processed and this DiaSource record was generated,
+      expressed as Modified Julian Date, International Atomic Time.
+    datatype: double
+    nullable: false
+    ivoa:ucd: time.epoch
+  - name: trailAngle
+    description: Maximum likelihood fit of the angle between the meridian through
+      the centroid and the trail direction (bearing).
+    datatype: double
+    ivoa:unit: deg
+  - name: trailDec
+    description: Declination coordinate of centroid for trailed source model.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: trailFlux
+    description: Flux for a trailed source model. Note this actually measures the
+      flux difference between the template and the visit image.
+    datatype: float
+    ivoa:unit: nJy
+  - name: trailFluxErr
+    description: Uncertainty of trailFlux.
+    datatype: float
+    ivoa:unit: nJy
+  - name: trailLength
+    description: Maximum likelihood fit of trail length.
+    datatype: double
+    ivoa:unit: arcsec
+  - name: trailRa
+    description: Right ascension coordinate of centroid for trailed source model.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: trail_flag_edge
+    description: This flag is set if a trailed source extends onto or past edge pixels.
+    datatype: boolean
+    nullable: false
+  - name: visit
+    description: Id of the visit where this diaSource was measured.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+  - name: x
+    description: Unweighted first moment centroid, overall centroid.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.cartesian.x
+    ivoa:unit: pixel
+  - name: xErr
+    description: 1-sigma uncertainty on x position.
+    datatype: float
+    ivoa:ucd: stat.error;pos.cartesian.x
+    ivoa:unit: pixel
+  - name: y
+    description: Unweighted first moment centroid, overall centroid.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.cartesian.y
+    ivoa:unit: pixel
+  - name: yErr
+    description: 1-sigma uncertainty on y position.
+    datatype: float
+    ivoa:ucd: stat.error;pos.cartesian.y
+    ivoa:unit: pixel
+- name: DiaObject
+  description: Properties of time-varying astronomical objects based on association
+    of data from one or more spatially-related DiaSource detections on individual
+    single-epoch difference images.
+  columns:
+  - name: dec
+    description: Declination coordinate of the position of the DiaObject.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: diaObjectId
+    description: Unique identifier of this DiaObject.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: g_psfFluxErrMean
+    description: Mean of the g band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_psfFluxMax
+    description: Maximum observed g band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: g_psfFluxMaxSlope
+    description: Maximum slope between g band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: g_psfFluxMean
+    description: Weighted mean point-source model magnitude for g filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: g_psfFluxMeanErr
+    description: Standard error of g_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: g_psfFluxMin
+    description: Minimum observed g band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: g_psfFluxNdata
+    description: The number of g-band data points.
+    datatype: int
+    nullable: false
+  - name: g_psfFluxSigma
+    description: Standard deviation of the distribution of g_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: g_scienceFluxMean
+    description: Weighted mean forced photometry flux for g filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: g_scienceFluxMeanErr
+    description: Standard error of g_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: i_psfFluxErrMean
+    description: Mean of the i band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_psfFluxMax
+    description: Maximum observed i band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: i_psfFluxMaxSlope
+    description: Maximum slope between i band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: i_psfFluxMean
+    description: Weighted mean point-source model magnitude for i filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: i_psfFluxMeanErr
+    description: Standard error of i_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: i_psfFluxMin
+    description: Minimum observed i band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: i_psfFluxNdata
+    description: The number of i-band data points.
+    datatype: int
+    nullable: false
+  - name: i_psfFluxSigma
+    description: Standard deviation of the distribution of i_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: i_scienceFluxMean
+    description: Weighted mean forced photometry flux for i filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: i_scienceFluxMeanErr
+    description: Standard error of i_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: nDiaSources
+    description: Total number of DiaSources associated with this DiaObject.
+    datatype: long
+    nullable: false
+  - name: r_psfFluxErrMean
+    description: Mean of the r band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_psfFluxMax
+    description: Maximum observed r band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: r_psfFluxMaxSlope
+    description: Maximum slope between r band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: r_psfFluxMean
+    description: Weighted mean point-source model magnitude for r filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: r_psfFluxMeanErr
+    description: Standard error of r_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: r_psfFluxMin
+    description: Minimum observed r band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: r_psfFluxNdata
+    description: The number of r-band data points.
+    datatype: int
+    nullable: false
+  - name: r_psfFluxSigma
+    description: Standard deviation of the distribution of r_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: r_scienceFluxMean
+    description: Weighted mean forced photometry flux for r filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: r_scienceFluxMeanErr
+    description: Standard error of r_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: ra
+    description: Right Ascension coordinate of the position of the DiaObject.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: u_psfFluxErrMean
+    description: Mean of the u band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: u_psfFluxMax
+    description: Maximum observed u band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: u_psfFluxMaxSlope
+    description: Maximum slope between u band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: u_psfFluxMean
+    description: Weighted mean point-source model magnitude for u filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: u_psfFluxMeanErr
+    description: Standard error of u_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: u_psfFluxMin
+    description: Minimum observed u band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: u_psfFluxNdata
+    description: The number of u-band data points.
+    datatype: int
+    nullable: false
+  - name: u_psfFluxSigma
+    description: Standard deviation of the distribution of u_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: u_scienceFluxMean
+    description: Weighted mean forced photometry flux for u filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: u_scienceFluxMeanErr
+    description: Standard error of u_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: y_psfFluxErrMean
+    description: Mean of the y band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: y_psfFluxMax
+    description: Maximum observed y band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: y_psfFluxMaxSlope
+    description: Maximum slope between y band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: y_psfFluxMean
+    description: Weighted mean point-source model magnitude for y filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: y_psfFluxMeanErr
+    description: Standard error of y_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: y_psfFluxMin
+    description: Minimum observed y band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: y_psfFluxNdata
+    description: The number of y-band data points.
+    datatype: int
+    nullable: false
+  - name: y_psfFluxSigma
+    description: Standard deviation of the distribution of y_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: y_scienceFluxMean
+    description: Weighted mean forced photometry flux for y filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: y_scienceFluxMeanErr
+    description: Standard error of y_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: z_psfFluxErrMean
+    description: Mean of the z band flux errors.
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_psfFluxMax
+    description: Maximum observed z band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: z_psfFluxMaxSlope
+    description: Maximum slope between z band flux obsevations max(delta_flux/delta_time).
+    datatype: double
+    ivoa:unit: nJy/d
+  - name: z_psfFluxMean
+    description: Weighted mean point-source model magnitude for z filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: z_psfFluxMeanErr
+    description: Standard error of z_psfFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+  - name: z_psfFluxMin
+    description: Minimum observed z band fluxes.
+    datatype: double
+    ivoa:unit: nJy
+  - name: z_psfFluxNdata
+    description: The number of z-band data points.
+    datatype: int
+    nullable: false
+  - name: z_psfFluxSigma
+    description: Standard deviation of the distribution of z_psfFlux.
+    datatype: double
+    ivoa:ucd: stat.stdev
+    ivoa:unit: nJy
+  - name: z_scienceFluxMean
+    description: Weighted mean forced photometry flux for z filter.
+    datatype: double
+    ivoa:ucd: phot.count
+    ivoa:unit: nJy
+  - name: z_scienceFluxMeanErr
+    description: Standard error of z_scienceFluxMean.
+    datatype: double
+    ivoa:ucd: stat.error
+    ivoa:unit: nJy
+- name: ForcedSourceOnDiaObject
+  description: Point-source forced-photometry measurements on individual single-epoch
+    visit images and difference images, based on and linked to the entries in the
+    DiaObject table.
+  columns:
+  - name: band
+    description: Abstract filter that is not associated with a particular instrument
+    datatype: char
+    length: 1
+    tap:principal: 1
+  - name: coord_dec
+    description: Fiducial ICRS Declination of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:unit: deg
+  - name: coord_ra
+    description: Fiducial ICRS Right Ascension of centroid used for database indexing
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:unit: deg
+  - name: detector
+    description: Id of the detector where this forced source was measured.
+    datatype: short
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+  - name: diaObjectId
+    description: Id of the DiaObject that this DiaForcedSource was associated with.
+    datatype: long
+    tap:principal: 1
+  - name: diff_PixelFlags_nodataCenter
+    description: Source center is outside usable region on image difference (masked
+      NO_DATA)
+    datatype: boolean
+    nullable: false
+  - name: invalidPsfFlag
+    description: Forced source has an invalid PSF.
+    datatype: boolean
+    nullable: false
+  - name: parentObjectId
+    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
+    datatype: long
+  - name: patch
+    description: Skymap patch ID
+    datatype: long
+  - name: pixelFlags_bad
+    description: Bad pixel in the Source footprint
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_cr
+    description: Cosmic ray in the Source footprint
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_crCenter
+    description: Cosmic ray in the Source center
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_edge
+    description: Source is on the edge of an exposure region (masked EDGE)
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_interpolated
+    description: Interpolated pixel in the Source footprint
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_interpolatedCenter
+    description: Interpolated pixel in the Source center
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_nodata
+    description: Source is outside usable exposure region (masked NO_DATA)
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_saturated
+    description: Saturated pixel in the Source footprint
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_saturatedCenter
+    description: Saturated pixel in the Source center
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_suspect
+    description: Sources footprint includes suspect pixels
+    datatype: boolean
+    nullable: false
+  - name: pixelFlags_suspectCenter
+    description: Sources center is close to suspect pixels
+    datatype: boolean
+    nullable: false
+  - name: psfDiffFlux
+    description: Flux derived from linear least-squares fit of psf model forced on
+      the image difference
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfDiffFluxErr
+    description: Uncertainty on the flux derived from linear least-squares fit of
+      psf model forced on the image difference
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfDiffFlux_flag
+    description: Failure to derive linear least-squares fit of psf model forced on
+      the image difference
+    datatype: boolean
+    nullable: false
+  - name: psfFlux
+    description: Flux derived from linear least-squares fit of psf model forced on
+      the calexp
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfFluxErr
+    description: Uncertainty on the flux derived from linear least-squares fit of
+      psf model forced on the calexp
+    datatype: float
+    ivoa:unit: nJy
+    tap:principal: 1
+  - name: psfFlux_flag
+    description: Failure to derive linear least-squares fit of psf model forced on
+      the calexp
+    datatype: boolean
+    nullable: false
+  - name: tract
+    description: Skymap tract ID
+    datatype: long
+  - name: visit
+    description: Id of the visit where this forced source was measured.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+- name: CoaddPatches
+  description: Static information about the subset of tracts and patches from the
+    standard LSST skymap that apply to coadds in these catalogs
+  columns:
+  - name: lsst_patch
+    description: ID number of the second level, 'patch', within the standard LSST
+      skymap
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id.part;obs.field
+    tap:column_index: 2
+    tap:principal: 1
+  - name: lsst_tract
+    description: ID number of the top level, 'tract', within the standard LSST skymap
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;obs.field
+    tap:column_index: 1
+    tap:principal: 1
+  - name: s_dec
+    description: Central Spatial Position in ICRS; Declination
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+    tap:column_index: 4
+    tap:principal: 1
+    tap:std: 1
+  - name: s_ra
+    description: Central Spatial Position in ICRS; Right ascension
+    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+    tap:column_index: 3
+    tap:principal: 1
+    tap:std: 1
+  - name: s_region
+    description: Sky region covered by the coadd (expressed in ICRS frame)
+    votable:utype: Char.SpatialAxis.Coverage.Support.Area
+    datatype: string
+    length: 512
+    nullable: false
+    ivoa:ucd: pos.outline;obs.field
+    tap:column_index: 5
+    tap:principal: 1
+    votable:arraysize: 512*
+    tap:std: 1
+- name: Visit
+  description: Metadata about the pointings of the telescope, largely associated with
+    the boresight of the LSSTComCam focal plane as a whole.
+  columns:
+  - name: airmass
+    description: Airmass of the observed line of sight.
+    datatype: double
+    tap:principal: 1
+  - name: altitude
+    description: Altitude of focal plane center at the middle of the visit.
+    datatype: double
+    ivoa:unit: deg
+  - name: azimuth
+    description: Azimuth of focal plane center at the middle of the visit.
+    datatype: double
+    ivoa:unit: deg
+  - name: band
+    description: Name of the band used to take the visit where this source was measured.
+      Abstract filter that is not associated with a particular instrument.
+    datatype: char
+    length: 1
+    tap:principal: 1
+    votable:arraysize: '*'
+  - name: dec
+    description: Declination of focal plane center
+    datatype: double
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: expMidpt
+    description: Midpoint time for exposure at the fiducial center of the focal plane
+      array. TAI, accurate to 10ms.
+    datatype: timestamp
+    precision: 6
+    tap:column_index: 6
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: expMidptMJD
+    description: Midpoint time for exposure at the fiducial center of the focal plane
+      array in MJD. TAI, accurate to 10ms.
+    datatype: double
+    ivoa:ucd: time.epoch;obs.exposure
+    ivoa:unit: d
+    tap:column_index: 5
+    tap:principal: 1
+  - name: expTime
+    description: Spatially-averaged duration of visit, accurate to 10ms.
+    datatype: double
+    ivoa:unit: s
+    tap:principal: 1
+  - name: obsStart
+    description: Start time of the visit at the fiducial center of the focal plane
+      array, TAI, accurate to 10ms.
+    datatype: timestamp
+    precision: 6
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: obsStartMJD
+    description: Start of the exposure in MJD, TAI, accurate to 10ms.
+    datatype: double
+    ivoa:ucd: time.start;obs.exposure
+    ivoa:unit: d
+    tap:column_index: 7
+  - name: physical_filter
+    description: ID of physical filter, the filter associated with a particular instrument.
+    datatype: char
+    length: 32
+    votable:arraysize: '*'
+  - name: ra
+    description: Right Ascension of focal plane center.
+    datatype: double
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: skyRotation
+    description: Sky rotation angle.
+    datatype: double
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: visit
+    description: Unique identifier.
+    datatype: long
+    ivoa:ucd: meta.id;obs.image
+    tap:principal: 1
+  - name: zenithDistance
+    description: Zenith distance at the middle of the visit.
+    datatype: double
+    ivoa:unit: deg
+- name: VisitDetector
+  description: Per-detector metadata and metrics associated with each visit
+  columns:
+  - name: astromOffsetMean
+    description: Mean offset of astrometric calibration matches (arcsec)
+    datatype: double
+    ivoa:unit: arcsec
+  - name: astromOffsetStd
+    description: Standard deviation of offsets of astrometric calibration matches
+      (arcsec)
+    datatype: double
+    ivoa:unit: arcsec
+  - name: band
+    description: Name of the band used to take the visit where this source was measured.
+      Abstract filter that is not associated with a particular instrument.
+    datatype: char
+    length: 1
+    tap:principal: 1
+    votable:arraysize: '*'
+  - name: centroidDiffShapeletsVsSlotMedian
+    description: Median centroid difference (sqrt((slot_x - shapelet_x)**2 + (slot_y
+      - shapelet_y)**2)) for sources used in the shapelet decomposition.
+    datatype: double
+    ivoa:unit: pixel
+  - name: darkTime
+    description: Average dark current accumulation time, accurate to 10ms.
+    datatype: double
+    ivoa:unit: s
+  - name: dec
+    description: Declination of Ccd center.
+    datatype: double
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: detector
+    description: Detector ID. A detector associated with a particular instrument (not
+      an observation of that detector).
+    datatype: long
+    tap:principal: 1
+  - name: effTime
+    description: Effective time metric
+    datatype: double
+    ivoa:unit: s
+  - name: effTimePsfSigmaScale
+    description: Effective time metric -- PSF size component
+    datatype: double
+  - name: effTimeSkyBgScale
+    description: Effective time metric -- Sky background component
+    datatype: double
+  - name: effTimeZeroPointScale
+    description: Effective time metric -- Throughput component
+    datatype: double
+  - name: expMidpt
+    description: Midpoint time for exposure at the fiducial center of the focal plane
+      array. TAI, accurate to 10ms.
+    datatype: timestamp
+    precision: 6
+    tap:column_index: 6
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: expMidptMJD
+    description: Midpoint time for exposure at the fiducial center of the focal plane
+      array in MJD. TAI, accurate to 10ms.
+    datatype: double
+    ivoa:ucd: time.epoch;obs.exposure
+    ivoa:unit: d
+    tap:column_index: 5
+    tap:principal: 1
+  - name: expTime
+    description: Spatially-averaged duration of visit, accurate to 10ms.
+    datatype: double
+    ivoa:unit: s
+    tap:principal: 1
+  - name: llcdec
+    description: Declination of lower left corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: llcra
+    description: Right Ascension of lower left corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: lrcdec
+    description: Declination of lower right corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: lrcra
+    description: Right Ascension of lower right corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: magLim
+    description: 5-sigma limiting magnitude
+    datatype: double
+    ivoa:unit: mag
+    tap:principal: 1
+  - name: maxDistToNearestPsf
+    description: Maximum distance of an unmasked pixel to its nearest model psf star
+      (pixel)
+    datatype: double
+    ivoa:unit: pixel
+  - name: nPsfStar
+    description: Number of stars used for PSF model
+    datatype: int
+  - name: nShapeletsStar
+    description: Number of sources used in the shapelet decomposition.
+    datatype: int
+  - name: obsStart
+    description: Start of the visit, TAI, accurate to 10ms.
+    datatype: timestamp
+    precision: 6
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: obsStartMJD
+    description: Start of the exposure in MJD, TAI, accurate to 10ms.
+    datatype: double
+    ivoa:ucd: time.start;obs.exposure
+    ivoa:unit: d
+    tap:column_index: 7
+  - name: physical_filter
+    description: ID of physical filter, the filter associated with a particular instrument.
+    datatype: char
+    length: 32
+    votable:arraysize: '*'
+  - name: pixelScale
+    description: Measured detector pixel scale.
+    datatype: float
+    ivoa:unit: arcsec/pixel
+  - name: psfAdaptiveIncludeThresholdMultiplier
+    description: Threshold multiplier used in the adaptive threshold detection pass
+      for PSF modelling.
+    datatype: double
+  - name: psfAdaptiveThresholdValue
+    description: Threshold value used in the adaptive threshold detection pass for
+      PSF modelling.
+    datatype: double
+  - name: psfApCorrSigmaScaledDelta
+    description: Delta (max - min) of psf flux aperture correction factors scaled
+      (divided) by the psfSigma evaluated on a grid of unmasked pixels
+    datatype: double
+  - name: psfApFluxDelta
+    description: Delta (max - min) of model psf aperture flux (with aperture radius
+      of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels
+    datatype: double
+  - name: psfSigma
+    description: PSF model second-moments determinant radius (center of chip)
+    datatype: float
+    ivoa:unit: pixel
+    tap:principal: 1
+  - name: psfStarDeltaE1Median
+    description: Median E1 residual (starE1 - psfE1) for psf stars
+    datatype: double
+  - name: psfStarDeltaE1Scatter
+    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for psf stars
+    datatype: double
+  - name: psfStarDeltaE2Median
+    description: Median E2 residual (starE2 - psfE2) for psf stars
+    datatype: double
+  - name: psfStarDeltaE2Scatter
+    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for psf stars
+    datatype: double
+  - name: psfStarDeltaSizeMedian
+    description: Median size residual (starSize - psfSize) for psf stars (pixel)
+    datatype: double
+    ivoa:unit: pixel
+  - name: psfStarDeltaSizeScatter
+    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars
+      (pixel)
+    datatype: double
+    ivoa:unit: pixel
+  - name: psfStarScaledDeltaSizeScatter
+    description: Scatter (via MAD) of size residual scaled by median size squared
+    datatype: double
+  - name: psfTraceRadiusDelta
+    description: Delta (max - min) of model psf trace radius values evaluated on a
+      grid of unmasked pixels (pixel)
+    datatype: double
+    ivoa:unit: pixel
+  - name: ra
+    description: Right Ascension of Ccd center.
+    datatype: double
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: refCatSourceDensity
+    description: Source density for the detector region as computed from the loaded
+      reference catalog (number per degrees**2)
+    datatype: float
+    ivoa:unit: count/deg**2
+  - name: seeing
+    description: Mean measured FWHM of the PSF.
+    datatype: double
+    ivoa:unit: arcsec
+    tap:principal: 1
+  - name: shapeletsIqScore
+    description: The dimensionless image quality score as determined from the shapelets
+      decomposition that includes power from the median centroid offset between those
+      used in the decomposition and those of the centroid slot in addition to non-atmospheric
+      decomposition coefficients. The score spans the range [0.0, 1.0] with lower
+      values indicating better image quality.
+    datatype: double
+  - name: shapeletsOnlyIqScore
+    description: The dimensionless image quality score as determined from the shapelets
+      decomposition that includes power only from the non-atmospheric decomposition
+      coefficients. The score spans the range [0.0, 1.0] with lower values indicating
+      better image quality.
+    datatype: double
+  - name: shapeletsStarEMedian
+    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the sources
+      used in the shapelet decomposition.
+    datatype: double
+  - name: shapeletsStarUnNormalizedEMedian
+    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
+      of the sources used in the shapelet decomposition.
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: skyBg
+    description: Average sky background.
+    datatype: float
+    ivoa:unit: adu
+  - name: skyNoise
+    description: RMS noise of the sky background.
+    datatype: float
+    ivoa:unit: adu
+  - name: skyRotation
+    description: Sky rotation angle.
+    datatype: double
+    ivoa:unit: deg
+  - name: starComa1Median
+    description: Coma-like higher-order moment combination (median M30 + M12 of the
+      stars used in the PSF model)
+    datatype: double
+  - name: starComa2Median
+    description: Coma-like higher-order moment combination (median M21 + M03 of the
+      stars used in the PSF model)
+    datatype: double
+  - name: starE41Median
+    description: Fourth-order ellipticity-like higher-order moment combination (median
+      M40 - M04 of the stars used in the PSF model)
+    datatype: double
+  - name: starE42Median
+    description: Fourth-order ellipticity-like higher-order moment combination (median
+      2*(M31 + M13) of the stars used in the PSF model)
+    datatype: double
+  - name: starEMedian
+    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the stars
+      used in the PSF model.
+    datatype: double
+  - name: starKurtosisMedian
+    description: Kurtosis-like higher-order moment combination (median M40 + 2*M22
+      + M04 of the stars used in the PSF model)
+    datatype: double
+  - name: starTrefoil1Median
+    description: Trefoil-like higher-order moment combination (median M30 - 3*M12
+      of the stars used in the PSF model)
+    datatype: double
+  - name: starTrefoil2Median
+    description: Trefoil-like higher-order moment combination (median 3*M21 - M03
+      of the stars used in the PSF model)
+    datatype: double
+  - name: starUnNormalizedEMedian
+    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
+      of the stars used in the PSF model.
+    datatype: double
+    ivoa:unit: pixel**2
+  - name: ulcdec
+    description: Declination of upper left corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: ulcra
+    description: Right Ascension of upper left corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: urcdec
+    description: Declination of upper right corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: urcra
+    description: Right Ascension of upper right corner.
+    datatype: double
+    ivoa:unit: deg
+  - name: visitId
+    description: Reference to the corresponding entry in the Visit table.
+    datatype: long
+    ivoa:ucd: meta.id.parent;obs
+    tap:column_index: 2
+    tap:principal: 1
+  - name: wcsCornerMaxOffset
+    description: Maximum distance between the preliminary and final WCS at the corners
+      of the detector. The WCS is set to null if this exceeds 0.5".
+    datatype: double
+    ivoa:unit: arcsec
+  - name: wcsDetectorPointingResidual
+    description: Maximum difference (on the pointing-fit grid) between the final WCS
+      position and the position predicted by camera geometry, after re-pointing using
+      the final WCS for this detector only.  The detector is rejected from the pointing
+      fit if this exceeds 10".
+    datatype: double
+    ivoa:unit: arcsec
+  - name: wcsPreliminaryDetectorPointingResidual
+    description: Maximum difference (on the pointing-fit grid) between the preliminary
+      WCS position and the position predicted by camera geometry, after re-pointing
+      using the prelimnary WCS for this detector only.  The detector is rejected from
+      the pointing fit if this exceeds 10".
+    datatype: double
+    ivoa:unit: arcsec
+  - name: wcsPreliminaryVisitPointingResidual
+    description: Maximum difference (on the pointing-fit grid) between the preliminary
+      WCS position and the position predicted by camera geometry, after re-pointing
+      using the preliminary WCS of all non-rejected detectors in the visit. The WCS
+      is set to null if this exceeds 60".
+    datatype: double
+    ivoa:unit: arcsec
+  - name: wcsVisitPointingResidual
+    description: Maximum difference (on the pointing-fit grid) between the final WCS
+      position and the position predicted by camera geometry, after re-pointing using
+      the final WCS of all non-rejected detectors in the visit. The WCS is set to
+      null if this exceeds 60".
+    datatype: double
+    ivoa:unit: arcsec
+  - name: xSize
+    description: Number of columns in the image.
+    datatype: long
+    ivoa:unit: pixel
+  - name: ySize
+    description: Number of rows in the image.
+    datatype: long
+    ivoa:unit: pixel
+  - name: zenithDistance
+    description: Zenith distance at observation mid-point.
+    datatype: float
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: zeroPoint
+    description: Zero-point for the Ccd, estimated at Ccd center.
+    datatype: float
+    ivoa:unit: mag
+- name: SSObject
+  description: LSST-computed per-object quantities.
+  columns:
+  - name: MOIDEarth
+    description: Minimum orbit intersection distance to Earth.
+    datatype: float
+    ivoa:ucd: pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: MOIDEarthDeltaV
+    description: DeltaV at the MOID point.
+    datatype: float
+    ivoa:ucd: phys.veloc.orbital
+    ivoa:unit: km/s
+  - name: MOIDEarthEclipticLongitude
+    description: Ecliptic longitude of the MOID point (Earth's orbit).
+    datatype: float
+    ivoa:ucd: pos.ecliptic.lon
+    ivoa:unit: deg
+  - name: MOIDEarthTrueAnomaly
+    description: True anomaly of the MOID point on Earth's orbit.
+    datatype: float
+    ivoa:ucd: pos.phaseAng
+    ivoa:unit: deg
+  - name: MOIDEarthTrueAnomalyObject
+    description: True anomaly of the MOID point on the object's orbit.
+    datatype: float
+    ivoa:ucd: pos.phaseAng;src.orbital
+    ivoa:unit: deg
+  - name: arc
+    description: Timespan ("arc") of all LSST observations, t_{last} - t_{first}
+    datatype: float
+    nullable: false
+    ivoa:ucd: time.duration;obs
+    ivoa:unit: d
+  - name: designation
+    description: The unpacked primary provisional designation for this object.
+    datatype: char
+    length: 16
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: extendednessMax
+    description: Maximum `extendedness` value from the DiaSource.
+    datatype: float
+  - name: extendednessMedian
+    description: Median `extendedness` value from the DiaSource.
+    datatype: float
+  - name: extendednessMin
+    description: Minimum `extendedness` value from the DiaSource.
+    datatype: float
+  - name: firstObservationMjdTai
+    description: The time of the first LSST observation of this object (could be precovered),
+      TAI.
+    datatype: double
+    ivoa:ucd: time.epoch;obs
+    ivoa:unit: d
+  - name: g_Chi2
+    description: Chi^2 statistic of the phase curve fit (g band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: g_G12
+    description: Best fit G12 slope parameter (g band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: g_G12Err
+    description: Error in the estimate of G12 (g band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: g_H
+    description: Best fit absolute magnitude (g band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: g_HErr
+    description: Error in the estimate of H (g band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: g_H_g_G12_Cov
+    description: "H\u2013G12 covariance (g band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: g_nObs
+    description: Total number of data points (g band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: g_nObsUsed
+    description: The number of data points used to fit the phase curve (g band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: g_phaseAngleMax
+    description: Maximum phase angle observed (g band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: g_phaseAngleMin
+    description: Minimum phase angle observed (g band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: g_slope_fit_failed
+    description: G12 fit failed in g band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+  - name: i_Chi2
+    description: Chi^2 statistic of the phase curve fit (i band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: i_G12
+    description: Best fit G12 slope parameter (i band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: i_G12Err
+    description: Error in the estimate of G12 (i band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: i_H
+    description: Best fit absolute magnitude (i band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: i_HErr
+    description: Error in the estimate of H (i band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: i_H_i_G12_Cov
+    description: "H\u2013G12 covariance (i band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: i_nObs
+    description: Total number of data points (i band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: i_nObsUsed
+    description: The number of data points used to fit the phase curve (i band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: i_phaseAngleMax
+    description: Maximum phase angle observed (i band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: i_phaseAngleMin
+    description: Minimum phase angle observed (i band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: i_slope_fit_failed
+    description: G12 fit failed in i band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+  - name: nObs
+    description: Total number of LSST observations of this object.
+    datatype: int
+    nullable: false
+    ivoa:ucd: meta.number;obs
+  - name: r_Chi2
+    description: Chi^2 statistic of the phase curve fit (r band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: r_G12
+    description: Best fit G12 slope parameter (r band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: r_G12Err
+    description: Error in the estimate of G12 (r band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: r_H
+    description: Best fit absolute magnitude (r band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: r_HErr
+    description: Error in the estimate of H (r band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: r_H_r_G12_Cov
+    description: "H\u2013G12 covariance (r band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: r_nObs
+    description: Total number of data points (r band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: r_nObsUsed
+    description: The number of data points used to fit the phase curve (r band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: r_phaseAngleMax
+    description: Maximum phase angle observed (r band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: r_phaseAngleMin
+    description: Minimum phase angle observed (r band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: r_slope_fit_failed
+    description: G12 fit failed in r band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+  - name: ssObjectId
+    description: Unique identifier.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: tisserand_J
+    description: Tisserand parameter with respect to Jupiter (T_J).
+    datatype: float
+    ivoa:ucd: src.orbital.TissJ
+  - name: u_Chi2
+    description: Chi^2 statistic of the phase curve fit (u band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: u_G12
+    description: Best fit G12 slope parameter (u band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: u_G12Err
+    description: Error in the estimate of G12 (u band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: u_H
+    description: Best fit absolute magnitude (u band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: u_HErr
+    description: Error in the estimate of H (u band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: u_H_u_G12_Cov
+    description: "H\u2013G12 covariance (u band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: u_nObs
+    description: Total number of data points (u band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: u_nObsUsed
+    description: The number of data points used to fit the phase curve (u band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: u_phaseAngleMax
+    description: Maximum phase angle observed (u band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: u_phaseAngleMin
+    description: Minimum phase angle observed (u band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: u_slope_fit_failed
+    description: G12 fit failed in u band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+  - name: y_Chi2
+    description: Chi^2 statistic of the phase curve fit (y band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: y_G12
+    description: Best fit G12 slope parameter (y band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: y_G12Err
+    description: Error in the estimate of G12 (y band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: y_H
+    description: Best fit absolute magnitude (y band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: y_HErr
+    description: Error in the estimate of H (y band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: y_H_y_G12_Cov
+    description: "H\u2013G12 covariance (y band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: y_nObs
+    description: Total number of data points (y band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: y_nObsUsed
+    description: The number of data points used to fit the phase curve (y band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: y_phaseAngleMax
+    description: Maximum phase angle observed (y band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: y_phaseAngleMin
+    description: Minimum phase angle observed (y band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: y_slope_fit_failed
+    description: G12 fit failed in y band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+  - name: z_Chi2
+    description: Chi^2 statistic of the phase curve fit (z band).
+    datatype: float
+    ivoa:ucd: stat.fit.chi2
+  - name: z_G12
+    description: Best fit G12 slope parameter (z band).
+    datatype: float
+    ivoa:ucd: stat.fit.param
+  - name: z_G12Err
+    description: Error in the estimate of G12 (z band).
+    datatype: float
+    ivoa:ucd: stat.error;stat.fit.param
+  - name: z_H
+    description: Best fit absolute magnitude (z band).
+    datatype: float
+    ivoa:ucd: phot.mag
+    ivoa:unit: mag
+  - name: z_HErr
+    description: Error in the estimate of H (z band).
+    datatype: float
+    ivoa:ucd: stat.error;phot.mag
+    ivoa:unit: mag
+  - name: z_H_z_G12_Cov
+    description: "H\u2013G12 covariance (z band)."
+    datatype: float
+    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
+    ivoa:unit: mag**2
+  - name: z_nObs
+    description: Total number of data points (z band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: z_nObsUsed
+    description: The number of data points used to fit the phase curve (z band).
+    datatype: int
+    ivoa:ucd: meta.number;obs
+  - name: z_phaseAngleMax
+    description: Maximum phase angle observed (z band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.max
+    ivoa:unit: deg
+  - name: z_phaseAngleMin
+    description: Minimum phase angle observed (z band).
+    datatype: float
+    ivoa:ucd: pos.phaseAng;stat.min
+    ivoa:unit: deg
+  - name: z_slope_fit_failed
+    description: G12 fit failed in z band. G12 contains a fiducial value used to fit
+      H.
+    datatype: boolean
+- name: SSSource
+  description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
+  columns:
+  - name: designation
+    description: The unpacked primary provisional designation for this object.
+    datatype: char
+    length: 16
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: diaDistanceRank
+    description: The rank of the diaSourceId-identified source in terms of its closeness
+      to the predicted SSO position.  If diaSourceId is the nearest DiaSource to this
+      SSO prediction, diaSourceDistanceRank=1 would be set. If it is the second nearest,
+      it would be 2, etc.
+    datatype: short
+  - name: diaSourceId
+    description: Unique identifier of the observation (matching DiaSource.diaSourceId).
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: eclBeta
+    description: Ecliptic latitude, converted from the observed coordinates.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.ecliptic.lat
+    ivoa:unit: deg
+  - name: eclLambda
+    description: Ecliptic longitude, converted from the observed coordinates.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.ecliptic.lon
+    ivoa:unit: deg
+  - name: elongation
+    description: Solar elongation of the object at the time of observation.
+    datatype: float
+    ivoa:ucd: pos.phaseAng
+    ivoa:unit: deg
+  - name: ephDec
+    description: Predicted ICRS declination from the orbit in mpc_orbits.
+    datatype: double
+    ivoa:ucd: pos.eq.dec;meta.modelled;pos.ephem
+    ivoa:unit: deg
+  - name: ephOffset
+    description: Total observed versus predicted angular separation on the sky.
+    datatype: float
+    ivoa:ucd: pos.angDistance;stat.fit.omc
+    ivoa:unit: arcsec
+  - name: ephOffsetAlongTrack
+    description: Offset between observed and predicted position in the along-track
+      direction on the sky.
+    datatype: float
+    ivoa:ucd: pos.angDistance;stat.fit.omc
+    ivoa:unit: arcsec
+  - name: ephOffsetCrossTrack
+    description: Offset between observed and predicted position in the cross-track
+      direction on the sky.
+    datatype: float
+    ivoa:ucd: pos.angDistance;stat.fit.omc
+    ivoa:unit: arcsec
+  - name: ephOffsetDec
+    description: Offset between observed and predicted position in declination.
+    datatype: double
+    ivoa:ucd: pos.eq.dec;stat.fit.omc
+    ivoa:unit: arcsec
+  - name: ephOffsetRa
+    description: Offset between observed and predicted position in the R.A. direction
+      (includes cos(dec) term).
+    datatype: double
+    ivoa:ucd: pos.eq.ra;stat.fit.omc
+    ivoa:unit: arcsec
+  - name: ephRa
+    description: Predicted ICRS right ascension from the orbit in mpc_orbits.
+    datatype: double
+    ivoa:ucd: pos.eq.ra;meta.modelled;pos.ephem
+    ivoa:unit: deg
+  - name: ephRate
+    description: Total predicted on-sky angular rate of motion.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.ephem
+    ivoa:unit: deg/d
+  - name: ephRateDec
+    description: Predicted on-sky angular rate in the declination direction.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.dec;pos.ephem
+    ivoa:unit: deg/d
+  - name: ephRateRa
+    description: Predicted on-sky angular rate in the R.A. direction (includes the
+      cos(dec) factor).
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.ra;pos.ephem
+    ivoa:unit: deg/d
+  - name: ephVmag
+    description: Predicted magnitude in V band, computed from mpc_orbits data including
+      the mpc_orbits-provided (H, G) estimates
+    datatype: float
+    ivoa:ucd: phot.mag;em.opt.V
+    ivoa:unit: mag
+  - name: galLat
+    description: Galactic latitude, converted from the observed coordinates.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.galactic.lat
+    ivoa:unit: deg
+  - name: galLon
+    description: Galactic longitude, converted from the observed coordinates.
+    datatype: double
+    nullable: false
+    ivoa:ucd: pos.galactic.lon
+    ivoa:unit: deg
+  - name: helioRange
+    description: Heliocentric distance (r) at light-emission time.
+    datatype: float
+    ivoa:ucd: pos.distance;pos.heliocentric
+    ivoa:unit: AU
+  - name: helioRangeRate
+    description: Heliocentric radial velocity (rdot); positive values indicate motion
+      away from the Sun.
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.heliocentric
+    ivoa:unit: km/s
+  - name: helio_vtot
+    description: The magnitude of the heliocentric velocity vector, sqrt(vx*vx + vy*vy
+      + vz*vz).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.heliocentric
+    ivoa:unit: km/s
+  - name: helio_vx
+    description: Cartesian heliocentric X velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.x
+    ivoa:unit: km/s
+  - name: helio_vy
+    description: Cartesian heliocentric Y velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.y
+    ivoa:unit: km/s
+  - name: helio_vz
+    description: Cartesian heliocentric Z velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.z
+    ivoa:unit: km/s
+  - name: helio_x
+    description: Cartesian heliocentric X coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.x;pos.heliocentric
+    ivoa:unit: AU
+  - name: helio_y
+    description: Cartesian heliocentric Y coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.y;pos.heliocentric
+    ivoa:unit: AU
+  - name: helio_z
+    description: Cartesian heliocentric Z coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.z;pos.heliocentric
+    ivoa:unit: AU
+  - name: phaseAngle
+    description: Phase angle between the Sun, object, and observer.
+    datatype: float
+    ivoa:ucd: pos.phaseAng
+    ivoa:unit: deg
+  - name: ssObjectId
+    description: Unique LSST identifier of the Solar System object.
+    datatype: long
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: topoRange
+    description: Topocentric distance (delta) at light-emission time.
+    datatype: float
+    ivoa:ucd: pos.distance
+    ivoa:unit: AU
+  - name: topoRangeRate
+    description: Topocentric radial (line-of-sight) velocity (deldot); positive values
+      indicate motion away from the observer.
+    datatype: float
+    ivoa:ucd: phys.veloc
+    ivoa:unit: km/s
+  - name: topo_vtot
+    description: The magnitude of the topocentric velocity vector, sqrt(vx*vx + vy*vy
+      + vz*vz).
+    datatype: float
+    ivoa:ucd: phys.veloc
+    ivoa:unit: km/s
+  - name: topo_vx
+    description: Cartesian topocentric X velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.x
+    ivoa:unit: km/s
+  - name: topo_vy
+    description: Cartesian topocentric Y velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.y
+    ivoa:unit: km/s
+  - name: topo_vz
+    description: Cartesian topocentric Z velocity at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: phys.veloc;pos.cartesian.z
+    ivoa:unit: km/s
+  - name: topo_x
+    description: Cartesian topocentric X coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.x
+    ivoa:unit: AU
+  - name: topo_y
+    description: Cartesian topocentric Y coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.y
+    ivoa:unit: AU
+  - name: topo_z
+    description: Cartesian topocentric Z coordinate at light-emission time (ICRS).
+    datatype: float
+    ivoa:ucd: pos.cartesian.z
+    ivoa:unit: AU
+- name: mpc_orbits
+  description: Table of orbital elements and related information of known (sun-orbiting
+    and unbound) Solar System objects. Replicated from the Minor Planet Center (Postgres)
+    database. This schema will generally closely follow the schema of the upstream
+    table, to allow end-users to rerun queries developed elsewhere on the RSP.
+  columns:
+  - name: a
+    description: Semi Major Axis [au]
+    datatype: double
+    ivoa:ucd: pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: a1
+    description: A1 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a1_unc
+    description: Uncertainty on A1 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a2
+    description: A2 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a2_unc
+    description: Uncertainty on A2 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a3
+    description: A3 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a3_unc
+    description: Uncertainty on A3 non-grav components [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: a_unc
+    description: Uncertainty on Semi Major Axis [au]
+    datatype: double
+    ivoa:ucd: stat.error;pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: arc_length_sel
+    description: Arc length over total observations *selected* [days]
+    datatype: double
+    ivoa:unit: d
+  - name: arc_length_total
+    description: Arc length over total observations [days]
+    datatype: double
+    ivoa:unit: d
+  - name: argperi
+    description: Argument of Pericenter [degrees]
+    datatype: double
+    ivoa:ucd: src.orbital.periastron
+    ivoa:unit: deg
+  - name: argperi_unc
+    description: Uncertainty on Argument of Pericenter [degrees]
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.periastron
+    ivoa:unit: deg
+  - name: created_at
+    description: When this row was created
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.creation;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: designation
+    description: The primary provisional designation in unpacked form (e.g. 2008 AB).
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: dt
+    description: DT non-grav component
+    datatype: double
+  - name: dt_unc
+    description: Uncertainty on DT non-grav component
+    datatype: double
+  - name: e
+    description: Eccentricity
+    datatype: double
+    ivoa:ucd: src.orbital.eccentricity
+  - name: e_unc
+    description: Uncertainty on Eccentricity
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.eccentricity
+  - name: earth_moid
+    description: Minimum Orbit Intersection Distance [au] with respect to the Earths
+      Orbit
+    datatype: double
+    ivoa:ucd: pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: epoch_mjd
+    description: Epoch of the Orbfit-Solution in MJD
+    datatype: double
+    ivoa:ucd: time.epoch;src.orbital
+    ivoa:unit: d
+  - name: fitting_datetime
+    description: Date of the last orbit fit
+    datatype: timestamp
+    precision: 6
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: g
+    description: G-Slope Parameter
+    datatype: double
+  - name: h
+    description: H-Magnitude
+    datatype: double
+    ivoa:ucd: phys.magAbs
+    ivoa:unit: mag
+  - name: i
+    description: Inclination [degrees]
+    datatype: double
+    ivoa:ucd: src.orbital.inclination
+    ivoa:unit: deg
+  - name: i_unc
+    description: Uncertainty on Inclination [degrees]
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.inclination
+    ivoa:unit: deg
+  - name: id
+    description: Internal ID (generally not seen/used by the user)
+    datatype: int
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: mean_anomaly
+    description: Mean Anomaly [degrees]
+    datatype: double
+    ivoa:ucd: src.orbital.meanAnomaly
+    ivoa:unit: deg
+  - name: mean_anomaly_unc
+    description: Uncertainty on Mean Anomaly [degrees]
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.meanAnomaly
+    ivoa:unit: deg
+  - name: mean_motion
+    description: Orbital Mean Motion [degrees per day]
+    datatype: double
+    ivoa:ucd: src.orbital.meanMotion
+    ivoa:unit: deg.d-1
+  - name: mean_motion_unc
+    description: Uncertainty on Orbital Mean Motion [degrees per day]
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.meanMotion
+    ivoa:unit: deg.d-1
+  - name: mpc_orb_jsonb
+    description: Details of the orbit solution in JSON form
+    datatype: text
+    votable:arraysize: '*'
+  - name: nobs_total
+    description: Total number of all observations (optical + radar) available
+    datatype: int
+  - name: nobs_total_sel
+    description: Total number of all observations (optical + radar) selected for use
+      in orbit fitting
+    datatype: int
+  - name: node
+    description: Longitude of Ascending Node [degrees]
+    datatype: double
+    ivoa:ucd: src.orbital.node
+    ivoa:unit: deg
+  - name: node_unc
+    description: Uncertainty on Longitude of Ascending Node [degrees]
+    datatype: double
+    ivoa:ucd: stat.error;src.orbital.node
+    ivoa:unit: deg
+  - name: nopp
+    description: number of oppositions
+    datatype: int
+  - name: normalized_rms
+    description: rms of the fit [unitless]
+    datatype: double
+    ivoa:ucd: stat.rms;stat.fit
+  - name: not_normalized_rms
+    description: unnormalized rms of the fit [arcsec]
+    datatype: double
+    ivoa:ucd: stat.rms;stat.fit
+    ivoa:unit: arcsec
+  - name: orbit_type_int
+    description: Orbit Type (Integer)
+    datatype: int
+  - name: packed_primary_provisional_designation
+    description: The primary provisional designation in packed form (e.g. K08A00B)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: peri_time
+    description: Time from Pericenter Passage [days]
+    datatype: double
+    ivoa:unit: d
+  - name: peri_time_unc
+    description: Uncertainty on Time from Pericenter Passage [days]
+    datatype: double
+    ivoa:unit: d
+  - name: period
+    description: Orbital Period [days]
+    datatype: double
+    ivoa:ucd: time.period.revolution;src.orbital
+    ivoa:unit: d
+  - name: period_unc
+    description: Uncertainty on Orbital Period [days]
+    datatype: double
+    ivoa:ucd: stat.error;time.period.revolution;src.orbital
+    ivoa:unit: d
+  - name: q
+    description: Pericenter Distance [au]
+    datatype: double
+    ivoa:ucd: pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: q_unc
+    description: Uncertainty on Pericenter Distance [au]
+    datatype: double
+    ivoa:ucd: stat.error;pos.distance;src.orbital
+    ivoa:unit: AU
+  - name: srp
+    description: Solar-Radiation Pressure Component [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: srp_unc
+    description: Uncertainty on Solar-Radiation Pressure Component [m^2/ton]
+    datatype: double
+    ivoa:unit: m2.t-1
+  - name: u_param
+    description: U parameter
+    datatype: int
+  - name: unpacked_primary_provisional_designation
+    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: updated_at
+    description: When this row was updated
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.processing;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: yarkovsky
+    description: Yarkovsky Component [10^(-10)*au/day^2]
+    datatype: double
+    ivoa:unit: 1e-10.au.d-2
+  - name: yarkovsky_unc
+    description: Uncertainty on Yarkovsky Component [10^(-10)*au/day^2]
+    datatype: double
+    ivoa:unit: 1e-10.au.d-2
+- name: current_identifications
+  description: All single-designations, and all identifications between designations.
+    Always uses primary provisional designation (even for numbered objects). Includes
+    all comets and satellites. Replicated from the Minor Planet Center (Postgres)
+    database. This schema will generally closely follow the schema of the upstream
+    table, to allow end-users to rerun queries developed elsewhere on the RSP.
+  columns:
+  - name: created_at
+    description: When this row was created
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.creation;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: id
+    description: Internal ID (generally not seen/used by the user)
+    datatype: int
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: identifier_ids
+    description: This is a set of unique identifier_ids in an array that points to
+      the identification_metadata table.
+    datatype: text
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '*'
+  - name: numbered
+    description: Has the object been numbered and hence does it appear in the numbered_objects
+      table?
+    datatype: boolean
+  - name: object_type
+    description: Integer to indicate the object type. To be linked (foreign key) to
+      object_type lookup table
+    datatype: int
+  - name: packed_primary_provisional_designation
+    description: The primary provisional designation in packed form (e.g. K08A00B)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: packed_secondary_provisional_designation
+    description: The secondary provisional designation in packed form (e.g. K08A00B).
+      May be the same-as (A=A) or different-to (A=B) the primary provisional designation
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: published
+    description: Has this been published yet? i.e. has it been released to the public?
+    datatype: boolean
+    ivoa:ucd: meta.code.status;meta.dataset
+  - name: unpacked_primary_provisional_designation
+    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: unpacked_secondary_provisional_designation
+    description: The secondary provisional designation in unpacked form (e.g. 2008
+      AB). May be the same-as (A=A) or different-to (A=B) the primary provisional
+      designation
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: updated_at
+    description: When this row was updated
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.processing;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+- name: numbered_identifications
+  description: The numbered identification table contains all the numbered objects
+    (minor planets, comets and natural satellites) with their primary provisional
+    designations. The table is continously updated everytime a new object is numbered.
+    Replicated from the Minor Planet Center (Postgres) database. This schema will
+    generally closely follow the schema of the upstream table, to allow end-users
+    to rerun queries developed elsewhere on the RSP.
+  columns:
+  - name: created_at
+    description: When this row was created
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.creation;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+  - name: iau_designation
+    description: IAU-approved designation (not filled at the moment)
+    datatype: text
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '*'
+  - name: iau_name
+    description: IAU-approved name (not filled at the moment)
+    datatype: char
+    length: 32
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '32'
+  - name: id
+    description: Internal ID (generally not seen/used by the user)
+    datatype: int
+    nullable: false
+    ivoa:ucd: meta.id;src
+  - name: named_publication_references
+    description: MPEC where this object was named
+    datatype: text
+    ivoa:ucd: meta.bib.bibcode
+    votable:arraysize: '*'
+  - name: naming_credit
+    description: Credit for suggesting the name
+    datatype: text
+    votable:arraysize: '*'
+  - name: numbered_publication_references
+    description: MPEC where this object was numbered
+    datatype: text
+    ivoa:ucd: meta.bib.bibcode
+    votable:arraysize: '*'
+  - name: packed_primary_provisional_designation
+    description: The primary provisional designation in packed form (e.g. K08A00B)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: permid
+    description: Permanent designation (number)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: unpacked_primary_provisional_designation
+    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
+    datatype: char
+    length: 16
+    nullable: false
+    ivoa:ucd: meta.id;src
+    votable:arraysize: '16'
+  - name: updated_at
+    description: When this row was updated
+    datatype: timestamp
+    precision: 6
+    ivoa:ucd: time.processing;meta.dataset
+    votable:arraysize: '*'
+    votable:xtype: timestamp
+- name: Parent
+  description: Descriptions of the parent objects in the deblending hierarchy.
+  columns:
+  - name: deblend_chi2
+    description: Chi^2 of the source after deblending.
+    datatype: float
+  - name: deblend_failed
+    description: Deblender failed to deblend this source
+    datatype: boolean
+  - name: deblend_incompleteData
+    description: One or more bands were not deblended due to an inability to model
+      the PSF.
+    datatype: boolean
+  - name: deblend_iterations
+    description: Number of iterations during deblending
+    datatype: int
+  - name: deblend_nChild
+    description: Number of children this object has (defaults to 0)
+    datatype: int
+  - name: deblend_nPeaks
+    description: Number of peaks this parent footprint has (even if the deblender
+      failed or skipped this blend)
+    datatype: int
+  - name: deblend_skipped
+    description: Deblender skipped this source
+    datatype: boolean
+  - name: deblend_skipped_isPseudo
+    description: Deblender skipped this source because it was marked as a pseudo source
+      like a sky object.
+    datatype: boolean
+  - name: deblend_skipped_isolatedParent
+    description: Deblender skipped this footprint because there was only a single
+      peak
+    datatype: boolean
+  - name: deblend_skipped_masked
+    description: Deblender skipped this source because there were too many masked
+      pixels.
+    datatype: boolean
+  - name: deblend_skipped_parentTooBig
+    description: Deblender skipped this source because the parent footprint was too
+      large.
+    datatype: boolean
+  - name: deblend_skipped_tooManyPeaks
+    description: Deblender skipped this source because there were too many peaks in
+      the Footprint.
+    datatype: boolean
+  - name: merge_peak_sky
+    description: True when the parent object is a sky object
+    datatype: boolean
+  - name: objectId
+    description: Unique id. Unique ObjectID
+    datatype: long
+    ivoa:ucd: meta.id;src
+    tap:principal: 1
+  - name: parentObjectId
+    description: Unique ID of parent source. Reference band.
+    datatype: long
+    tap:principal: 1
+- name: ShearObject
+  description: Descriptions of shear objects detected and measured on coadds with
+    metadetection.
+  primaryKey: '#ShearObject.shearObjectId'
+  tap:table_index: 170
+  columns:
+  - name: bmask_flags
+    description: bmask flags for the ShearObject.
+    datatype: int
+  - name: cell_x
+    description: Column of the cell within the patch on which this measurement was
+      made.
+    datatype: int
+  - name: cell_y
+    description: Row of the cell within the patch on which this measurement was made.
+    datatype: int
+  - name: dec
+    description: Detected Declination of the ShearObject.
+    datatype: double
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: g_gaussFlux
+    description: Flux in g band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaussFluxErr
+    description: Flux uncertainty in g band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_gaussFlux_flags
+    description: Flags set for flux in g band measured with gauss algorithm.
+    datatype: int
+  - name: g_pgaussFlux
+    description: Flux in g band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_pgaussFluxErr
+    description: Flux uncertainty in g band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: g_pgaussFlux_flags
+    description: Flags set for flux in g band measured with pgauss algorithm.
+    datatype: int
+  - name: gauss_T
+    description: Trace (<x^2> + <y^2>) measurement of the ShearObject (measured with
+      gauss algorithm).
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: gauss_TErr
+    description: Uncertainty in the trace measurement of the ShearObject (measured
+      with gauss algorithm).
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: gauss_flags
+    description: Overall flags for gauss measurement algorithm.
+    datatype: int
+  - name: gauss_g1
+    description: Reduced-shear g1 measurement of the ShearObject (measured with gauss
+      algorithm).
+    datatype: float
+  - name: gauss_g1_g1_Cov
+    description: Auto-covariance of g1 measurement of the ShearObject (measured with
+      gauss algorithm).
+    datatype: float
+  - name: gauss_g1_g2_Cov
+    description: Cross-covariance of g1 and g2 measurement of the ShearObject (measured
+      with gauss algorithm).
+    datatype: float
+  - name: gauss_g2
+    description: Reduced-shear g2 measurement of the ShearObject (measured with gauss
+      algorithm).
+    datatype: float
+  - name: gauss_g2_g2_Cov
+    description: Auto-covariance of g2 measurement of the ShearObject (measured with
+      gauss algorithm).
+    datatype: float
+  - name: gauss_object_flags
+    description: Flags for the ShearObject measurement (measured with gauss algorithm).
+    datatype: int
+  - name: gauss_psfReconvolved_T
+    description: Trace (<x^2> + <y^2>) of the reconvolved PSF (measured with gauss
+      algorithm).
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: gauss_psfReconvolved_flags
+    description: Flags for reconvolved PSF (measured with gauss algorithm).
+    datatype: int
+  - name: gauss_psfReconvolved_g1
+    description: Reduced-shear g1 of the reconvolved PSF (measured with gauss algorithm).
+    datatype: float
+  - name: gauss_psfReconvolved_g2
+    description: Reduced-shear g2 of the reconvolved PSF (measured with gauss algorithm).
+    datatype: float
+  - name: gauss_shape_flags
+    description: Flags for the second moments measurement of the ShearObject (measured
+      with gauss algorithm).
+    datatype: int
+  - name: gauss_snr
+    description: Signal-to-noise ratio measure of the ShearObject (measured with gauss
+      algorithm).
+    datatype: float
+  - name: i_gaussFlux
+    description: Flux in i band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaussFluxErr
+    description: Flux uncertainty in i band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_gaussFlux_flags
+    description: Flags set for flux in i band measured with gauss algorithm.
+    datatype: int
+  - name: i_pgaussFlux
+    description: Flux in i band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_pgaussFluxErr
+    description: Flux uncertainty in i band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: i_pgaussFlux_flags
+    description: Flags set for flux in i band measured with pgauss algorithm.
+    datatype: int
+  - name: image_flags
+    description: Flags for the image on which this measurement was made.
+    datatype: int
+  - name: metaStep
+    description: Type of artificial shear applied to image. One of 'ns', '1p', '1m',
+      '2p', '2m'.
+    datatype: char
+    length: 2
+    votable:arraysize: '2'
+  - name: mfrac
+    description: Gaussian-weighted masked fraction for the ShearObject.
+    datatype: float
+  - name: ormask_flags
+    description: ored mask flags for the ShearObject.
+    datatype: int
+  - name: patch
+    description: Skymap patch ID
+    datatype: long
+    tap:principal: 1
+  - name: pgauss_T
+    description: Trace (<x^2> + <y^2>) measurement of the ShearObject (measured with
+      pgauss algorithm).
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: pgauss_TErr
+    description: Uncertainty in the trace measurement of the ShearObject (measured
+      with pgauss algorithm).
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: pgauss_flags
+    description: Overall flags for pgauss measurement algorithm.
+    datatype: int
+  - name: pgauss_object_flags
+    description: Flags for the ShearObject measurement (measured with pgauss algorithm).
+    datatype: int
+  - name: pgauss_shape_flags
+    description: Flags for the second moments measurement of the ShearObject (measured
+      with pgauss algorithm).
+    datatype: int
+  - name: pgauss_snr
+    description: Signal-to-noise ratio measure of the ShearObject (measured with pgauss
+      algorithm).
+    datatype: float
+  - name: psfOriginal_T
+    description: Trace (<x^2> + <y^2>) measurement of the original PSF from adaptive
+      moments.
+    datatype: float
+    ivoa:unit: arcsec**2
+  - name: psfOriginal_e1
+    description: Distortion-style e1 of the original PSF from adaptive moments.
+    datatype: float
+  - name: psfOriginal_e2
+    description: Distortion-style e2 of the original PSF from adaptive moments.
+    datatype: float
+  - name: psfOriginal_flags
+    description: Flags for the original PSF measurement.
+    datatype: int
+  - name: r_gaussFlux
+    description: Flux in r band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaussFluxErr
+    description: Flux uncertainty in r band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_gaussFlux_flags
+    description: Flags set for flux in r band measured with gauss algorithm.
+    datatype: int
+  - name: r_pgaussFlux
+    description: Flux in r band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_pgaussFluxErr
+    description: Flux uncertainty in r band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: r_pgaussFlux_flags
+    description: Flags set for flux in r band measured with pgauss algorithm.
+    datatype: int
+  - name: ra
+    description: Detected Right Ascension of the ShearObject.
+    datatype: double
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: shearObjectId
+    description: Unique identifier for a ShearObject, specific to a single metacalibration
+      counterfactual image.
+    datatype: long
+    ivoa:ucd: meta.id;src
+    tap:principal: 1
+  - name: tract
+    description: Skymap tract ID
+    datatype: long
+    tap:principal: 1
+  - name: x
+    description: Centroid (tract, x-axis) of the detected ShearObject.
+    datatype: float
+  - name: y
+    description: Centroid (tract, y-axis) of the detected ShearObject.
+    datatype: float
+  - name: z_gaussFlux
+    description: Flux in z band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaussFluxErr
+    description: Flux uncertainty in z band (measured with gauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_gaussFlux_flags
+    description: Flags set for flux in z band measured with gauss algorithm.
+    datatype: int
+  - name: z_pgaussFlux
+    description: Flux in z band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_pgaussFluxErr
+    description: Flux uncertainty in z band (measured with pgauss algorithm).
+    datatype: float
+    ivoa:unit: nJy
+  - name: z_pgaussFlux_flags
+    description: Flags set for flux in z band measured with pgauss algorithm.
+    datatype: int
+- name: IsolatedStarStellarMotions
+  description: Position, proper motion, and parallax for isolated stars, fit using
+    associated source measurements, with positions for associated reference objects
+    if available.
+  columns:
+  - name: dec
+    description: Position in declination at the reference epoch.
+    datatype: float
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: decErr
+    description: Error in declination at the reference epoch.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.dec
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: decPM
+    description: Proper motion in declination.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.dec
+    ivoa:unit: mas/yr
+    tap:principal: 1
+  - name: decPMErr
+    description: Error in proper motion in declination.
+    datatype: float
+    ivoa:ucd: stat.error;pos.pm;pos.eq.dec
+    ivoa:unit: mas/yr
+    tap:principal: 1
+  - name: decPM_parallax_Cov
+    description: Covariance between proper motion in declination and parallax.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.pm;pos.eq.dec;pos.parallax
+    ivoa:unit: mas**2/yr
+    tap:principal: 1
+  - name: dec_decPM_Cov
+    description: Covariance between declination and proper motion in declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.dec
+    ivoa:unit: deg*mas/yr
+    tap:principal: 1
+  - name: dec_parallax_Cov
+    description: Covariance between declination and parallax.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.dec;pos.parallax
+    ivoa:unit: deg*mas
+    tap:principal: 1
+  - name: dec_raPM_Cov
+    description: Covariance between declination and proper motion in right ascension.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.ra
+    ivoa:unit: deg*mas/yr
+    tap:principal: 1
+  - name: epoch
+    description: Epoch in MJD to which the position corresponds.
+    datatype: float
+    ivoa:ucd: time.epoch
+    ivoa:unit: d
+    tap:principal: 1
+  - name: isolated_star_id
+    description: Unique id of isolated star
+    datatype: int
+    ivoa:ucd: meta.id;meta.main
+    tap:principal: 1
+  - name: parallax
+    description: Parallax
+    datatype: float
+    ivoa:ucd: pos.parallax
+    ivoa:unit: mas
+    tap:principal: 1
+  - name: parallaxErr
+    description: Error in parallax.
+    datatype: float
+    ivoa:ucd: stat.error;pos.parallax
+    ivoa:unit: mas
+    tap:principal: 1
+  - name: ra
+    description: Position in right ascension at the reference epoch.
+    datatype: float
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: raErr
+    description: Error in right ascension at the reference epoch.
+    datatype: float
+    ivoa:ucd: stat.error;pos.eq.ra
+    ivoa:unit: deg
+    tap:principal: 1
+  - name: raPM
+    description: Proper motion in right ascension.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.ra
+    ivoa:unit: mas/yr
+    tap:principal: 1
+  - name: raPMErr
+    description: Error in proper motion in right ascension.
+    datatype: float
+    ivoa:ucd: stat.error;pos.pm;pos.eq.ra
+    ivoa:unit: mas/yr
+    tap:principal: 1
+  - name: raPM_decPM_Cov
+    description: Covariance between proper motion in right ascension and proper motion
+      in declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.pm;pos.eq.dec
+    ivoa:unit: mas**2/yr**2
+    tap:principal: 1
+  - name: raPM_parallax_Cov
+    description: Covariance between proper motion in right ascension and parallax.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.parallax
+    ivoa:unit: mas**2/yr
+    tap:principal: 1
+  - name: ra_decPM_Cov
+    description: Covariance between right ascension and proper motion in declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.dec
+    ivoa:unit: deg*mas/yr
+    tap:principal: 1
+  - name: ra_dec_Cov
+    description: Covariance between right ascension and declination.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
+    ivoa:unit: deg**2
+    tap:principal: 1
+  - name: ra_parallax_Cov
+    description: Covariance between right ascension and parallax.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.parallax
+    ivoa:unit: deg*mas
+    tap:principal: 1
+  - name: ra_raPM_Cov
+    description: Covariance between right ascension and proper motion in right ascension.
+    datatype: float
+    ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.ra
+    ivoa:unit: deg*mas/yr
+    tap:principal: 1
+  - name: ref_dec
+    description: Position of the reference object in declination at the reference
+      epoch.
+    datatype: float
+    ivoa:ucd: pos.eq.dec
+    ivoa:unit: deg
+  - name: ref_decPM
+    description: Proper motion of the reference object in declination.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.dec
+    ivoa:unit: mas/yr
+  - name: ref_parallax
+    description: Parallax of the reference object
+    datatype: float
+    ivoa:ucd: pos.parallax
+    ivoa:unit: mas
+  - name: ref_ra
+    description: Position of the reference object in right ascension at the reference
+      epoch.
+    datatype: float
+    ivoa:ucd: pos.eq.ra
+    ivoa:unit: deg
+  - name: ref_raPM
+    description: Proper motion of the reference object in right ascension.
+    datatype: float
+    ivoa:ucd: pos.pm;pos.eq.ra
+    ivoa:unit: mas/yr
+  - name: referenceId
+    description: Id of the reference object if available.
+    datatype: float
+    tap:principal: 1

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -73,10 +73,27 @@ tables:
       patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter
       (see config.pseudoFilterList) and is a deblended child
     datatype: boolean
+  - name: detect_isDeblendedSource
+    description: True if source has no children and is in the inner region of a coadd
+      patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter
+      (see config.pseudoFilterList) and is either an unblended isolated source or
+      a deblended child from a parent with
+    datatype: boolean
   - name: detect_isIsolated
     description: This source is not a part of a blend.
     datatype: boolean
     tap:principal: 1
+  - name: detect_isPatchInner
+    description: True if source is in the inner region of a coadd patch
+    datatype: boolean
+  - name: detect_isPrimary
+    description: True if source has no children and is in the inner region of a coadd
+      patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter
+      (see config.pseudoFilterList)
+    datatype: boolean
+  - name: detect_isTractInner
+    description: True if source is in the inner region of a coadd tract
+    datatype: boolean
   - name: ebv
     description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
     datatype: float
@@ -1722,6 +1739,9 @@ tables:
     description: Flag set for any failure in the moments-based extendedness. Measured
       on i-band.
     datatype: boolean
+  - name: merge_peak_sky
+    description: Peak detected in filter sky
+    datatype: boolean
   - name: objectId
     description: Unique id. Unique ObjectID
     datatype: long
@@ -2634,6 +2654,10 @@ tables:
     datatype: float
     ivoa:unit: pixel**2
     tap:principal: 1
+  - name: sky_object
+    description: No source was detected here. This object exists to characterize properties
+      of the sky background
+    datatype: boolean
   - name: tract
     description: Skymap tract ID
     datatype: long
@@ -5205,6 +5229,10 @@ tables:
     datatype: float
     ivoa:ucd: stat.error;pos.eq.dec
     ivoa:unit: deg
+  - name: detect_isPrimary
+    description: True if Object seed has no children and is in the inner region of
+      a coadd patch and is in the inner region of a coadd tract and is not a sky object
+    datatype: boolean
   - name: detector
     description: Id of the detector where this source was measured.
     datatype: short

--- a/python/lsst/sdm/schemas/hsc.yaml
+++ b/python/lsst/sdm/schemas/hsc.yaml
@@ -33,6 +33,12 @@ tables:
         detect_fromBlend:
         detect_isDeblendedModelSource:
         detect_isIsolated:
+        detect_isDeblendedSource:
+        detect_isPatchInner:
+        detect_isPrimary:
+        detect_isTractInner:
+        merge_peak_sky:
+        sky_object:
         ebv:
         footprintArea:
         parentObjectId:
@@ -1049,31 +1055,6 @@ tables:
         r_epoch:
         y_epoch:
         z_epoch:
-  columns:
-  - name: detect_isDeblendedSource
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
-    fits:tunit:
-  - name: detect_isPatchInner
-    datatype: boolean
-    description: True if source is in the inner region of a coadd patch
-    fits:tunit:
-  - name: detect_isPrimary
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
-    fits:tunit:
-  - name: detect_isTractInner
-    datatype: boolean
-    description: True if source is in the inner region of a coadd tract
-    fits:tunit:
-  - name: merge_peak_sky
-    datatype: boolean
-    description: Peak detected in filter sky
-    fits:tunit:
-  - name: sky_object
-    datatype: boolean
-    description: No source was detected here. This object exists to characterize properties of the sky background
-    fits:tunit:
 - name: Source
   description: Table to store high signal-to-noise sources;. A source is
     a measurement of Object's properties from a single image that contains its footprint
@@ -1146,6 +1127,7 @@ tables:
         blendedness_flag:
         blendedness_flag_noCentroid:
         blendedness_flag_noShape:
+        detect_isPrimary:
         apFlux_12_0_flag:
         apFlux_12_0_flag_apertureTruncated:
         apFlux_12_0_flag_sincCoeffsTruncated:
@@ -1269,10 +1251,6 @@ tables:
   - name: localWcs_CDMatrix_2_2
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    fits:tunit:
-  - name: detect_isPrimary
-    datatype: boolean
-    description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
     fits:tunit:
 - name: Visit
   description: Defines a single Visit.

--- a/python/lsst/sdm/schemas/hsc.yaml
+++ b/python/lsst/sdm/schemas/hsc.yaml
@@ -1223,35 +1223,35 @@ tables:
   - name: localPhotoCalib
     datatype: double
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
-    fits:tunit:
+    ivoa:unit:
   - name: localPhotoCalib_flag
     datatype: boolean
     description: Set for any fatal failure
-    fits:tunit:
+    ivoa:unit:
   - name: localPhotoCalibErr
     datatype: double
     description: Error on the local approximation of the PhotoCalib calibration factor at the location of the src.
-    fits:tunit:
+    ivoa:unit:
   - name: localWcs_flag
     datatype: boolean
     description: Set for any fatal failure
-    fits:tunit:
+    ivoa:unit:
   - name: localWcs_CDMatrix_2_1
     datatype: double
     description: (2, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    fits:tunit:
+    ivoa:unit:
   - name: localWcs_CDMatrix_1_1
     datatype: double
     description: (1, 1) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    fits:tunit:
+    ivoa:unit:
   - name: localWcs_CDMatrix_1_2
     datatype: double
     description: (1, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    fits:tunit:
+    ivoa:unit:
   - name: localWcs_CDMatrix_2_2
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
-    fits:tunit:
+    ivoa:unit:
 - name: Visit
   description: Defines a single Visit.
   columnRefs:
@@ -1273,18 +1273,18 @@ tables:
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
+    ivoa:unit: deg
   - name: midpoint
     datatype: timestamp
     precision: 6
     description: Midpoint time of the visit at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
-    fits:tunit:
+    ivoa:unit:
   - name: midpointMjdTai
     datatype: double
     description: Midpoint time of the visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
-    fits:tunit: d
+    ivoa:unit: d
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified
@@ -1364,7 +1364,7 @@ tables:
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
+    ivoa:unit: deg
   - name: midpoint
     datatype: timestamp
     precision: 6
@@ -1373,7 +1373,7 @@ tables:
     datatype: double
     description: Midpoint of this visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    fits:tunit: d
+    ivoa:unit: d
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified

--- a/python/lsst/sdm/schemas/hsc.yaml
+++ b/python/lsst/sdm/schemas/hsc.yaml
@@ -4,6 +4,9 @@ description: |
   The HyperSuprimeCam (HSC) Schema describes the outputs of the latest data release production pipelines for
   HyperSuprimeCam.
   It is used in the CI testing of the pipelines.
+resources:
+  base:
+    uri: "drp_base.yaml"
 tables:
 - name: Object
   description: The Object table contains descriptions of the multi-epoch static astronomical
@@ -11,76 +14,1045 @@ tables:
     of the Sources that are associated with them. Note that fast moving objects are
     kept in the MovingObject tables. Note that less-frequently used columns are stored
     in a separate table called Object_Extra.
+  columnRefs:
+    base:
+      Object:
+        objectId:
+        coord_dec:
+        coord_ra:
+        coord_decErr:
+        coord_raErr:
+        coord_ra_dec_Cov:
+        deblend_parentNChild:
+        deblend_parentNPeaks:
+        deblend_peak_center_x:
+        deblend_peak_center_y:
+        deblend_chi2:
+        deblend_blendId:
+        deblend_blendNChild:
+        detect_fromBlend:
+        detect_isDeblendedModelSource:
+        detect_isIsolated:
+        ebv:
+        footprintArea:
+        parentObjectId:
+        patch:
+        refBand:
+        refExtendedness:
+        refSizeExtendedness:
+        shape_flag:
+        shape_xx:
+        shape_xy:
+        shape_yy:
+        tract:
+        coord_flag:
+        g_ap03Flux:
+        g_ap03FluxErr:
+        g_ap03Flux_flag:
+        g_ap06Flux:
+        g_ap06FluxErr:
+        g_ap06Flux_flag:
+        g_ap09Flux:
+        g_ap09FluxErr:
+        g_ap09Flux_flag:
+        g_ap12Flux:
+        g_ap12FluxErr:
+        g_ap12Flux_flag:
+        g_ap17Flux:
+        g_ap17FluxErr:
+        g_ap17Flux_flag:
+        g_ap25Flux:
+        g_ap25FluxErr:
+        g_ap25Flux_flag:
+        g_ap35Flux:
+        g_ap35FluxErr:
+        g_ap35Flux_flag:
+        g_ap50Flux:
+        g_ap50FluxErr:
+        g_ap50Flux_flag:
+        g_ap70Flux:
+        g_ap70FluxErr:
+        g_ap70Flux_flag:
+        g_apFlux_flag:
+        g_apFlux_flag_apertureTruncated:
+        g_apFlux_flag_sincCoeffsTruncated:
+        g_cModel_chi2:
+        g_cModel_devFlux:
+        g_cModel_devFluxErr:
+        g_cModel_expFlux:
+        g_cModel_expFluxErr:
+        g_cModel_dev_reff_major:
+        g_cModel_dev_reff_minor:
+        g_cModel_dev_theta:
+        g_cModel_exp_reff_major:
+        g_cModel_exp_reff_minor:
+        g_cModel_exp_theta:
+        g_blendedness:
+        g_blendedness_flag:
+        g_cModelFlux:
+        g_cModelFluxErr:
+        g_cModelFlux_inner:
+        g_cModel_fracDev:
+        g_cModel_flag:
+        g_cModel_flag_apCorr:
+        g_calib_astrometry_used:
+        g_calib_photometry_used:
+        g_calib_psf_candidate:
+        g_calib_psf_reserved:
+        g_calib_psf_used:
+        g_centroid_flag:
+        g_dec:
+        g_decErr:
+        g_extendedness:
+        g_extendedness_flag:
+        g_sizeExtendedness:
+        g_sizeExtendedness_flag:
+        g_model_extendedness:
+        g_free_cModelFlux:
+        g_free_cModelFluxErr:
+        g_free_cModelFlux_flag:
+        g_free_cModelFlux_inner:
+        g_free_cModel_fracDev:
+        g_free_cModel_devFlux:
+        g_free_cModel_devFluxErr:
+        g_free_cModel_expFlux:
+        g_free_cModel_expFluxErr:
+        g_free_psfFlux:
+        g_free_psfFluxErr:
+        g_free_psfFlux_flag:
+        g_gaap0p7FluxErr:
+        g_gaap1p0FluxErr:
+        g_gaapPsfFluxErr:
+        g_gaapPsfFlux:
+        g_gaap0p7Flux:
+        g_gaap1p0Flux:
+        g_gaapFlux_flag:
+        g_gaapFlux_flag_edge:
+        g_moments_g1:
+        g_moments_g2:
+        g_moments_trace:
+        g_moments_flag:
+        g_moments_psf_g1:
+        g_moments_psf_g2:
+        g_moments_psf_trace:
+        g_moments_psf_flag:
+        g_moments_psf_debiased_g1:
+        g_moments_psf_debiased_g2:
+        g_moments_psf_debiased_trace:
+        g_moments_psf_debiased_flag:
+        g_hsmShapeRegauss_e1:
+        g_hsmShapeRegauss_e2:
+        g_hsmShapeRegauss_flag:
+        g_hsmShapeRegauss_sigma:
+        g_iPSF_flag:
+        g_i_flag:
+        g_inputCount:
+        g_inputCount_flag:
+        g_inputCount_flag_noInputs:
+        g_ixx:
+        g_ixxPSF:
+        g_ixy:
+        g_ixyPSF:
+        g_iyy:
+        g_iyyPSF:
+        g_hsm_moments_30:
+        g_hsm_momentsPsf_30:
+        g_hsm_moments_21:
+        g_hsm_momentsPsf_21:
+        g_hsm_moments_12:
+        g_hsm_momentsPsf_12:
+        g_hsm_moments_03:
+        g_hsm_momentsPsf_03:
+        g_hsm_moments_40:
+        g_hsm_momentsPsf_40:
+        g_hsm_moments_31:
+        g_hsm_momentsPsf_31:
+        g_hsm_moments_22:
+        g_hsm_momentsPsf_22:
+        g_hsm_moments_13:
+        g_hsm_momentsPsf_13:
+        g_hsm_moments_04:
+        g_hsm_momentsPsf_04:
+        g_hsm_moments_flag:
+        g_hsm_momentsPsf_flag:
+        g_kronFlux:
+        g_kronFluxErr:
+        g_kronFlux_flag:
+        g_kronFlux_flag_bad_radius:
+        g_kronFlux_flag_bad_shape:
+        g_kronFlux_flag_bad_shape_no_psf:
+        g_kronFlux_flag_edge:
+        g_kronFlux_flag_no_fallback_radius:
+        g_kronFlux_flag_no_minimum_radius:
+        g_kronFlux_flag_small_radius:
+        g_kronFlux_flag_used_minimum_radius:
+        g_kronFlux_flag_used_psf_radius:
+        g_kronRad:
+        g_pixelFlags_bad:
+        g_pixelFlags_clipped:
+        g_pixelFlags_clippedCenter:
+        g_pixelFlags_cr:
+        g_pixelFlags_crCenter:
+        g_pixelFlags_edge:
+        g_pixelFlags_inexact_psf:
+        g_pixelFlags_inexact_psfCenter:
+        g_pixelFlags_interpolated:
+        g_pixelFlags_interpolatedCenter:
+        g_pixelFlags_nodata:
+        g_pixelFlags_offimage:
+        g_pixelFlags_saturated:
+        g_pixelFlags_saturatedCenter:
+        g_pixelFlags_sensor_edge:
+        g_pixelFlags_sensor_edgeCenter:
+        g_pixelFlags_suspect:
+        g_pixelFlags_suspectCenter:
+        g_invalidPsfFlag:
+        g_psfFlux:
+        g_psfFluxErr:
+        g_psfFlux_area:
+        g_psfFlux_flag:
+        g_psfFlux_flag_apCorr:
+        g_psfFlux_flag_edge:
+        g_psfFlux_flag_noGoodPixels:
+        g_ra:
+        g_raErr:
+        g_ra_dec_Cov:
+        g_deblend_dataCoverage:
+        g_deblend_blendedness:
+        g_deblend_fluxOverlap:
+        g_deblend_fluxOverlapFraction:
+        g_deblend_zeroFlux:
+        griz_model_extendedness:
+        i_ap03Flux:
+        i_ap03FluxErr:
+        i_ap03Flux_flag:
+        i_ap06Flux:
+        i_ap06FluxErr:
+        i_ap06Flux_flag:
+        i_ap09Flux:
+        i_ap09FluxErr:
+        i_ap09Flux_flag:
+        i_ap12Flux:
+        i_ap12FluxErr:
+        i_ap12Flux_flag:
+        i_ap17Flux:
+        i_ap17FluxErr:
+        i_ap17Flux_flag:
+        i_ap25Flux:
+        i_ap25FluxErr:
+        i_ap25Flux_flag:
+        i_ap35Flux:
+        i_ap35FluxErr:
+        i_ap35Flux_flag:
+        i_ap50Flux:
+        i_ap50FluxErr:
+        i_ap50Flux_flag:
+        i_ap70Flux:
+        i_ap70FluxErr:
+        i_ap70Flux_flag:
+        i_apFlux_flag:
+        i_apFlux_flag_apertureTruncated:
+        i_apFlux_flag_sincCoeffsTruncated:
+        i_cModel_chi2:
+        i_cModel_devFlux:
+        i_cModel_devFluxErr:
+        i_cModel_expFlux:
+        i_cModel_expFluxErr:
+        i_cModel_dev_reff_major:
+        i_cModel_dev_reff_minor:
+        i_cModel_dev_theta:
+        i_cModel_exp_reff_major:
+        i_cModel_exp_reff_minor:
+        i_cModel_exp_theta:
+        i_blendedness:
+        i_blendedness_flag:
+        i_cModelFlux:
+        i_cModelFluxErr:
+        i_cModelFlux_inner:
+        i_cModel_fracDev:
+        i_cModel_flag:
+        i_cModel_flag_apCorr:
+        i_calib_astrometry_used:
+        i_calib_photometry_used:
+        i_calib_psf_candidate:
+        i_calib_psf_reserved:
+        i_calib_psf_used:
+        i_centroid_flag:
+        i_dec:
+        i_decErr:
+        i_extendedness:
+        i_extendedness_flag:
+        i_sizeExtendedness:
+        i_sizeExtendedness_flag:
+        i_model_extendedness:
+        i_free_cModelFlux:
+        i_free_cModelFluxErr:
+        i_free_cModelFlux_flag:
+        i_free_cModelFlux_inner:
+        i_free_cModel_fracDev:
+        i_free_cModel_devFlux:
+        i_free_cModel_devFluxErr:
+        i_free_cModel_expFlux:
+        i_free_cModel_expFluxErr:
+        i_free_psfFlux:
+        i_free_psfFluxErr:
+        i_free_psfFlux_flag:
+        i_gaap0p7FluxErr:
+        i_gaap1p0FluxErr:
+        i_gaapPsfFluxErr:
+        i_gaapPsfFlux:
+        i_gaap0p7Flux:
+        i_gaap1p0Flux:
+        i_gaapFlux_flag:
+        i_gaapFlux_flag_edge:
+        i_moments_g1:
+        i_moments_g2:
+        i_moments_trace:
+        i_moments_flag:
+        i_moments_psf_g1:
+        i_moments_psf_g2:
+        i_moments_psf_trace:
+        i_moments_psf_flag:
+        i_moments_psf_debiased_g1:
+        i_moments_psf_debiased_g2:
+        i_moments_psf_debiased_trace:
+        i_moments_psf_debiased_flag:
+        i_hsmShapeRegauss_e1:
+        i_hsmShapeRegauss_e2:
+        i_hsmShapeRegauss_flag:
+        i_hsmShapeRegauss_sigma:
+        i_iPSF_flag:
+        i_i_flag:
+        i_inputCount:
+        i_inputCount_flag:
+        i_inputCount_flag_noInputs:
+        i_ixx:
+        i_ixxPSF:
+        i_ixy:
+        i_ixyPSF:
+        i_iyy:
+        i_iyyPSF:
+        i_hsm_moments_30:
+        i_hsm_momentsPsf_30:
+        i_hsm_moments_21:
+        i_hsm_momentsPsf_21:
+        i_hsm_moments_12:
+        i_hsm_momentsPsf_12:
+        i_hsm_moments_03:
+        i_hsm_momentsPsf_03:
+        i_hsm_moments_40:
+        i_hsm_momentsPsf_40:
+        i_hsm_moments_31:
+        i_hsm_momentsPsf_31:
+        i_hsm_moments_22:
+        i_hsm_momentsPsf_22:
+        i_hsm_moments_13:
+        i_hsm_momentsPsf_13:
+        i_hsm_moments_04:
+        i_hsm_momentsPsf_04:
+        i_hsm_moments_flag:
+        i_hsm_momentsPsf_flag:
+        i_kronFlux:
+        i_kronFluxErr:
+        i_kronFlux_flag:
+        i_kronFlux_flag_bad_radius:
+        i_kronFlux_flag_bad_shape:
+        i_kronFlux_flag_bad_shape_no_psf:
+        i_kronFlux_flag_edge:
+        i_kronFlux_flag_no_fallback_radius:
+        i_kronFlux_flag_no_minimum_radius:
+        i_kronFlux_flag_small_radius:
+        i_kronFlux_flag_used_minimum_radius:
+        i_kronFlux_flag_used_psf_radius:
+        i_kronRad:
+        i_pixelFlags_bad:
+        i_pixelFlags_clipped:
+        i_pixelFlags_clippedCenter:
+        i_pixelFlags_cr:
+        i_pixelFlags_crCenter:
+        i_pixelFlags_edge:
+        i_pixelFlags_inexact_psf:
+        i_pixelFlags_inexact_psfCenter:
+        i_pixelFlags_interpolated:
+        i_pixelFlags_interpolatedCenter:
+        i_pixelFlags_nodata:
+        i_pixelFlags_offimage:
+        i_pixelFlags_saturated:
+        i_pixelFlags_saturatedCenter:
+        i_pixelFlags_sensor_edge:
+        i_pixelFlags_sensor_edgeCenter:
+        i_pixelFlags_suspect:
+        i_pixelFlags_suspectCenter:
+        i_invalidPsfFlag:
+        i_psfFlux:
+        i_psfFluxErr:
+        i_psfFlux_area:
+        i_psfFlux_flag:
+        i_psfFlux_flag_apCorr:
+        i_psfFlux_flag_edge:
+        i_psfFlux_flag_noGoodPixels:
+        i_ra:
+        i_raErr:
+        i_ra_dec_Cov:
+        i_deblend_dataCoverage:
+        i_deblend_blendedness:
+        i_deblend_fluxOverlap:
+        i_deblend_fluxOverlapFraction:
+        i_deblend_zeroFlux:
+        r_ap03Flux:
+        r_ap03FluxErr:
+        r_ap03Flux_flag:
+        r_ap06Flux:
+        r_ap06FluxErr:
+        r_ap06Flux_flag:
+        r_ap09Flux:
+        r_ap09FluxErr:
+        r_ap09Flux_flag:
+        r_ap12Flux:
+        r_ap12FluxErr:
+        r_ap12Flux_flag:
+        r_ap17Flux:
+        r_ap17FluxErr:
+        r_ap17Flux_flag:
+        r_ap25Flux:
+        r_ap25FluxErr:
+        r_ap25Flux_flag:
+        r_ap35Flux:
+        r_ap35FluxErr:
+        r_ap35Flux_flag:
+        r_ap50Flux:
+        r_ap50FluxErr:
+        r_ap50Flux_flag:
+        r_ap70Flux:
+        r_ap70FluxErr:
+        r_ap70Flux_flag:
+        r_apFlux_flag:
+        r_apFlux_flag_apertureTruncated:
+        r_apFlux_flag_sincCoeffsTruncated:
+        r_cModel_chi2:
+        r_cModel_devFlux:
+        r_cModel_devFluxErr:
+        r_cModel_expFlux:
+        r_cModel_expFluxErr:
+        r_cModel_dev_reff_major:
+        r_cModel_dev_reff_minor:
+        r_cModel_dev_theta:
+        r_cModel_exp_reff_major:
+        r_cModel_exp_reff_minor:
+        r_cModel_exp_theta:
+        r_blendedness:
+        r_blendedness_flag:
+        r_cModelFlux:
+        r_cModelFluxErr:
+        r_cModelFlux_inner:
+        r_cModel_fracDev:
+        r_cModel_flag:
+        r_cModel_flag_apCorr:
+        r_calib_astrometry_used:
+        r_calib_photometry_used:
+        r_calib_psf_candidate:
+        r_calib_psf_reserved:
+        r_calib_psf_used:
+        r_centroid_flag:
+        r_dec:
+        r_decErr:
+        r_extendedness:
+        r_extendedness_flag:
+        r_sizeExtendedness:
+        r_sizeExtendedness_flag:
+        r_model_extendedness:
+        r_free_cModelFlux:
+        r_free_cModelFluxErr:
+        r_free_cModelFlux_flag:
+        r_free_cModelFlux_inner:
+        r_free_cModel_fracDev:
+        r_free_cModel_devFlux:
+        r_free_cModel_devFluxErr:
+        r_free_cModel_expFlux:
+        r_free_cModel_expFluxErr:
+        r_free_psfFlux:
+        r_free_psfFluxErr:
+        r_free_psfFlux_flag:
+        r_gaap0p7FluxErr:
+        r_gaap1p0FluxErr:
+        r_gaapPsfFluxErr:
+        r_gaapPsfFlux:
+        r_gaap0p7Flux:
+        r_gaap1p0Flux:
+        r_gaapFlux_flag:
+        r_gaapFlux_flag_edge:
+        r_moments_g1:
+        r_moments_g2:
+        r_moments_trace:
+        r_moments_flag:
+        r_moments_psf_g1:
+        r_moments_psf_g2:
+        r_moments_psf_trace:
+        r_moments_psf_flag:
+        r_moments_psf_debiased_g1:
+        r_moments_psf_debiased_g2:
+        r_moments_psf_debiased_trace:
+        r_moments_psf_debiased_flag:
+        r_hsmShapeRegauss_e1:
+        r_hsmShapeRegauss_e2:
+        r_hsmShapeRegauss_flag:
+        r_hsmShapeRegauss_sigma:
+        r_iPSF_flag:
+        r_i_flag:
+        r_inputCount:
+        r_inputCount_flag:
+        r_inputCount_flag_noInputs:
+        r_ixx:
+        r_ixxPSF:
+        r_ixy:
+        r_ixyPSF:
+        r_iyy:
+        r_iyyPSF:
+        r_hsm_moments_30:
+        r_hsm_momentsPsf_30:
+        r_hsm_moments_21:
+        r_hsm_momentsPsf_21:
+        r_hsm_moments_12:
+        r_hsm_momentsPsf_12:
+        r_hsm_moments_03:
+        r_hsm_momentsPsf_03:
+        r_hsm_moments_40:
+        r_hsm_momentsPsf_40:
+        r_hsm_moments_31:
+        r_hsm_momentsPsf_31:
+        r_hsm_moments_22:
+        r_hsm_momentsPsf_22:
+        r_hsm_moments_13:
+        r_hsm_momentsPsf_13:
+        r_hsm_moments_04:
+        r_hsm_momentsPsf_04:
+        r_hsm_moments_flag:
+        r_hsm_momentsPsf_flag:
+        r_kronFlux:
+        r_kronFluxErr:
+        r_kronFlux_flag:
+        r_kronFlux_flag_bad_radius:
+        r_kronFlux_flag_bad_shape:
+        r_kronFlux_flag_bad_shape_no_psf:
+        r_kronFlux_flag_edge:
+        r_kronFlux_flag_no_fallback_radius:
+        r_kronFlux_flag_no_minimum_radius:
+        r_kronFlux_flag_small_radius:
+        r_kronFlux_flag_used_minimum_radius:
+        r_kronFlux_flag_used_psf_radius:
+        r_kronRad:
+        r_pixelFlags_bad:
+        r_pixelFlags_clipped:
+        r_pixelFlags_clippedCenter:
+        r_pixelFlags_cr:
+        r_pixelFlags_crCenter:
+        r_pixelFlags_edge:
+        r_pixelFlags_inexact_psf:
+        r_pixelFlags_inexact_psfCenter:
+        r_pixelFlags_interpolated:
+        r_pixelFlags_interpolatedCenter:
+        r_pixelFlags_nodata:
+        r_pixelFlags_offimage:
+        r_pixelFlags_saturated:
+        r_pixelFlags_saturatedCenter:
+        r_pixelFlags_sensor_edge:
+        r_pixelFlags_sensor_edgeCenter:
+        r_pixelFlags_suspect:
+        r_pixelFlags_suspectCenter:
+        r_invalidPsfFlag:
+        r_psfFlux:
+        r_psfFluxErr:
+        r_psfFlux_area:
+        r_psfFlux_flag:
+        r_psfFlux_flag_apCorr:
+        r_psfFlux_flag_edge:
+        r_psfFlux_flag_noGoodPixels:
+        r_ra:
+        r_raErr:
+        r_ra_dec_Cov:
+        r_deblend_dataCoverage:
+        r_deblend_blendedness:
+        r_deblend_fluxOverlap:
+        r_deblend_fluxOverlapFraction:
+        r_deblend_zeroFlux:
+        y_ap03Flux:
+        y_ap03FluxErr:
+        y_ap03Flux_flag:
+        y_ap06Flux:
+        y_ap06FluxErr:
+        y_ap06Flux_flag:
+        y_ap09Flux:
+        y_ap09FluxErr:
+        y_ap09Flux_flag:
+        y_ap12Flux:
+        y_ap12FluxErr:
+        y_ap12Flux_flag:
+        y_ap17Flux:
+        y_ap17FluxErr:
+        y_ap17Flux_flag:
+        y_ap25Flux:
+        y_ap25FluxErr:
+        y_ap25Flux_flag:
+        y_ap35Flux:
+        y_ap35FluxErr:
+        y_ap35Flux_flag:
+        y_ap50Flux:
+        y_ap50FluxErr:
+        y_ap50Flux_flag:
+        y_ap70Flux:
+        y_ap70FluxErr:
+        y_ap70Flux_flag:
+        y_apFlux_flag:
+        y_apFlux_flag_apertureTruncated:
+        y_apFlux_flag_sincCoeffsTruncated:
+        y_cModel_chi2:
+        y_cModel_devFlux:
+        y_cModel_devFluxErr:
+        y_cModel_expFlux:
+        y_cModel_expFluxErr:
+        y_cModel_dev_reff_major:
+        y_cModel_dev_reff_minor:
+        y_cModel_dev_theta:
+        y_cModel_exp_reff_major:
+        y_cModel_exp_reff_minor:
+        y_cModel_exp_theta:
+        y_blendedness:
+        y_blendedness_flag:
+        y_cModelFlux:
+        y_cModelFluxErr:
+        y_cModelFlux_inner:
+        y_cModel_fracDev:
+        y_cModel_flag:
+        y_cModel_flag_apCorr:
+        y_calib_astrometry_used:
+        y_calib_photometry_used:
+        y_calib_psf_candidate:
+        y_calib_psf_reserved:
+        y_calib_psf_used:
+        y_centroid_flag:
+        y_dec:
+        y_decErr:
+        y_extendedness:
+        y_extendedness_flag:
+        y_sizeExtendedness:
+        y_sizeExtendedness_flag:
+        y_model_extendedness:
+        y_free_cModelFlux:
+        y_free_cModelFluxErr:
+        y_free_cModelFlux_flag:
+        y_free_cModelFlux_inner:
+        y_free_cModel_fracDev:
+        y_free_cModel_devFlux:
+        y_free_cModel_devFluxErr:
+        y_free_cModel_expFlux:
+        y_free_cModel_expFluxErr:
+        y_free_psfFlux:
+        y_free_psfFluxErr:
+        y_free_psfFlux_flag:
+        y_gaap0p7FluxErr:
+        y_gaap1p0FluxErr:
+        y_gaapPsfFluxErr:
+        y_gaapPsfFlux:
+        y_gaap0p7Flux:
+        y_gaap1p0Flux:
+        y_gaapFlux_flag:
+        y_gaapFlux_flag_edge:
+        y_moments_g1:
+        y_moments_g2:
+        y_moments_trace:
+        y_moments_flag:
+        y_moments_psf_g1:
+        y_moments_psf_g2:
+        y_moments_psf_trace:
+        y_moments_psf_flag:
+        y_moments_psf_debiased_g1:
+        y_moments_psf_debiased_g2:
+        y_moments_psf_debiased_trace:
+        y_moments_psf_debiased_flag:
+        y_hsmShapeRegauss_e1:
+        y_hsmShapeRegauss_e2:
+        y_hsmShapeRegauss_flag:
+        y_hsmShapeRegauss_sigma:
+        y_iPSF_flag:
+        y_i_flag:
+        y_inputCount:
+        y_inputCount_flag:
+        y_inputCount_flag_noInputs:
+        y_ixx:
+        y_ixxPSF:
+        y_ixy:
+        y_ixyPSF:
+        y_iyy:
+        y_iyyPSF:
+        y_hsm_moments_30:
+        y_hsm_momentsPsf_30:
+        y_hsm_moments_21:
+        y_hsm_momentsPsf_21:
+        y_hsm_moments_12:
+        y_hsm_momentsPsf_12:
+        y_hsm_moments_03:
+        y_hsm_momentsPsf_03:
+        y_hsm_moments_40:
+        y_hsm_momentsPsf_40:
+        y_hsm_moments_31:
+        y_hsm_momentsPsf_31:
+        y_hsm_moments_22:
+        y_hsm_momentsPsf_22:
+        y_hsm_moments_13:
+        y_hsm_momentsPsf_13:
+        y_hsm_moments_04:
+        y_hsm_momentsPsf_04:
+        y_hsm_moments_flag:
+        y_hsm_momentsPsf_flag:
+        y_kronFlux:
+        y_kronFluxErr:
+        y_kronFlux_flag:
+        y_kronFlux_flag_bad_radius:
+        y_kronFlux_flag_bad_shape:
+        y_kronFlux_flag_bad_shape_no_psf:
+        y_kronFlux_flag_edge:
+        y_kronFlux_flag_no_fallback_radius:
+        y_kronFlux_flag_no_minimum_radius:
+        y_kronFlux_flag_small_radius:
+        y_kronFlux_flag_used_minimum_radius:
+        y_kronFlux_flag_used_psf_radius:
+        y_kronRad:
+        y_pixelFlags_bad:
+        y_pixelFlags_clipped:
+        y_pixelFlags_clippedCenter:
+        y_pixelFlags_cr:
+        y_pixelFlags_crCenter:
+        y_pixelFlags_edge:
+        y_pixelFlags_inexact_psf:
+        y_pixelFlags_inexact_psfCenter:
+        y_pixelFlags_interpolated:
+        y_pixelFlags_interpolatedCenter:
+        y_pixelFlags_nodata:
+        y_pixelFlags_offimage:
+        y_pixelFlags_saturated:
+        y_pixelFlags_saturatedCenter:
+        y_pixelFlags_sensor_edge:
+        y_pixelFlags_sensor_edgeCenter:
+        y_pixelFlags_suspect:
+        y_pixelFlags_suspectCenter:
+        y_invalidPsfFlag:
+        y_psfFlux:
+        y_psfFluxErr:
+        y_psfFlux_area:
+        y_psfFlux_flag:
+        y_psfFlux_flag_apCorr:
+        y_psfFlux_flag_edge:
+        y_psfFlux_flag_noGoodPixels:
+        y_ra:
+        y_raErr:
+        y_ra_dec_Cov:
+        y_deblend_dataCoverage:
+        y_deblend_blendedness:
+        y_deblend_fluxOverlap:
+        y_deblend_fluxOverlapFraction:
+        y_deblend_zeroFlux:
+        z_ap03Flux:
+        z_ap03FluxErr:
+        z_ap03Flux_flag:
+        z_ap06Flux:
+        z_ap06FluxErr:
+        z_ap06Flux_flag:
+        z_ap09Flux:
+        z_ap09FluxErr:
+        z_ap09Flux_flag:
+        z_ap12Flux:
+        z_ap12FluxErr:
+        z_ap12Flux_flag:
+        z_ap17Flux:
+        z_ap17FluxErr:
+        z_ap17Flux_flag:
+        z_ap25Flux:
+        z_ap25FluxErr:
+        z_ap25Flux_flag:
+        z_ap35Flux:
+        z_ap35FluxErr:
+        z_ap35Flux_flag:
+        z_ap50Flux:
+        z_ap50FluxErr:
+        z_ap50Flux_flag:
+        z_ap70Flux:
+        z_ap70FluxErr:
+        z_ap70Flux_flag:
+        z_apFlux_flag:
+        z_apFlux_flag_apertureTruncated:
+        z_apFlux_flag_sincCoeffsTruncated:
+        z_cModel_chi2:
+        z_cModel_devFlux:
+        z_cModel_devFluxErr:
+        z_cModel_expFlux:
+        z_cModel_expFluxErr:
+        z_cModel_dev_reff_major:
+        z_cModel_dev_reff_minor:
+        z_cModel_dev_theta:
+        z_cModel_exp_reff_major:
+        z_cModel_exp_reff_minor:
+        z_cModel_exp_theta:
+        z_blendedness:
+        z_blendedness_flag:
+        z_cModelFlux:
+        z_cModelFluxErr:
+        z_cModelFlux_inner:
+        z_cModel_fracDev:
+        z_cModel_flag:
+        z_cModel_flag_apCorr:
+        z_calib_astrometry_used:
+        z_calib_photometry_used:
+        z_calib_psf_candidate:
+        z_calib_psf_reserved:
+        z_calib_psf_used:
+        z_centroid_flag:
+        z_dec:
+        z_decErr:
+        z_extendedness:
+        z_extendedness_flag:
+        z_sizeExtendedness:
+        z_sizeExtendedness_flag:
+        z_model_extendedness:
+        z_free_cModelFlux:
+        z_free_cModelFluxErr:
+        z_free_cModelFlux_flag:
+        z_free_cModelFlux_inner:
+        z_free_cModel_fracDev:
+        z_free_cModel_devFlux:
+        z_free_cModel_devFluxErr:
+        z_free_cModel_expFlux:
+        z_free_cModel_expFluxErr:
+        z_free_psfFlux:
+        z_free_psfFluxErr:
+        z_free_psfFlux_flag:
+        z_gaap0p7FluxErr:
+        z_gaap1p0FluxErr:
+        z_gaapPsfFluxErr:
+        z_gaapPsfFlux:
+        z_gaap0p7Flux:
+        z_gaap1p0Flux:
+        z_gaapFlux_flag:
+        z_gaapFlux_flag_edge:
+        z_moments_g1:
+        z_moments_g2:
+        z_moments_trace:
+        z_moments_flag:
+        z_moments_psf_g1:
+        z_moments_psf_g2:
+        z_moments_psf_trace:
+        z_moments_psf_flag:
+        z_moments_psf_debiased_g1:
+        z_moments_psf_debiased_g2:
+        z_moments_psf_debiased_trace:
+        z_moments_psf_debiased_flag:
+        z_hsmShapeRegauss_e1:
+        z_hsmShapeRegauss_e2:
+        z_hsmShapeRegauss_flag:
+        z_hsmShapeRegauss_sigma:
+        z_iPSF_flag:
+        z_i_flag:
+        z_inputCount:
+        z_inputCount_flag:
+        z_inputCount_flag_noInputs:
+        z_ixx:
+        z_ixxPSF:
+        z_ixy:
+        z_ixyPSF:
+        z_iyy:
+        z_iyyPSF:
+        z_hsm_moments_30:
+        z_hsm_momentsPsf_30:
+        z_hsm_moments_21:
+        z_hsm_momentsPsf_21:
+        z_hsm_moments_12:
+        z_hsm_momentsPsf_12:
+        z_hsm_moments_03:
+        z_hsm_momentsPsf_03:
+        z_hsm_moments_40:
+        z_hsm_momentsPsf_40:
+        z_hsm_moments_31:
+        z_hsm_momentsPsf_31:
+        z_hsm_moments_22:
+        z_hsm_momentsPsf_22:
+        z_hsm_moments_13:
+        z_hsm_momentsPsf_13:
+        z_hsm_moments_04:
+        z_hsm_momentsPsf_04:
+        z_hsm_moments_flag:
+        z_hsm_momentsPsf_flag:
+        z_kronFlux:
+        z_kronFluxErr:
+        z_kronFlux_flag:
+        z_kronFlux_flag_bad_radius:
+        z_kronFlux_flag_bad_shape:
+        z_kronFlux_flag_bad_shape_no_psf:
+        z_kronFlux_flag_edge:
+        z_kronFlux_flag_no_fallback_radius:
+        z_kronFlux_flag_no_minimum_radius:
+        z_kronFlux_flag_small_radius:
+        z_kronFlux_flag_used_minimum_radius:
+        z_kronFlux_flag_used_psf_radius:
+        z_kronRad:
+        z_pixelFlags_bad:
+        z_pixelFlags_clipped:
+        z_pixelFlags_clippedCenter:
+        z_pixelFlags_cr:
+        z_pixelFlags_crCenter:
+        z_pixelFlags_edge:
+        z_pixelFlags_inexact_psf:
+        z_pixelFlags_inexact_psfCenter:
+        z_pixelFlags_interpolated:
+        z_pixelFlags_interpolatedCenter:
+        z_pixelFlags_nodata:
+        z_pixelFlags_offimage:
+        z_pixelFlags_saturated:
+        z_pixelFlags_saturatedCenter:
+        z_pixelFlags_sensor_edge:
+        z_pixelFlags_sensor_edgeCenter:
+        z_pixelFlags_suspect:
+        z_pixelFlags_suspectCenter:
+        z_invalidPsfFlag:
+        z_psfFlux:
+        z_psfFluxErr:
+        z_psfFlux_area:
+        z_psfFlux_flag:
+        z_psfFlux_flag_apCorr:
+        z_psfFlux_flag_edge:
+        z_psfFlux_flag_noGoodPixels:
+        z_ra:
+        z_raErr:
+        z_ra_dec_Cov:
+        z_deblend_dataCoverage:
+        z_deblend_blendedness:
+        z_deblend_fluxOverlap:
+        z_deblend_fluxOverlapFraction:
+        z_deblend_zeroFlux:
+        g_psfModel_TwoGaussian_gauss1_sigma_x:
+        g_psfModel_TwoGaussian_gauss1_sigma_y:
+        g_psfModel_TwoGaussian_gauss1_rho:
+        g_psfModel_TwoGaussian_gauss1_fluxfrac:
+        g_psfModel_TwoGaussian_gauss2_sigma_x:
+        g_psfModel_TwoGaussian_gauss2_sigma_y:
+        g_psfModel_TwoGaussian_gauss2_rho:
+        g_psfModel_TwoGaussian_n_iter:
+        g_psfModel_TwoGaussian_chi2_reduced:
+        g_psfModel_TwoGaussian_unknown_flag:
+        g_psfModel_TwoGaussian_no_inputs_flag:
+        i_psfModel_TwoGaussian_gauss1_sigma_x:
+        i_psfModel_TwoGaussian_gauss1_sigma_y:
+        i_psfModel_TwoGaussian_gauss1_rho:
+        i_psfModel_TwoGaussian_gauss1_fluxfrac:
+        i_psfModel_TwoGaussian_gauss2_sigma_x:
+        i_psfModel_TwoGaussian_gauss2_sigma_y:
+        i_psfModel_TwoGaussian_gauss2_rho:
+        i_psfModel_TwoGaussian_n_iter:
+        i_psfModel_TwoGaussian_chi2_reduced:
+        i_psfModel_TwoGaussian_unknown_flag:
+        i_psfModel_TwoGaussian_no_inputs_flag:
+        r_psfModel_TwoGaussian_gauss1_sigma_x:
+        r_psfModel_TwoGaussian_gauss1_sigma_y:
+        r_psfModel_TwoGaussian_gauss1_rho:
+        r_psfModel_TwoGaussian_gauss1_fluxfrac:
+        r_psfModel_TwoGaussian_gauss2_sigma_x:
+        r_psfModel_TwoGaussian_gauss2_sigma_y:
+        r_psfModel_TwoGaussian_gauss2_rho:
+        r_psfModel_TwoGaussian_n_iter:
+        r_psfModel_TwoGaussian_chi2_reduced:
+        r_psfModel_TwoGaussian_unknown_flag:
+        r_psfModel_TwoGaussian_no_inputs_flag:
+        y_psfModel_TwoGaussian_gauss1_sigma_x:
+        y_psfModel_TwoGaussian_gauss1_sigma_y:
+        y_psfModel_TwoGaussian_gauss1_rho:
+        y_psfModel_TwoGaussian_gauss1_fluxfrac:
+        y_psfModel_TwoGaussian_gauss2_sigma_x:
+        y_psfModel_TwoGaussian_gauss2_sigma_y:
+        y_psfModel_TwoGaussian_gauss2_rho:
+        y_psfModel_TwoGaussian_n_iter:
+        y_psfModel_TwoGaussian_chi2_reduced:
+        y_psfModel_TwoGaussian_unknown_flag:
+        y_psfModel_TwoGaussian_no_inputs_flag:
+        z_psfModel_TwoGaussian_gauss1_sigma_x:
+        z_psfModel_TwoGaussian_gauss1_sigma_y:
+        z_psfModel_TwoGaussian_gauss1_rho:
+        z_psfModel_TwoGaussian_gauss1_fluxfrac:
+        z_psfModel_TwoGaussian_gauss2_sigma_x:
+        z_psfModel_TwoGaussian_gauss2_sigma_y:
+        z_psfModel_TwoGaussian_gauss2_rho:
+        z_psfModel_TwoGaussian_n_iter:
+        z_psfModel_TwoGaussian_chi2_reduced:
+        z_psfModel_TwoGaussian_unknown_flag:
+        z_psfModel_TwoGaussian_no_inputs_flag:
+        exponential_ra:
+        exponential_raErr:
+        exponential_dec:
+        exponential_decErr:
+        exponential_ra_dec_Cov:
+        exponential_reff_x:
+        exponential_reff_xErr:
+        exponential_reff_y:
+        exponential_reff_yErr:
+        exponential_rho:
+        exponential_rhoErr:
+        exponential_reff_major:
+        exponential_reff_minor:
+        exponential_theta:
+        g_exponentialFlux:
+        g_exponentialFluxErr:
+        i_exponentialFlux:
+        i_exponentialFluxErr:
+        r_exponentialFlux:
+        r_exponentialFluxErr:
+        y_exponentialFlux:
+        y_exponentialFluxErr:
+        z_exponentialFlux:
+        z_exponentialFluxErr:
+        exponential_n_eval_jac:
+        exponential_n_iter:
+        exponential_chi2_reduced:
+        exponential_delta_lnL_fit_linear:
+        exponential_delta_lnL_fit_ps:
+        exponential_no_data_flag:
+        exponential_unknown_flag:
+        sersic_ra:
+        sersic_raErr:
+        sersic_dec:
+        sersic_decErr:
+        sersic_ra_dec_Cov:
+        sersic_reff_x:
+        sersic_reff_xErr:
+        sersic_reff_y:
+        sersic_reff_yErr:
+        sersic_rho:
+        sersic_rhoErr:
+        sersic_reff_major:
+        sersic_reff_minor:
+        sersic_theta:
+        g_sersicFlux:
+        g_sersicFluxErr:
+        i_sersicFlux:
+        i_sersicFluxErr:
+        r_sersicFlux:
+        r_sersicFluxErr:
+        y_sersicFlux:
+        y_sersicFluxErr:
+        z_sersicFlux:
+        z_sersicFluxErr:
+        sersic_index:
+        sersic_indexErr:
+        sersic_n_eval_jac:
+        sersic_n_iter:
+        sersic_chi2_reduced:
+        sersic_no_data_flag:
+        sersic_unknown_flag:
+        g_epoch:
+        i_epoch:
+        r_epoch:
+        y_epoch:
+        z_epoch:
   columns:
-  - name: objectId
-    datatype: long
-    description: Unique id. Unique ObjectID
-    ivoa:ucd: meta.id;src
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-  - name: coord_decErr
-    datatype: float
-    description: Error in fiducial ICRS Declination of centroid.
-    fits:tunit: deg
-  - name: coord_raErr
-    datatype: float
-    description: Error in fiducial ICRS Right Ascension of centroid.
-    fits:tunit: deg
-  - name: coord_ra_dec_Cov
-    datatype: float
-    description: Covariance between fiducial ICRS Right Ascension and Declination of centroid.
-    fits:tunit: deg**2
-  - name: deblend_parentNChild
-    datatype: int
-    description: Number of children in deblended from the parent footprint.
-    fits:tunit:
-  - name: deblend_parentNPeaks
-    datatype: int
-    description: Number of peaks the parent footprint has (even if the deblender
-      failed or skipped this blend)
-    fits:tunit:
-  - name: deblend_peak_center_x
-    datatype: int
-    description: x-coordinate of the peak after source detection
-    fits:tunit: pixel
-  - name: deblend_peak_center_y
-    datatype: int
-    description: y-coordinate of the peak after source detection
-    fits:tunit: pixel
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-    fits:tunit:
-  - name: deblend_blendId
-    description: Unique ID of the deconvolved parent source that this source was deblended from.
-    datatype: long
-    fits:tunit:
-  - name: deblend_blendNChild
-    description: Number of children in the deconvolved parent source that this source
-      was deblended from.
-    datatype: int
-    fits:tunit:
-  - name: detect_fromBlend
-    datatype: boolean
-    description: This source is deblended from a parent with more than one child.
-    fits:tunit:
-  - name: detect_isDeblendedModelSource
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is a deblended child
-    fits:tunit:
   - name: detect_isDeblendedSource
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
-    fits:tunit:
-  - name: detect_isIsolated
-    datatype: boolean
-    description: This source is not a part of a blend.
     fits:tunit:
   - name: detect_isPatchInner
     datatype: boolean
@@ -94,4289 +1066,178 @@ tables:
     datatype: boolean
     description: True if source is in the inner region of a coadd tract
     fits:tunit:
-  - name: ebv
-    datatype: float
-    description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
-    fits:tunit: mag
-  - name: footprintArea
-    datatype: int
-    description: Number of pixels in the sources detection footprint. Reference band.
-    fits:tunit: pixel
   - name: merge_peak_sky
     datatype: boolean
     description: Peak detected in filter sky
     fits:tunit:
-  - name: parentObjectId
-    datatype: long
-    description: Unique ID of parent source. Reference band.
-    fits:tunit:
-  - name: patch
-    datatype: long
-    description: Skymap patch ID
-    fits:tunit:
-  - name: refBand
-    datatype: char
-    length: 1
-    description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
-    fits:tunit:
-  - name: refExtendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Reference band.
-    fits:tunit:
-  - name: refSizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Reference band.
-    fits:tunit:
-  - name: shape_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Reference band.
-    fits:tunit:
-  - name: shape_xx
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
-  - name: shape_xy
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
-  - name: shape_yy
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
   - name: sky_object
     datatype: boolean
     description: No source was detected here. This object exists to characterize properties of the sky background
     fits:tunit:
-  - name: tract
-    datatype: long
-    description: Skymap tract ID
-    fits:tunit:
-  - name: coord_flag
-    description: General Centroid Failure Flag. Reference band.
-    datatype: boolean
-  - name: g_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on g-band.
-    fits:tunit:
-  - name: g_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    fits:tunit:
-  - name: g_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on g-band.
-    fits:tunit:
-  - name: g_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on g-band.
-    fits:tunit:
-  - name: g_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on g-band.
-    fits:tunit:
-  - name: g_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_dec
-    datatype: double
-    description: Position in declination, measured on g-band.
-    fits:tunit: deg
-  - name: g_decErr
-    datatype: float
-    description: Error in declination, measured on g-band.
-    fits:tunit: deg
-  - name: g_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on g-band.
-    fits:tunit:
-  - name: g_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on g-band.
-    fits:tunit:
-  - name: g_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on g-band.
-    fits:tunit:
-  - name: g_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on g-band.
-    fits:tunit:
-  - name: g_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
-    fits:tunit:
-  - name: g_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on g-band.
-    fits:tunit:
-  - name: g_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on g-band.
-    fits:tunit:
-  - name: g_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on g-band.
-    fits:tunit:
-  - name: g_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on g-band.
-    fits:tunit:
-  - name: g_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_trace
-    description: Moments-based trace radius (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_flag
-    description: Failure flag for moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_trace
-    description: Moments-based trace radius of the PSF (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_flag
-    description: Failure flag for PSF moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (g-band)
-    datatype: boolean
-  - name: g_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on g-band.
-    fits:tunit:
-  - name: g_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on g-band.
-    fits:tunit:
-  - name: g_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on g-band.
-    fits:tunit:
-  - name: g_ixx
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixy
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_iyy
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with g_i_flag. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with g_iPSF_flag. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on g-band.
-    fits:tunit:
-  - name: g_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on g-band.
-    fits:tunit:
-  - name: g_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on g-band.
-    fits:tunit: pixel
-  - name: g_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on g-band.
-    fits:tunit:
-  - name: g_ra
-    datatype: double
-    description: Position in right ascension, measured on g-band.
-    fits:tunit: deg
-  - name: g_raErr
-    datatype: float
-    description: Error in right ascension, measured on g-band.
-    fits:tunit: deg
-  - name: g_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on g-band.
-    fits:tunit: deg**2
-  - name: g_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the g-band.
-    fits:tunit:
-  - name: g_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: g_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: g_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: g_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: griz_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses the sum of g, r, i, and z-band fluxes.
-    fits:tunit:
-  - name: i_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on i-band.
-    fits:tunit:
-  - name: i_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    fits:tunit:
-  - name: i_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on i-band.
-    fits:tunit:
-  - name: i_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on i-band.
-    fits:tunit:
-  - name: i_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on i-band.
-    fits:tunit:
-  - name: i_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_dec
-    datatype: double
-    description: Position in declination, measured on i-band.
-    fits:tunit: deg
-  - name: i_decErr
-    datatype: float
-    description: Error in declination, measured on i-band.
-    fits:tunit: deg
-  - name: i_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on i-band.
-    fits:tunit:
-  - name: i_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on i-band.
-    fits:tunit:
-  - name: i_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on i-band.
-    fits:tunit:
-  - name: i_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on i-band.
-    fits:tunit:
-  - name: i_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
-    fits:tunit:
-  - name: i_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on i-band.
-    fits:tunit:
-  - name: i_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on i-band.
-    fits:tunit:
-  - name: i_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on i-band.
-    fits:tunit:
-  - name: i_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on i-band.
-    fits:tunit:
-  - name: i_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_trace
-    description: Moments-based trace radius (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_flag
-    description: Failure flag for moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_trace
-    description: Moments-based trace radius of the PSF (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_flag
-    description: Failure flag for PSF moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (i-band)
-    datatype: boolean
-  - name: i_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on i-band.
-    fits:tunit:
-  - name: i_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on i-band.
-    fits:tunit:
-  - name: i_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on i-band.
-    fits:tunit:
-  - name: i_ixx
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixy
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_iyy
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with i_i_flag. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with i_iPSF_flag. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on i-band.
-    fits:tunit:
-  - name: i_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on i-band.
-    fits:tunit:
-  - name: i_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on i-band.
-    fits:tunit: pixel
-  - name: i_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on i-band.
-    fits:tunit:
-  - name: i_ra
-    datatype: double
-    description: Position in right ascension, measured on i-band.
-    fits:tunit: deg
-  - name: i_raErr
-    datatype: float
-    description: Error in right ascension, measured on i-band.
-    fits:tunit: deg
-  - name: i_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on i-band.
-    fits:tunit: deg**2
-  - name: i_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the i-band.
-    fits:tunit:
-  - name: i_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: i_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: i_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: i_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: r_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on r-band.
-    fits:tunit:
-  - name: r_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    fits:tunit:
-  - name: r_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on r-band.
-    fits:tunit:
-  - name: r_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on r-band.
-    fits:tunit:
-  - name: r_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on r-band.
-    fits:tunit:
-  - name: r_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_dec
-    datatype: double
-    description: Position in declination, measured on r-band.
-    fits:tunit: deg
-  - name: r_decErr
-    datatype: float
-    description: Error in declination, measured on r-band.
-    fits:tunit: deg
-  - name: r_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on r-band.
-    fits:tunit:
-  - name: r_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on r-band.
-    fits:tunit:
-  - name: r_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on r-band.
-    fits:tunit:
-  - name: r_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on r-band.
-    fits:tunit:
-  - name: r_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
-    fits:tunit:
-  - name: r_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on r-band.
-    fits:tunit:
-  - name: r_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on r-band.
-    fits:tunit:
-  - name: r_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on r-band.
-    fits:tunit:
-  - name: r_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on r-band.
-    fits:tunit:
-  - name: r_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_trace
-    description: Moments-based trace radius (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_flag
-    description: Failure flag for moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_trace
-    description: Moments-based trace radius of the PSF (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_flag
-    description: Failure flag for PSF moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (r-band)
-    datatype: boolean
-  - name: r_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on r-band.
-    fits:tunit:
-  - name: r_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on r-band.
-    fits:tunit:
-  - name: r_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on r-band.
-    fits:tunit:
-  - name: r_ixx
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixy
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_iyy
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with r_i_flag. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with r_iPSF_flag. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on r-band.
-    fits:tunit:
-  - name: r_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on r-band.
-    fits:tunit:
-  - name: r_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on r-band.
-    fits:tunit: pixel
-  - name: r_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on r-band.
-    fits:tunit:
-  - name: r_ra
-    datatype: double
-    description: Position in right ascension, measured on r-band.
-    fits:tunit: deg
-  - name: r_raErr
-    datatype: float
-    description: Error in right ascension, measured on r-band.
-    fits:tunit: deg
-  - name: r_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on r-band.
-    fits:tunit: deg**2
-  - name: r_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the r-band.
-    fits:tunit:
-  - name: r_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: r_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: r_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: r_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: y_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on y-band.
-    fits:tunit:
-  - name: y_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    fits:tunit:
-  - name: y_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on y-band.
-    fits:tunit:
-  - name: y_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on y-band.
-    fits:tunit:
-  - name: y_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on y-band.
-    fits:tunit:
-  - name: y_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_dec
-    datatype: double
-    description: Position in declination, measured on y-band.
-    fits:tunit: deg
-  - name: y_decErr
-    datatype: float
-    description: Error in declination, measured on y-band.
-    fits:tunit: deg
-  - name: y_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on y-band.
-    fits:tunit:
-  - name: y_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on y-band.
-    fits:tunit:
-  - name: y_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on y-band.
-    fits:tunit:
-  - name: y_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on y-band.
-    fits:tunit:
-  - name: y_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
-    fits:tunit:
-  - name: y_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on y-band.
-    fits:tunit:
-  - name: y_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on y-band.
-    fits:tunit:
-  - name: y_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on y-band.
-    fits:tunit:
-  - name: y_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on y-band.
-    fits:tunit:
-  - name: y_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_trace
-    description: Moments-based trace radius (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_flag
-    description: Failure flag for moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_trace
-    description: Moments-based trace radius of the PSF (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_flag
-    description: Failure flag for PSF moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (y-band)
-    datatype: boolean
-  - name: y_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on y-band.
-    fits:tunit:
-  - name: y_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on y-band.
-    fits:tunit:
-  - name: y_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on y-band.
-    fits:tunit:
-  - name: y_ixx
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixy
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_iyy
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with y_i_flag. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with y_iPSF_flag. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on y-band.
-    fits:tunit:
-  - name: y_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on y-band.
-    fits:tunit:
-  - name: y_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on y-band.
-    fits:tunit: pixel
-  - name: y_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on y-band.
-    fits:tunit:
-  - name: y_ra
-    datatype: double
-    description: Position in right ascension, measured on y-band.
-    fits:tunit: deg
-  - name: y_raErr
-    datatype: float
-    description: Error in right ascension, measured on y-band.
-    fits:tunit: deg
-  - name: y_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on y-band.
-    fits:tunit: deg**2
-  - name: y_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the y-band.
-    fits:tunit:
-  - name: y_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: y_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: y_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: y_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: z_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on z-band.
-    fits:tunit:
-  - name: z_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    fits:tunit:
-  - name: z_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on z-band.
-    fits:tunit:
-  - name: z_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on z-band.
-    fits:tunit:
-  - name: z_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on z-band.
-    fits:tunit:
-  - name: z_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_dec
-    datatype: double
-    description: Position in declination, measured on z-band.
-    fits:tunit: deg
-  - name: z_decErr
-    datatype: float
-    description: Error in declination, measured on z-band.
-    fits:tunit: deg
-  - name: z_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on z-band.
-    fits:tunit:
-  - name: z_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on z-band.
-    fits:tunit:
-  - name: z_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on z-band.
-    fits:tunit:
-  - name: z_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on z-band.
-    fits:tunit:
-  - name: z_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
-    fits:tunit:
-  - name: z_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on z-band.
-    fits:tunit:
-  - name: z_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on z-band.
-    fits:tunit:
-  - name: z_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleur fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleur fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on z-band.
-    fits:tunit:
-  - name: z_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on z-band.
-    fits:tunit:
-  - name: z_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_trace
-    description: Moments-based trace radius (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_flag
-    description: Failure flag for moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_trace
-    description: Moments-based trace radius of the PSF (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_flag
-    description: Failure flag for PSF moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (z-band)
-    datatype: boolean
-  - name: z_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on z-band.
-    fits:tunit:
-  - name: z_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on z-band.
-    fits:tunit:
-  - name: z_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on z-band.
-    fits:tunit:
-  - name: z_ixx
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixy
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_iyy
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with z_i_flag. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with z_iPSF_flag. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on z-band.
-    fits:tunit:
-  - name: z_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on z-band.
-    fits:tunit:
-  - name: z_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on z-band.
-    fits:tunit: pixel
-  - name: z_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on z-band.
-    fits:tunit:
-  - name: z_ra
-    datatype: double
-    description: Position in right ascension, measured on z-band.
-    fits:tunit: deg
-  - name: z_raErr
-    datatype: float
-    description: Error in right ascension, measured on z-band.
-    fits:tunit: deg
-  - name: z_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on z-band.
-    fits:tunit: deg**2
-  - name: z_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the z-band.
-    fits:tunit:
-  - name: z_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: z_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: z_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: z_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: exponential_ra
-    datatype: double
-    description: Centroid (right ascension) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_raErr
-    datatype: float
-    description: Error on the centroid (right ascension) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_dec
-    datatype: double
-    description: Centroid (declination) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_decErr
-    datatype: float
-    description: Error on the centroid (declination) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband exponential model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: exponential_reff_x
-    datatype: float
-    description: Effective radius (x-axis) from the multiband exponential model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: exponential_reff_xErr
-    datatype: float
-    description: Error on the effective radius (x-axis) from the multiband exponential model fit.
-    fits:tunit: pixel
-  - name: exponential_reff_y
-    datatype: float
-    description: Effective radius (y-axis) from the multiband exponential model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: exponential_reff_yErr
-    datatype: float
-    description: Error on the effective radius (y-axis) from the multiband exponential model fit.
-    fits:tunit: pixel
-  - name: exponential_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_rhoErr
-    datatype: float
-    description: Error on ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: exponential_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: exponential_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-    fits:tunit:
-  - name: g_exponentialFlux
-    datatype: float
-    description: g-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: g_exponentialFluxErr
-    datatype: float
-    description: Error on the g-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: i_exponentialFlux
-    datatype: float
-    description: i-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: i_exponentialFluxErr
-    datatype: float
-    description: Error on the i-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: r_exponentialFlux
-    datatype: float
-    description: r-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: r_exponentialFluxErr
-    datatype: float
-    description: Error on the r-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: y_exponentialFlux
-    datatype: float
-    description: y-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: y_exponentialFluxErr
-    datatype: float
-    description: Error on the y-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: z_exponentialFlux
-    datatype: float
-    description: z-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: z_exponentialFluxErr
-    datatype: float
-    description: Error on the z-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: exponential_n_eval_jac
-    datatype: int
-    description: Number of Jacobian evaluations for the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_delta_lnL_fit_linear
-    datatype: float
-    description: The ln-likelihood of the best model non-linear fit parameters minus the ln-likelihood of a subsequent linear least squares fit.
-    fits:tunit:
-  - name: exponential_delta_lnL_fit_ps
-    datatype: float
-    description: The ln-likelihood of the best-fit exponential model minus the ln-likelihood of a point source with the same centroid and PSF model.
-    fits:tunit:
-  - name: exponential_no_data_flag
-    datatype: boolean
-    description: Flag set when there is insufficient data to fit for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the multiband exponential model.
-    fits:tunit:
-  - name: sersic_ra
-    datatype: double
-    description: Centroid (right ascension) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_raErr
-    datatype: float
-    description: Error on the centroid (right ascension) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_dec
-    datatype: double
-    description: Centroid (declination) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_decErr
-    datatype: float
-    description: Error on the centroid (declination) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband Sersic model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: sersic_reff_x
-    datatype: float
-    description: Effective radius (x-axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: sersic_reff_xErr
-    datatype: float
-    description: Error on the effective radius (x-axis) from the multiband Sersic model fit.
-    fits:tunit: pixel
-  - name: sersic_reff_y
-    datatype: float
-    description: Effective radius (y-axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: sersic_reff_yErr
-    datatype: float
-    description: Error on the effective radius (y-axis) from the multiband Sersic model fit.
-    fits:tunit: pixel
-  - name: sersic_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_rhoErr
-    datatype: float
-    description: Error on ellipse rho (correlation coefficient) from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: sersic_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: sersic_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-    fits:tunit:
-  - name: g_sersicFlux
-    datatype: float
-    description: g-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: g_sersicFluxErr
-    datatype: float
-    description: Error on the g-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: i_sersicFlux
-    datatype: float
-    description: i-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: i_sersicFluxErr
-    datatype: float
-    description: Error on the i-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: r_sersicFlux
-    datatype: float
-    description: r-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: r_sersicFluxErr
-    datatype: float
-    description: Error on the r-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: y_sersicFlux
-    datatype: float
-    description: y-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: y_sersicFluxErr
-    datatype: float
-    description: Error on the y-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: z_sersicFlux
-    datatype: float
-    description: z-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: z_sersicFluxErr
-    datatype: float
-    description: Error on the z-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: sersic_index
-    datatype: float
-    description: Sersic profile index parameter from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_indexErr
-    datatype: float
-    description: Error on the Sersic profile index parameter from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_n_eval_jac
-    datatype: int
-    description: Number of Jacobian evaluations for the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_no_data_flag
-    datatype: boolean
-    description: Flag set when there is insufficient data to fit for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the multiband Sersic model.
-    fits:tunit:
-  - name: g_epoch
-    datatype: double
-    description: Mean epoch of the object in the g-band coadd in MJD TAI
-    fits:tunit: d
-  - name: i_epoch
-    datatype: double
-    description: Mean epoch of the object in the i-band coadd in MJD TAI
-    fits:tunit: d
-  - name: r_epoch
-    datatype: double
-    description: Mean epoch of the object in the r-band coadd in MJD TAI
-    fits:tunit: d
-  - name: y_epoch
-    datatype: double
-    description: Mean epoch of the object in the y-band coadd in MJD TAI
-    fits:tunit: d
-  - name: z_epoch
-    datatype: double
-    description: Mean epoch of the object in the z-band coadd in MJD TAI
-    fits:tunit: d
-
 - name: Source
   description: Table to store high signal-to-noise sources;. A source is
     a measurement of Object's properties from a single image that contains its footprint
     on the sky.
+  columnRefs:
+    base:
+      Source:
+        sourceId:
+        coord_ra:
+        coord_dec:
+        visit:
+        detector:
+        parentSourceId:
+        x:
+        y:
+        xErr:
+        yErr:
+        ra:
+        dec:
+        raErr:
+        decErr:
+        ra_dec_Cov:
+        calibFlux:
+        calibFluxErr:
+        ap03Flux:
+        ap03FluxErr:
+        ap03Flux_flag:
+        ap06Flux:
+        ap06FluxErr:
+        ap06Flux_flag:
+        ap09Flux:
+        ap09FluxErr:
+        ap09Flux_flag:
+        ap12Flux:
+        ap12FluxErr:
+        ap12Flux_flag:
+        ap17Flux:
+        ap17FluxErr:
+        ap17Flux_flag:
+        ap25Flux:
+        ap25FluxErr:
+        ap25Flux_flag:
+        ap35Flux:
+        ap35FluxErr:
+        ap35Flux_flag:
+        ap50Flux:
+        ap50FluxErr:
+        ap50Flux_flag:
+        ap70Flux:
+        ap70FluxErr:
+        ap70Flux_flag:
+        sky:
+        skyErr:
+        psfFlux:
+        psfFluxErr:
+        ixx:
+        iyy:
+        ixy:
+        ixxPSF:
+        iyyPSF:
+        ixyPSF:
+        ixxDebiasedPSF:
+        iyyDebiasedPSF:
+        ixyDebiasedPSF:
+        gaussianFlux:
+        gaussianFluxErr:
+        extendedness:
+        sizeExtendedness:
+        blendedness_abs:
+        blendedness_flag:
+        blendedness_flag_noCentroid:
+        blendedness_flag_noShape:
+        apFlux_12_0_flag:
+        apFlux_12_0_flag_apertureTruncated:
+        apFlux_12_0_flag_sincCoeffsTruncated:
+        apFlux_12_0_instFlux:
+        apFlux_12_0_instFluxErr:
+        apFlux_17_0_flag:
+        apFlux_17_0_instFlux:
+        apFlux_17_0_instFluxErr:
+        apFlux_35_0_flag:
+        apFlux_35_0_instFlux:
+        apFlux_35_0_instFluxErr:
+        apFlux_50_0_flag:
+        apFlux_50_0_instFlux:
+        apFlux_50_0_instFluxErr:
+        normCompTophatFlux_flag:
+        normCompTophatFlux_instFlux:
+        normCompTophatFlux_instFluxErr:
+        extendedness_flag:
+        sizeExtendedness_flag:
+        footprintArea_value:
+        jacobian_flag:
+        jacobian_value:
+        localBackground_instFlux:
+        localBackground_instFluxErr:
+        localBackground_flag:
+        localBackground_flag_noGoodPixels:
+        localBackground_flag_noPsf:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_offimage:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        invalidPsfFlag:
+        psfFlux_apCorr:
+        psfFlux_apCorrErr:
+        psfFlux_area:
+        psfFlux_flag:
+        psfFlux_flag_apCorr:
+        psfFlux_flag_edge:
+        psfFlux_flag_noGoodPixels:
+        gaussianFlux_flag:
+        centroid_flag:
+        centroid_flag_almostNoSecondDerivative:
+        centroid_flag_badError:
+        centroid_flag_edge:
+        centroid_flag_noSecondDerivative:
+        centroid_flag_notAtMaximum:
+        centroid_flag_resetToPeak:
+        variance_flag:
+        variance_flag_emptyFootprint:
+        variance_value:
+        calib_astrometry_used:
+        calib_photometry_reserved:
+        calib_photometry_used:
+        calib_psf_candidate:
+        calib_psf_reserved:
+        calib_psf_used:
+        deblend_deblendedAsPsf:
+        deblend_hasStrayFlux:
+        deblend_masked:
+        deblend_nChild:
+        deblend_parentTooBig:
+        deblend_patchedTemplate:
+        deblend_rampedTemplate:
+        deblend_skipped:
+        deblend_tooManyPeaks:
+        hsmPsfMoments_flag:
+        hsmPsfMoments_flag_no_pixels:
+        hsmPsfMoments_flag_not_contained:
+        hsmPsfMoments_flag_parent_source:
+        iDebiasedPSF_flag:
+        iDebiasedPSF_flag_no_pixels:
+        iDebiasedPSF_flag_not_contained:
+        iDebiasedPSF_flag_parent_source:
+        iDebiasedPSF_flag_galsim:
+        iDebiasedPSF_flag_edge:
+        hsmShapeRegauss_flag:
+        hsmShapeRegauss_flag_galsim:
+        hsmShapeRegauss_flag_no_pixels:
+        hsmShapeRegauss_flag_not_contained:
+        hsmShapeRegauss_flag_parent_source:
+        sky_source:
+        band:
+        physical_filter:
   columns:
-  - name: sourceId
-    datatype: long
-    nullable: false
-    description: Unique id. Unique Source ID. Primary Key.
-    ivoa:ucd: meta.id;src
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-  - name: visit
-    datatype: long
-    nullable: false
-    description: Id of the visit where this source was measured.
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    datatype: short
-    nullable: false
-    description: Id of the detector where this source was measured.
-      Datatype short instead of byte because of DB concerns about unsigned bytes.
-    ivoa:ucd: meta.id;obs.image
-  - name: parentSourceId
-    datatype: long
-    description: Unique ID of parent source
-    fits:tunit:
-  - name: x
-    datatype: double
-    description: Centroid from Sdss Centroid algorithm
-    fits:tunit: pixel
-  - name: y
-    datatype: double
-    description: Centroid from Sdss Centroid algorithm
-    fits:tunit: pixel
-  - name: xErr
-    datatype: float
-    description: 1-sigma uncertainty on x position
-    fits:tunit: pixel
-  - name: yErr
-    datatype: float
-    description: 1-sigma uncertainty on y position
-    fits:tunit: pixel
-  - name: ra
-    datatype: double
-    description: Position in right ascension.
-    fits:tunit: deg
-  - name: dec
-    datatype: double
-    description: Position in declination.
-    fits:tunit: deg
-  - name: raErr
-    datatype: float
-    description: Error in right ascension.
-    fits:tunit: deg
-  - name: decErr
-    datatype: float
-    description: Error in declination.
-    fits:tunit: deg
-  - name: ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination.
-    fits:tunit: deg**2
-  - name: calibFlux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: calibFluxErr
-    datatype: double
-    description: Flux uncertainty within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03Flux
-    datatype: double
-    description: Flux within 3.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03FluxErr
-    datatype: double
-    description: Flux uncertainty within 3.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap06Flux
-    datatype: double
-    description: Flux within 6.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap06FluxErr
-    datatype: double
-    description: Flux uncertainty within 6.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap09Flux
-    datatype: double
-    description: Flux within 9.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap09FluxErr
-    datatype: double
-    description: Flux uncertainty within 9.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap12Flux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap12FluxErr
-    datatype: double
-    description: Flux uncertainty within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap17Flux
-    datatype: double
-    description: Flux within 17.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap17FluxErr
-    datatype: double
-    description: Flux uncertainty within 17.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap25Flux
-    datatype: double
-    description: Flux within 25.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap25FluxErr
-    datatype: double
-    description: Flux uncertainty within 25.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap35Flux
-    datatype: double
-    description: Flux within 35.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap35FluxErr
-    datatype: double
-    description: Flux uncertainty within 35.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap50Flux
-    datatype: double
-    description: Flux within 50.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap50FluxErr
-    datatype: double
-    description: Flux uncertainty within 50.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap70Flux
-    datatype: double
-    description: Flux within 70.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap70FluxErr
-    datatype: double
-    description: Flux uncertainty within 70.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: sky
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: nJy
-  - name: skyErr
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: nJy
-  - name: psfFlux
-    datatype: double
-    description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: psfFluxErr
-    datatype: double
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: ixx
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: iyy
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixy
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixxPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: iyyPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixyPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixxDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit:
-  - name: iyyDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit:
-  - name: ixyDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit:
-  - name: gaussianFlux
-    datatype: double
-    description: Flux from Gaussian Flux algorithm
-    fits:tunit: nJy
-  - name: gaussianFluxErr
-    datatype: double
-    description: Flux uncertainty from Gaussian Flux algorithm
-    fits:tunit: nJy
-  - name: extendedness
-    datatype: double
-    description: Set to 1 for extended sources, 0 for point sources.
-    fits:tunit:
-  - name: sizeExtendedness
-    datatype: double
-    description: Moments-based measure of a source to be a galaxy.
-    fits:tunit:
   - name: localPhotoCalib
     datatype: double
     description: Local approximation of the PhotoCalib calibration factor at the location of the src.
@@ -4409,457 +1270,32 @@ tables:
     datatype: double
     description: (2, 2) element of the CDMatrix for the linear approximation of the WCS at the src location. Gives units in radians.
     fits:tunit:
-  - name: blendedness_abs
-    datatype: double
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit:
-  - name: blendedness_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: blendedness_flag_noCentroid
-    datatype: boolean
-    description: Object has no centroid
-    fits:tunit:
-  - name: blendedness_flag_noShape
-    datatype: boolean
-    description: Object has no shape
-    fits:tunit:
-  - name: apFlux_12_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_12_0_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image
-    fits:tunit:
-  - name: apFlux_12_0_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image
-    fits:tunit:
-  - name: apFlux_12_0_instFlux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_12_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_17_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_17_0_instFlux
-    datatype: double
-    description: Flux within 17.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_17_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_35_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_35_0_instFlux
-    datatype: double
-    description: Flux within 35.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_35_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_50_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_50_0_instFlux
-    datatype: double
-    description: Flux within 50.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_50_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: normCompTophatFlux_flag
-    datatype: boolean
-    description: General failure flag for normCompTophatFlux.
-    fits:tunit:
-  - name: normCompTophatFlux_instFlux
-    datatype: double
-    description: Normalized compensated tophat flux for calibration
-    fits:tunit: count
-  - name: normCompTophatFlux_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty on normCompTophatFlux_instFlux
-    fits:tunit: count
-  - name: extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure.
-    fits:tunit:
-  - name: sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure.
-    fits:tunit:
-  - name: footprintArea_value
-    datatype: int
-    description: Number of pixels in the sources detection footprint.
-    fits:tunit: pixel
-  - name: jacobian_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure
-    fits:tunit:
-  - name: jacobian_value
-    datatype: double
-    description: Jacobian correction
-    fits:tunit:
-  - name: localBackground_instFlux
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: count
-  - name: localBackground_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: localBackground_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: localBackground_flag_noGoodPixels
-    datatype: boolean
-    description: No good pixels in the annulus
-    fits:tunit:
-  - name: localBackground_flag_noPsf
-    datatype: boolean
-    description: No PSF provided
-    fits:tunit:
-  - name: pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center
-    fits:tunit:
-  - name: pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE)
-    fits:tunit:
-  - name: pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA)
-    fits:tunit:
-  - name: pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image
-    fits:tunit:
-  - name: pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels
-    fits:tunit:
-  - name: pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels
-    fits:tunit:
-  # These can be restored after both DM-46947 and DM-43077 are done.
-  # - name: pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint.
-  #   fits:tunit:
-  # - name: pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center.
-  #   fits:tunit:
-  - name: invalidPsfFlag
-    datatype: boolean
-    description: Source has an invalid psf.
-    fits:tunit:
-  - name: psfFlux_apCorr
-    datatype: double
-    description: Aperture correction applied to base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_apCorrErr
-    datatype: double
-    description: Standard deviation of aperture correction applied to base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_area
-    datatype: float
-    description: Effective area of PSF
-    fits:tunit: pixel
-  - name: psfFlux_flag
-    datatype: boolean
-    description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    fits:tunit:
-  - name: psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model
-    fits:tunit:
-  - name: psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit
-    fits:tunit:
-  - name: gaussianFlux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: centroid_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: centroid_flag_almostNoSecondDerivative
-    datatype: boolean
-    description: Almost vanishing second derivative
-    fits:tunit:
-  - name: centroid_flag_badError
-    datatype: boolean
-    description: Error on x and/or y position is NaN
-    fits:tunit:
-  - name: centroid_flag_edge
-    datatype: boolean
-    description: Object too close to edge
-    fits:tunit:
-  - name: centroid_flag_noSecondDerivative
-    datatype: boolean
-    description: Vanishing second derivative
-    fits:tunit:
-  - name: centroid_flag_notAtMaximum
-    datatype: boolean
-    description: Object is not at a maximum
-    fits:tunit:
-  - name: centroid_flag_resetToPeak
-    datatype: boolean
-    description: Set if CentroidChecker reset the centroid
-    fits:tunit:
-  - name: variance_flag
-    datatype: boolean
-    description: Set for any fatal failure
-    fits:tunit:
-  - name: variance_flag_emptyFootprint
-    datatype: boolean
-    description: Set to True when the footprint has no usable pixels
-    fits:tunit:
-  - name: variance_value
-    datatype: double
-    description: Variance at object position
-    fits:tunit:
-  - name: calib_astrometry_used
-    datatype: boolean
-    description: Set if source was used in astrometric calibration
-    fits:tunit:
-  - name: calib_photometry_reserved
-    datatype: boolean
-    description: Set if source was reserved from photometric calibration
-    fits:tunit:
-  - name: calib_photometry_used
-    datatype: boolean
-    description: Set if source was used in photometric calibration
-    fits:tunit:
-  - name: calib_psf_candidate
-    datatype: boolean
-    description: Flag set if the source was a candidate for PSF determination, as determined by the star selector.
-    fits:tunit:
-  - name: calib_psf_reserved
-    datatype: boolean
-    description: Set if source was reserved from PSF determination
-    fits:tunit:
-  - name: calib_psf_used
-    datatype: boolean
-    description: Flag set if the source was actually used for PSF determination, as determined by the
-    fits:tunit:
-  - name: deblend_deblendedAsPsf
-    datatype: boolean
-    description: Deblender thought this source looked like a PSF
-    fits:tunit:
-  - name: deblend_hasStrayFlux
-    datatype: boolean
-    description: This source was assigned some stray flux
-    fits:tunit:
-  - name: deblend_masked
-    datatype: boolean
-    description: Parent footprint was predominantly masked
-    fits:tunit:
-  - name: deblend_nChild
-    datatype: int
-    description: Number of children this object has (defaults to 0)
-    fits:tunit:
-  - name: deblend_parentTooBig
-    datatype: boolean
-    description: Parent footprint covered too many pixels
-    fits:tunit:
-  - name: deblend_patchedTemplate
-    datatype: boolean
-    description: This source was near an image edge and the deblender used patched edge-handling.
-    fits:tunit:
-  - name: deblend_rampedTemplate
-    datatype: boolean
-    description: This source was near an image edge and the deblender used ramp edge-handling.
-    fits:tunit:
-  - name: deblend_skipped
-    datatype: boolean
-    description: Deblender skipped this source
-    fits:tunit:
-  - name: deblend_tooManyPeaks
-    datatype: boolean
-    description: Source had too many peaks; only the brightest were included
-    fits:tunit:
-  - name: hsmPsfMoments_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: hsmPsfMoments_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: hsmPsfMoments_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: hsmPsfMoments_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: iDebiasedPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: iDebiasedPSF_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: iDebiasedPSF_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: iDebiasedPSF_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: iDebiasedPSF_flag_galsim
-    datatype: boolean
-    description: GalSim failure
-    fits:tunit:
-  - name: iDebiasedPSF_flag_edge
-    datatype: boolean
-    description: Variance undefined outside image edge
-    fits:tunit:
-  - name: hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_galsim
-    datatype: boolean
-    description: GalSim failure
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: sky_source
-    datatype: boolean
-    description: Sky objects.
-    fits:tunit:
   - name: detect_isPrimary
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
     fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
-    fits:tunit:
-  - name: physical_filter
-    datatype: char
-    description: ID of physical filter, the filter associated with a particular instrument.
-    length: 5
-    fits:tunit:
 - name: Visit
   description: Defines a single Visit.
+  columnRefs:
+    base:
+      Visit:
+        visit:
+        physical_filter:
+        band:
+        ra:
+        dec:
+        skyRotation:
+        azimuth:
+        altitude:
+        zenithDistance:
+        airmass:
+        expTime:
+        obsStart:
   columns:
-  - name: visit
-    datatype: long
-    description: Unique identifier.
-    ivoa:ucd: meta.id;obs.image
-  - name: physical_filter
-    datatype: char
-    length: 32
-    description: ID of physical filter, the filter associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: ra
-    datatype: double
-    description: RA of focal plane center.
-    fits:tunit: deg
-  - name: dec
-    datatype: double
-    description: Declination of focal plane center
-    fits:tunit: deg
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
     fits:tunit: deg
-  - name: skyRotation
-    datatype: double
-    description: Sky rotation angle.
-    fits:tunit: deg
-  - name: azimuth
-    datatype: double
-    description: Azimuth of focal plane center at the middle of the visit.
-    fits:tunit: deg
-  - name: altitude
-    datatype: double
-    description: Altitude of focal plane center at the middle of the visit.
-    fits:tunit: deg
-  - name: zenithDistance
-    datatype: double
-    description: Zenith distance at the middle of the visit.
-    fits:tunit: deg
-  - name: airmass
-    datatype: double
-    description: Airmass of the observed line of sight.
-    fits:tunit:
-  - name: expTime
-    datatype: double
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    fits:tunit: s
   - name: midpoint
     datatype: timestamp
     precision: 6
@@ -4871,11 +1307,6 @@ tables:
     description: Midpoint time of the visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
     fits:tunit: d
-  - name: obsStart
-    datatype: timestamp
-    precision: 6
-    description: Start time of the visit at the fiducial center of the focal plane array,
-      TAI, accurate to 10ms.
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified
@@ -4885,69 +1316,76 @@ tables:
   - "#VisitDetector.visitId"
   - "#VisitDetector.detector"
   description: Defines a single detector of a visit
+  columnRefs:
+    base:
+      VisitDetector:
+        visitId:
+        detector:
+        physical_filter:
+        band:
+        ra:
+        dec:
+        pixelScale:
+        zenithDistance:
+        zeroPoint:
+        psfSigma:
+        skyBg:
+        skyNoise:
+        seeing:
+        skyRotation:
+        expTime:
+        obsStart:
+        darkTime:
+        xSize:
+        ySize:
+        llcra:
+        llcdec:
+        ulcra:
+        ulcdec:
+        urcra:
+        urcdec:
+        lrcra:
+        lrcdec:
+        psfAdaptiveThresholdValue:
+        psfAdaptiveIncludeThresholdMultiplier:
+        nShapeletsStar:
+        shapeletsOnlyIqScore:
+        shapeletsIqScore:
+        centroidDiffShapeletsVsSlotMedian:
+        shapeletsStarEMedian:
+        shapeletsStarUnNormalizedEMedian:
+        refCatSourceDensity:
+        astromOffsetMean:
+        astromOffsetStd:
+        starComa1Median:
+        starComa2Median:
+        starTrefoil1Median:
+        starTrefoil2Median:
+        starKurtosisMedian:
+        starE41Median:
+        starE42Median:
+        nPsfStar:
+        psfStarDeltaE1Median:
+        psfStarDeltaE2Median:
+        psfStarDeltaE1Scatter:
+        psfStarDeltaE2Scatter:
+        psfStarDeltaSizeMedian:
+        psfStarDeltaSizeScatter:
+        psfStarScaledDeltaSizeScatter:
+        psfTraceRadiusDelta:
+        psfApFluxDelta:
+        psfApCorrSigmaScaledDelta:
+        maxDistToNearestPsf:
+        starEMedian:
+        starUnNormalizedEMedian:
+        wcsDetectorPointingResidual:
+        wcsVisitPointingResidual:
+        wcsPreliminaryDetectorPointingResidual:
+        wcsPreliminaryVisitPointingResidual:
   columns:
-  - name: visitId
-    datatype: long
-    description: Reference to the corresponding entry in the Visit table.
-  - name: detector
-    datatype: long
-    description: Detector ID. A detector associated with a particular instrument (not an observation of that detector)
-  - name: physical_filter
-    datatype: char
-    length: 32
-    description: ID of physical filter, the filter associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: ra
-    datatype: double
-    description: RA of Ccd center.
-    fits:tunit: deg
-  - name: dec
-    datatype: double
-    description: Declination of Ccd center.
-    fits:tunit: deg
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
-  - name: pixelScale
-    datatype: float
-    description: Measured detector pixel scale.
-    fits:tunit: arcsec/pixel
-  - name: zenithDistance
-    datatype: float
-    description: Zenith distance at observation mid-point.
-    fits:tunit: deg
-  - name: zeroPoint
-    datatype: float
-    description: Zero-point for the Ccd, estimated at Ccd center.
-    fits:tunit: mag
-  - name: psfSigma
-    datatype: float
-    description: PSF model second-moments determinant radius (center of chip)
-    fits:tunit: pixel
-  - name: skyBg
-    datatype: float
-    description: Average sky background.
-    fits:tunit: adu
-  - name: skyNoise
-    datatype: float
-    description: RMS noise of the sky background.
-    fits:tunit: adu
-  - name: seeing
-    datatype: double
-    description: Mean measured FWHM of the PSF.
-    fits:tunit: arcsec
-  - name: skyRotation
-    datatype: double
-    description: Sky rotation angle.
     fits:tunit: deg
   - name: midpoint
     datatype: timestamp
@@ -4958,301 +1396,32 @@ tables:
     description: Midpoint of this visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
     fits:tunit: d
-  - name: expTime
-    datatype: double
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    fits:tunit: s
-  - name: obsStart
-    datatype: timestamp
-    precision: 6
-    description: Start of the visit, TAI, accurate to 10ms.
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified
       Julian Date, International Atomic Time, accurate to 10ms.
-  - name: darkTime
-    datatype: double
-    description: Average dark current accumulation time, accurate to 10ms.
-    fits:tunit: s
-  - name: xSize
-    datatype: long
-    description: Number of columns in the image.
-    fits:tunit: pixel
-  - name: ySize
-    datatype: long
-    description: Number of rows in the image.
-    fits:tunit: pixel
-  - name: llcra
-    datatype: double
-    description: RA of lower left corner.
-    fits:tunit: deg
-  - name: llcdec
-    datatype: double
-    description: Declination of lower left corner.
-    fits:tunit: deg
-  - name: ulcra
-    datatype: double
-    description: RA of upper left corner.
-    fits:tunit: deg
-  - name: ulcdec
-    datatype: double
-    description: Declination of upper left corner.
-    fits:tunit: deg
-  - name: urcra
-    datatype: double
-    description: RA of upper right corner.
-    fits:tunit: deg
-  - name: urcdec
-    datatype: double
-    description: Declination of upper right corner.
-    fits:tunit: deg
-  - name: lrcra
-    datatype: double
-    description: RA of lower right corner.
-    fits:tunit: deg
-  - name: lrcdec
-    datatype: double
-    description: Declination of lower right corner.
-    fits:tunit: deg
-  - name: psfAdaptiveThresholdValue
-    datatype: double
-    description: Threshold value used in the adaptive threshold detection pass for PSF modelling.
-  - name: psfAdaptiveIncludeThresholdMultiplier
-    datatype: double
-    description: Threshold multiplier used in the adaptive threshold detection pass for PSF modelling.
-  - name: nShapeletsStar
-    datatype: int
-    description: Number of sources used in the shapelet decomposition.
-  - name: shapeletsOnlyIqScore
-    datatype: double
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power only from the non-atmospheric decomposition coefficients. The
-      score spans the range [0.0, 1.0] with lower values indicating better image quality.
-  - name: shapeletsIqScore
-    datatype: double
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power from the median centroid offset between those used in the decomposition
-      and those of the centroid slot in addition to non-atmospheric decomposition coefficients.
-      The score spans the range [0.0, 1.0] with lower values indicating better image quality.
-  - name: centroidDiffShapeletsVsSlotMedian
-    datatype: double
-    description: Median centroid difference (sqrt((slot_x - shapelet_x)**2 + (slot_y - shapelet_y)**2))
-      for sources used in the shapelet decomposition.
-    fits:tunit: pixel
-  - name: shapeletsStarEMedian
-    datatype: double
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the sources used in the
-      shapelet decomposition.
-  - name: shapeletsStarUnNormalizedEMedian
-    datatype: double
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
-      of the sources used in the shapelet decomposition.
-    fits:tunit: pixel**2
-  - name: refCatSourceDensity
-    datatype: float
-    description: Source density for the detector region as computed from the loaded reference catalog
-      (number per degrees**2)
-    fits:tunit: count/deg**2
-  - name: astromOffsetMean
-    datatype: double
-    description: Mean offset of astrometric calibration matches (arcsec)
-    fits:tunit: arcsec
-  - name: astromOffsetStd
-    datatype: double
-    description: Standard deviation of offsets of astrometric calibration matches (arcsec)
-    fits:tunit: arcsec
-  - name: starComa1Median
-    description: Coma-like higher-order moment combination (median M30 + M12 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starComa2Median
-    description: Coma-like higher-order moment combination (median M21 + M03 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starTrefoil1Median
-    description: Trefoil-like higher-order moment combination (median M30 - 3*M12 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starTrefoil2Median
-    description: Trefoil-like higher-order moment combination (median 3*M21 - M03 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starKurtosisMedian
-    description: Kurtosis-like higher-order moment combination (median M40 + 2*M22 + M04 of the stars
-      used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starE41Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median M40 - M04
-      of the stars used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starE42Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median 2*(M31 + M13)
-      of the stars used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: nPsfStar
-    datatype: int
-    description: Number of stars used for PSF model
-    fits:tunit:
-  - name: psfStarDeltaE1Median
-    datatype: double
-    description: Median E1 residual (starE1 - psfE1) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE2Median
-    datatype: double
-    description: Median E2 residual (starE2 - psfE2) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE1Scatter
-    datatype: double
-    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE2Scatter
-    datatype: double
-    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaSizeMedian
-    datatype: double
-    description: Median size residual (starSize - psfSize) for psf stars (pixel)
-    fits:tunit: pixel
-  - name: psfStarDeltaSizeScatter
-    datatype: double
-    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars (pixel)
-    fits:tunit: pixel
-  - name: psfStarScaledDeltaSizeScatter
-    datatype: double
-    description: Scatter (via MAD) of size residual scaled by median size squared
-    fits:tunit:
-  - name: psfTraceRadiusDelta
-    datatype: double
-    description: Delta (max - min) of model psf trace radius values evaluated on a grid of unmasked pixels (pixel)
-    fits:tunit: pixel
-  - name: psfApFluxDelta
-    datatype: double
-    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels
-    fits:tunit:
-  - name: psfApCorrSigmaScaledDelta
-    datatype: double
-    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels
-    fits:tunit:
-  - name: maxDistToNearestPsf
-    datatype: double
-    description: Maximum distance of an unmasked pixel to its nearest model psf star (pixel)
-    fits:tunit: pixel
-  - name: starEMedian
-    datatype: double
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the stars used in the PSF model
-  - name: starUnNormalizedEMedian
-    datatype: double
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0)) of the stars used in the PSF model
-    fits:tunit: pixel**2
-  - name: wcsDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the prelimnary WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the preliminary WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-
 - name: Parent
   description: "Descriptions of the parent objects in the deblending hierarchy."
   tap:table_index: 130
   primaryKey: '#Parent.objectId'
-  columns:
-  - name: objectId
-    datatype: long
-    description: Unique id. Unique ObjectID
-    ivoa:ucd: meta.id;src
-  - name: parentObjectId
-    datatype: long
-    description: Unique ID of parent source. Reference band.
-    fits:tunit:
-  - name: merge_peak_sky
-    datatype: boolean
-    description: Peak detected in filter sky
-    fits:tunit:
-  - name: deblend_nChild
-    datatype: int
-    description: Number of children this object has (defaults to 0)
-    fits:tunit:
-  - name: deblend_nPeaks
-    datatype: int
-    description: Number of peaks this parent footprint has (even if the deblender failed or skipped this blend)
-    fits:tunit:
-  - name: deblend_failed
-    datatype: boolean
-    description: Deblender failed to deblend this source
-    fits:tunit:
-  - name: deblend_skipped
-    datatype: boolean
-    description: Deblender skipped this source
-    fits:tunit:
-  - name: deblend_skipped_isolatedParent
-    datatype: boolean
-    description: Deblender skipped this footprint because there was only a single peak
-    fits:tunit:
-  - name: deblend_skipped_parentTooBig
-    datatype: boolean
-    description: Deblender skipped this source because the parent footprint was too large.
-    fits:tunit:
-  - name: deblend_skipped_tooManyPeaks
-    datatype: boolean
-    description: Deblender skipped this source because there were too many peaks in the Footprint.
-    fits:tunit:
-  - name: deblend_skipped_masked
-    datatype: boolean
-    description: Deblender skipped this source because there were too many masked pixels.
-    fits:tunit:
-  - name: deblend_skipped_isPseudo
-    datatype: boolean
-    description: Deblender skipped this source because it was a pseudo source like a sky object
-    fits:tunit:
-  - name: deblend_incompleteData
-    datatype: boolean
-    description: One or more bands were not deblended due to an inability to model the PSF.
-    fits:tunit:
-  - name: deblend_iterations
-    datatype: int
-    description: Number of iterations during deblending
-    fits:tunit:
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-    fits:tunit:
+  columnRefs:
+    base:
+      Parent:
+        objectId:
+        parentObjectId:
+        merge_peak_sky:
+        deblend_nChild:
+        deblend_nPeaks:
+        deblend_failed:
+        deblend_skipped:
+        deblend_skipped_isolatedParent:
+        deblend_skipped_parentTooBig:
+        deblend_skipped_tooManyPeaks:
+        deblend_skipped_masked:
+        deblend_skipped_isPseudo:
+        deblend_incompleteData:
+        deblend_iterations:
+        deblend_chi2:
   indexes:
   - name: idx_Parent_objectId
     description: Unique index on objectId column

--- a/python/lsst/sdm/schemas/imsim.yaml
+++ b/python/lsst/sdm/schemas/imsim.yaml
@@ -3,6 +3,9 @@ name: ImsimSchema
 description: |
   The ImSim Schema describes the Science Pipelines outputs for on Imsim simulated full-focal-plane LSSTCam data.
   It is used in the CI testing of the pipelines.
+resources:
+  base:
+    uri: "drp_base.yaml"
 tables:
 - name: Object
   description: The object table contains descriptions of the multi-epoch static astronomical
@@ -10,5663 +13,1462 @@ tables:
     of the Sources that are associated with them. Note that fast moving objects are
     kept in the MovingObject tables. Note that less-frequently used columns are stored
     in a separate table called Object_Extra.
+  columnRefs:
+    base:
+      Object:
+        objectId:
+        coord_dec:
+        coord_decErr:
+        coord_ra:
+        coord_raErr:
+        coord_ra_dec_Cov:
+        coord_flag:
+        deblend_parentNChild:
+        deblend_parentNPeaks:
+        deblend_peak_center_x:
+        deblend_peak_center_y:
+        deblend_chi2:
+        deblend_blendId:
+        deblend_blendNChild:
+        detect_fromBlend:
+        detect_isDeblendedModelSource:
+        detect_isIsolated:
+        ebv:
+        footprintArea:
+        parentObjectId:
+        patch:
+        refBand:
+        refExtendedness:
+        refSizeExtendedness:
+        shape_flag:
+        shape_xx:
+        shape_xy:
+        shape_yy:
+        tract:
+        g_ap03Flux:
+        g_ap03FluxErr:
+        g_ap03Flux_flag:
+        g_ap06Flux:
+        g_ap06FluxErr:
+        g_ap06Flux_flag:
+        g_ap09Flux:
+        g_ap09FluxErr:
+        g_ap09Flux_flag:
+        g_ap12Flux:
+        g_ap12FluxErr:
+        g_ap12Flux_flag:
+        g_ap17Flux:
+        g_ap17FluxErr:
+        g_ap17Flux_flag:
+        g_ap25Flux:
+        g_ap25FluxErr:
+        g_ap25Flux_flag:
+        g_ap35Flux:
+        g_ap35FluxErr:
+        g_ap35Flux_flag:
+        g_ap50Flux:
+        g_ap50FluxErr:
+        g_ap50Flux_flag:
+        g_ap70Flux:
+        g_ap70FluxErr:
+        g_ap70Flux_flag:
+        g_apFlux_flag:
+        g_apFlux_flag_apertureTruncated:
+        g_apFlux_flag_sincCoeffsTruncated:
+        g_cModel_chi2:
+        g_cModel_devFlux:
+        g_cModel_devFluxErr:
+        g_cModel_expFlux:
+        g_cModel_expFluxErr:
+        g_cModel_dev_reff_major:
+        g_cModel_dev_reff_minor:
+        g_cModel_dev_theta:
+        g_cModel_exp_reff_major:
+        g_cModel_exp_reff_minor:
+        g_cModel_exp_theta:
+        g_blendedness:
+        g_blendedness_flag:
+        g_cModelFlux:
+        g_cModelFluxErr:
+        g_cModelFlux_inner:
+        g_cModel_fracDev:
+        g_cModel_flag:
+        g_cModel_flag_apCorr:
+        g_calib_astrometry_used:
+        g_calib_photometry_used:
+        g_calib_psf_candidate:
+        g_calib_psf_reserved:
+        g_calib_psf_used:
+        g_centroid_flag:
+        g_dec:
+        g_decErr:
+        g_extendedness:
+        g_extendedness_flag:
+        g_sizeExtendedness:
+        g_sizeExtendedness_flag:
+        g_model_extendedness:
+        griz_model_extendedness:
+        g_free_cModelFlux:
+        g_free_cModelFluxErr:
+        g_free_cModelFlux_flag:
+        g_free_cModelFlux_inner:
+        g_free_cModel_fracDev:
+        g_free_cModel_devFlux:
+        g_free_cModel_devFluxErr:
+        g_free_cModel_expFlux:
+        g_free_cModel_expFluxErr:
+        g_free_psfFlux:
+        g_free_psfFluxErr:
+        g_free_psfFlux_flag:
+        g_gaap0p7Flux:
+        g_gaap0p7FluxErr:
+        g_gaap1p0Flux:
+        g_gaap1p0FluxErr:
+        g_gaapFlux_flag:
+        g_gaapFlux_flag_edge:
+        g_gaapPsfFlux:
+        g_gaapPsfFluxErr:
+        g_moments_g1:
+        g_moments_g2:
+        g_moments_trace:
+        g_moments_flag:
+        g_moments_psf_g1:
+        g_moments_psf_g2:
+        g_moments_psf_trace:
+        g_moments_psf_flag:
+        g_moments_psf_debiased_g1:
+        g_moments_psf_debiased_g2:
+        g_moments_psf_debiased_trace:
+        g_moments_psf_debiased_flag:
+        g_hsmShapeRegauss_e1:
+        g_hsmShapeRegauss_e2:
+        g_hsmShapeRegauss_flag:
+        g_hsmShapeRegauss_sigma:
+        g_iPSF_flag:
+        g_i_flag:
+        g_inputCount:
+        g_inputCount_flag:
+        g_inputCount_flag_noInputs:
+        g_ixx:
+        g_ixxPSF:
+        g_ixy:
+        g_ixyPSF:
+        g_iyy:
+        g_iyyPSF:
+        g_hsm_moments_30:
+        g_hsm_momentsPsf_30:
+        g_hsm_moments_21:
+        g_hsm_momentsPsf_21:
+        g_hsm_moments_12:
+        g_hsm_momentsPsf_12:
+        g_hsm_moments_03:
+        g_hsm_momentsPsf_03:
+        g_hsm_moments_40:
+        g_hsm_momentsPsf_40:
+        g_hsm_moments_31:
+        g_hsm_momentsPsf_31:
+        g_hsm_moments_22:
+        g_hsm_momentsPsf_22:
+        g_hsm_moments_13:
+        g_hsm_momentsPsf_13:
+        g_hsm_moments_04:
+        g_hsm_momentsPsf_04:
+        g_hsm_moments_flag:
+        g_hsm_momentsPsf_flag:
+        g_kronFlux:
+        g_kronFluxErr:
+        g_kronFlux_flag:
+        g_kronFlux_flag_bad_radius:
+        g_kronFlux_flag_bad_shape:
+        g_kronFlux_flag_bad_shape_no_psf:
+        g_kronFlux_flag_edge:
+        g_kronFlux_flag_no_fallback_radius:
+        g_kronFlux_flag_no_minimum_radius:
+        g_kronFlux_flag_small_radius:
+        g_kronFlux_flag_used_minimum_radius:
+        g_kronFlux_flag_used_psf_radius:
+        g_kronRad:
+        g_pixelFlags_bad:
+        g_pixelFlags_clipped:
+        g_pixelFlags_clippedCenter:
+        g_pixelFlags_cr:
+        g_pixelFlags_crCenter:
+        g_pixelFlags_edge:
+        g_pixelFlags_inexact_psf:
+        g_pixelFlags_inexact_psfCenter:
+        g_pixelFlags_interpolated:
+        g_pixelFlags_interpolatedCenter:
+        g_pixelFlags_nodata:
+        g_pixelFlags_offimage:
+        g_pixelFlags_saturated:
+        g_pixelFlags_saturatedCenter:
+        g_pixelFlags_sensor_edge:
+        g_pixelFlags_sensor_edgeCenter:
+        g_pixelFlags_suspect:
+        g_pixelFlags_suspectCenter:
+        g_invalidPsfFlag:
+        g_psfFlux:
+        g_psfFluxErr:
+        g_psfFlux_area:
+        g_psfFlux_flag:
+        g_psfFlux_flag_apCorr:
+        g_psfFlux_flag_edge:
+        g_psfFlux_flag_noGoodPixels:
+        g_ra:
+        g_raErr:
+        g_ra_dec_Cov:
+        g_deblend_dataCoverage:
+        g_deblend_blendedness:
+        g_deblend_fluxOverlap:
+        g_deblend_fluxOverlapFraction:
+        g_deblend_zeroFlux:
+        i_ap03Flux:
+        i_ap03FluxErr:
+        i_ap03Flux_flag:
+        i_ap06Flux:
+        i_ap06FluxErr:
+        i_ap06Flux_flag:
+        i_ap09Flux:
+        i_ap09FluxErr:
+        i_ap09Flux_flag:
+        i_ap12Flux:
+        i_ap12FluxErr:
+        i_ap12Flux_flag:
+        i_ap17Flux:
+        i_ap17FluxErr:
+        i_ap17Flux_flag:
+        i_ap25Flux:
+        i_ap25FluxErr:
+        i_ap25Flux_flag:
+        i_ap35Flux:
+        i_ap35FluxErr:
+        i_ap35Flux_flag:
+        i_ap50Flux:
+        i_ap50FluxErr:
+        i_ap50Flux_flag:
+        i_ap70Flux:
+        i_ap70FluxErr:
+        i_ap70Flux_flag:
+        i_apFlux_flag:
+        i_apFlux_flag_apertureTruncated:
+        i_apFlux_flag_sincCoeffsTruncated:
+        i_cModel_chi2:
+        i_cModel_devFlux:
+        i_cModel_devFluxErr:
+        i_cModel_expFlux:
+        i_cModel_expFluxErr:
+        i_cModel_dev_reff_major:
+        i_cModel_dev_reff_minor:
+        i_cModel_dev_theta:
+        i_cModel_exp_reff_major:
+        i_cModel_exp_reff_minor:
+        i_cModel_exp_theta:
+        i_blendedness:
+        i_blendedness_flag:
+        i_cModelFlux:
+        i_cModelFluxErr:
+        i_cModelFlux_inner:
+        i_cModel_fracDev:
+        i_cModel_flag:
+        i_cModel_flag_apCorr:
+        i_calib_astrometry_used:
+        i_calib_photometry_used:
+        i_calib_psf_candidate:
+        i_calib_psf_reserved:
+        i_calib_psf_used:
+        i_centroid_flag:
+        i_dec:
+        i_decErr:
+        i_extendedness:
+        i_extendedness_flag:
+        i_sizeExtendedness:
+        i_sizeExtendedness_flag:
+        i_model_extendedness:
+        i_free_cModelFlux:
+        i_free_cModelFluxErr:
+        i_free_cModelFlux_flag:
+        i_free_cModelFlux_inner:
+        i_free_cModel_fracDev:
+        i_free_cModel_devFlux:
+        i_free_cModel_devFluxErr:
+        i_free_cModel_expFlux:
+        i_free_cModel_expFluxErr:
+        i_free_psfFlux:
+        i_free_psfFluxErr:
+        i_free_psfFlux_flag:
+        i_gaap0p7Flux:
+        i_gaap0p7FluxErr:
+        i_gaap1p0Flux:
+        i_gaap1p0FluxErr:
+        i_gaapFlux_flag:
+        i_gaapFlux_flag_edge:
+        i_gaapPsfFlux:
+        i_gaapPsfFluxErr:
+        i_moments_g1:
+        i_moments_g2:
+        i_moments_trace:
+        i_moments_flag:
+        i_moments_psf_g1:
+        i_moments_psf_g2:
+        i_moments_psf_trace:
+        i_moments_psf_flag:
+        i_moments_psf_debiased_g1:
+        i_moments_psf_debiased_g2:
+        i_moments_psf_debiased_trace:
+        i_moments_psf_debiased_flag:
+        i_hsmShapeRegauss_e1:
+        i_hsmShapeRegauss_e2:
+        i_hsmShapeRegauss_flag:
+        i_hsmShapeRegauss_sigma:
+        i_iPSF_flag:
+        i_i_flag:
+        i_inputCount:
+        i_inputCount_flag:
+        i_inputCount_flag_noInputs:
+        i_ixx:
+        i_ixxPSF:
+        i_ixy:
+        i_ixyPSF:
+        i_iyy:
+        i_iyyPSF:
+        i_hsm_moments_30:
+        i_hsm_momentsPsf_30:
+        i_hsm_moments_21:
+        i_hsm_momentsPsf_21:
+        i_hsm_moments_12:
+        i_hsm_momentsPsf_12:
+        i_hsm_moments_03:
+        i_hsm_momentsPsf_03:
+        i_hsm_moments_40:
+        i_hsm_momentsPsf_40:
+        i_hsm_moments_31:
+        i_hsm_momentsPsf_31:
+        i_hsm_moments_22:
+        i_hsm_momentsPsf_22:
+        i_hsm_moments_13:
+        i_hsm_momentsPsf_13:
+        i_hsm_moments_04:
+        i_hsm_momentsPsf_04:
+        i_hsm_moments_flag:
+        i_hsm_momentsPsf_flag:
+        i_kronFlux:
+        i_kronFluxErr:
+        i_kronFlux_flag:
+        i_kronFlux_flag_bad_radius:
+        i_kronFlux_flag_bad_shape:
+        i_kronFlux_flag_bad_shape_no_psf:
+        i_kronFlux_flag_edge:
+        i_kronFlux_flag_no_fallback_radius:
+        i_kronFlux_flag_no_minimum_radius:
+        i_kronFlux_flag_small_radius:
+        i_kronFlux_flag_used_minimum_radius:
+        i_kronFlux_flag_used_psf_radius:
+        i_kronRad:
+        i_pixelFlags_bad:
+        i_pixelFlags_clipped:
+        i_pixelFlags_clippedCenter:
+        i_pixelFlags_cr:
+        i_pixelFlags_crCenter:
+        i_pixelFlags_edge:
+        i_pixelFlags_inexact_psf:
+        i_pixelFlags_inexact_psfCenter:
+        i_pixelFlags_interpolated:
+        i_pixelFlags_interpolatedCenter:
+        i_pixelFlags_nodata:
+        i_pixelFlags_offimage:
+        i_pixelFlags_saturated:
+        i_pixelFlags_saturatedCenter:
+        i_pixelFlags_sensor_edge:
+        i_pixelFlags_sensor_edgeCenter:
+        i_pixelFlags_suspect:
+        i_pixelFlags_suspectCenter:
+        i_invalidPsfFlag:
+        i_psfFlux:
+        i_psfFluxErr:
+        i_psfFlux_area:
+        i_psfFlux_flag:
+        i_psfFlux_flag_apCorr:
+        i_psfFlux_flag_edge:
+        i_psfFlux_flag_noGoodPixels:
+        i_ra:
+        i_raErr:
+        i_ra_dec_Cov:
+        i_deblend_dataCoverage:
+        i_deblend_blendedness:
+        i_deblend_fluxOverlap:
+        i_deblend_fluxOverlapFraction:
+        i_deblend_zeroFlux:
+        r_ap03Flux:
+        r_ap03FluxErr:
+        r_ap03Flux_flag:
+        r_ap06Flux:
+        r_ap06FluxErr:
+        r_ap06Flux_flag:
+        r_ap09Flux:
+        r_ap09FluxErr:
+        r_ap09Flux_flag:
+        r_ap12Flux:
+        r_ap12FluxErr:
+        r_ap12Flux_flag:
+        r_ap17Flux:
+        r_ap17FluxErr:
+        r_ap17Flux_flag:
+        r_ap25Flux:
+        r_ap25FluxErr:
+        r_ap25Flux_flag:
+        r_ap35Flux:
+        r_ap35FluxErr:
+        r_ap35Flux_flag:
+        r_ap50Flux:
+        r_ap50FluxErr:
+        r_ap50Flux_flag:
+        r_ap70Flux:
+        r_ap70FluxErr:
+        r_ap70Flux_flag:
+        r_apFlux_flag:
+        r_apFlux_flag_apertureTruncated:
+        r_apFlux_flag_sincCoeffsTruncated:
+        r_cModel_chi2:
+        r_cModel_devFlux:
+        r_cModel_devFluxErr:
+        r_cModel_expFlux:
+        r_cModel_expFluxErr:
+        r_cModel_dev_reff_major:
+        r_cModel_dev_reff_minor:
+        r_cModel_dev_theta:
+        r_cModel_exp_reff_major:
+        r_cModel_exp_reff_minor:
+        r_cModel_exp_theta:
+        r_blendedness:
+        r_blendedness_flag:
+        r_cModelFlux:
+        r_cModelFluxErr:
+        r_cModelFlux_inner:
+        r_cModel_fracDev:
+        r_cModel_flag:
+        r_cModel_flag_apCorr:
+        r_calib_astrometry_used:
+        r_calib_photometry_used:
+        r_calib_psf_candidate:
+        r_calib_psf_reserved:
+        r_calib_psf_used:
+        r_centroid_flag:
+        r_dec:
+        r_decErr:
+        r_extendedness:
+        r_extendedness_flag:
+        r_sizeExtendedness:
+        r_sizeExtendedness_flag:
+        r_model_extendedness:
+        r_free_cModelFlux:
+        r_free_cModelFluxErr:
+        r_free_cModelFlux_flag:
+        r_free_cModelFlux_inner:
+        r_free_cModel_fracDev:
+        r_free_cModel_devFlux:
+        r_free_cModel_devFluxErr:
+        r_free_cModel_expFlux:
+        r_free_cModel_expFluxErr:
+        r_free_psfFlux:
+        r_free_psfFluxErr:
+        r_free_psfFlux_flag:
+        r_gaap0p7Flux:
+        r_gaap0p7FluxErr:
+        r_gaap1p0Flux:
+        r_gaap1p0FluxErr:
+        r_gaapFlux_flag:
+        r_gaapFlux_flag_edge:
+        r_gaapPsfFlux:
+        r_gaapPsfFluxErr:
+        r_moments_g1:
+        r_moments_g2:
+        r_moments_trace:
+        r_moments_flag:
+        r_moments_psf_g1:
+        r_moments_psf_g2:
+        r_moments_psf_trace:
+        r_moments_psf_flag:
+        r_moments_psf_debiased_g1:
+        r_moments_psf_debiased_g2:
+        r_moments_psf_debiased_trace:
+        r_moments_psf_debiased_flag:
+        r_hsmShapeRegauss_e1:
+        r_hsmShapeRegauss_e2:
+        r_hsmShapeRegauss_flag:
+        r_hsmShapeRegauss_sigma:
+        r_iPSF_flag:
+        r_i_flag:
+        r_inputCount:
+        r_inputCount_flag:
+        r_inputCount_flag_noInputs:
+        r_ixx:
+        r_ixxPSF:
+        r_ixy:
+        r_ixyPSF:
+        r_iyy:
+        r_iyyPSF:
+        r_hsm_moments_30:
+        r_hsm_momentsPsf_30:
+        r_hsm_moments_21:
+        r_hsm_momentsPsf_21:
+        r_hsm_moments_12:
+        r_hsm_momentsPsf_12:
+        r_hsm_moments_03:
+        r_hsm_momentsPsf_03:
+        r_hsm_moments_40:
+        r_hsm_momentsPsf_40:
+        r_hsm_moments_31:
+        r_hsm_momentsPsf_31:
+        r_hsm_moments_22:
+        r_hsm_momentsPsf_22:
+        r_hsm_moments_13:
+        r_hsm_momentsPsf_13:
+        r_hsm_moments_04:
+        r_hsm_momentsPsf_04:
+        r_hsm_moments_flag:
+        r_hsm_momentsPsf_flag:
+        r_kronFlux:
+        r_kronFluxErr:
+        r_kronFlux_flag:
+        r_kronFlux_flag_bad_radius:
+        r_kronFlux_flag_bad_shape:
+        r_kronFlux_flag_bad_shape_no_psf:
+        r_kronFlux_flag_edge:
+        r_kronFlux_flag_no_fallback_radius:
+        r_kronFlux_flag_no_minimum_radius:
+        r_kronFlux_flag_small_radius:
+        r_kronFlux_flag_used_minimum_radius:
+        r_kronFlux_flag_used_psf_radius:
+        r_kronRad:
+        r_pixelFlags_bad:
+        r_pixelFlags_clipped:
+        r_pixelFlags_clippedCenter:
+        r_pixelFlags_cr:
+        r_pixelFlags_crCenter:
+        r_pixelFlags_edge:
+        r_pixelFlags_inexact_psf:
+        r_pixelFlags_inexact_psfCenter:
+        r_pixelFlags_interpolated:
+        r_pixelFlags_interpolatedCenter:
+        r_pixelFlags_nodata:
+        r_pixelFlags_offimage:
+        r_pixelFlags_saturated:
+        r_pixelFlags_saturatedCenter:
+        r_pixelFlags_sensor_edge:
+        r_pixelFlags_sensor_edgeCenter:
+        r_pixelFlags_suspect:
+        r_pixelFlags_suspectCenter:
+        r_invalidPsfFlag:
+        r_psfFlux:
+        r_psfFluxErr:
+        r_psfFlux_area:
+        r_psfFlux_flag:
+        r_psfFlux_flag_apCorr:
+        r_psfFlux_flag_edge:
+        r_psfFlux_flag_noGoodPixels:
+        r_ra:
+        r_raErr:
+        r_ra_dec_Cov:
+        r_deblend_dataCoverage:
+        r_deblend_blendedness:
+        r_deblend_fluxOverlap:
+        r_deblend_fluxOverlapFraction:
+        r_deblend_zeroFlux:
+        u_ap03Flux:
+        u_ap03FluxErr:
+        u_ap03Flux_flag:
+        u_ap06Flux:
+        u_ap06FluxErr:
+        u_ap06Flux_flag:
+        u_ap09Flux:
+        u_ap09FluxErr:
+        u_ap09Flux_flag:
+        u_ap12Flux:
+        u_ap12FluxErr:
+        u_ap12Flux_flag:
+        u_ap17Flux:
+        u_ap17FluxErr:
+        u_ap17Flux_flag:
+        u_ap25Flux:
+        u_ap25FluxErr:
+        u_ap25Flux_flag:
+        u_ap35Flux:
+        u_ap35FluxErr:
+        u_ap35Flux_flag:
+        u_ap50Flux:
+        u_ap50FluxErr:
+        u_ap50Flux_flag:
+        u_ap70Flux:
+        u_ap70FluxErr:
+        u_ap70Flux_flag:
+        u_apFlux_flag:
+        u_apFlux_flag_apertureTruncated:
+        u_apFlux_flag_sincCoeffsTruncated:
+        u_cModel_chi2:
+        u_cModel_devFlux:
+        u_cModel_devFluxErr:
+        u_cModel_expFlux:
+        u_cModel_expFluxErr:
+        u_cModel_dev_reff_major:
+        u_cModel_dev_reff_minor:
+        u_cModel_dev_theta:
+        u_cModel_exp_reff_major:
+        u_cModel_exp_reff_minor:
+        u_cModel_exp_theta:
+        u_blendedness:
+        u_blendedness_flag:
+        u_cModelFlux:
+        u_cModelFluxErr:
+        u_cModelFlux_inner:
+        u_cModel_fracDev:
+        u_cModel_flag:
+        u_cModel_flag_apCorr:
+        u_calib_astrometry_used:
+        u_calib_photometry_used:
+        u_calib_psf_candidate:
+        u_calib_psf_reserved:
+        u_calib_psf_used:
+        u_centroid_flag:
+        u_dec:
+        u_decErr:
+        u_extendedness:
+        u_extendedness_flag:
+        u_sizeExtendedness:
+        u_sizeExtendedness_flag:
+        u_model_extendedness:
+        u_free_cModelFlux:
+        u_free_cModelFluxErr:
+        u_free_cModelFlux_flag:
+        u_free_cModelFlux_inner:
+        u_free_cModel_fracDev:
+        u_free_cModel_devFlux:
+        u_free_cModel_devFluxErr:
+        u_free_cModel_expFlux:
+        u_free_cModel_expFluxErr:
+        u_free_psfFlux:
+        u_free_psfFluxErr:
+        u_free_psfFlux_flag:
+        u_gaap0p7Flux:
+        u_gaap0p7FluxErr:
+        u_gaap1p0Flux:
+        u_gaap1p0FluxErr:
+        u_gaapFlux_flag:
+        u_gaapFlux_flag_edge:
+        u_gaapPsfFlux:
+        u_gaapPsfFluxErr:
+        u_moments_g1:
+        u_moments_g2:
+        u_moments_trace:
+        u_moments_flag:
+        u_moments_psf_g1:
+        u_moments_psf_g2:
+        u_moments_psf_trace:
+        u_moments_psf_flag:
+        u_moments_psf_debiased_g1:
+        u_moments_psf_debiased_g2:
+        u_moments_psf_debiased_trace:
+        u_moments_psf_debiased_flag:
+        u_hsmShapeRegauss_e1:
+        u_hsmShapeRegauss_e2:
+        u_hsmShapeRegauss_flag:
+        u_hsmShapeRegauss_sigma:
+        u_iPSF_flag:
+        u_i_flag:
+        u_inputCount:
+        u_inputCount_flag:
+        u_inputCount_flag_noInputs:
+        u_ixx:
+        u_ixxPSF:
+        u_ixy:
+        u_ixyPSF:
+        u_iyy:
+        u_iyyPSF:
+        u_hsm_moments_30:
+        u_hsm_momentsPsf_30:
+        u_hsm_moments_21:
+        u_hsm_momentsPsf_21:
+        u_hsm_moments_12:
+        u_hsm_momentsPsf_12:
+        u_hsm_moments_03:
+        u_hsm_momentsPsf_03:
+        u_hsm_moments_40:
+        u_hsm_momentsPsf_40:
+        u_hsm_moments_31:
+        u_hsm_momentsPsf_31:
+        u_hsm_moments_22:
+        u_hsm_momentsPsf_22:
+        u_hsm_moments_13:
+        u_hsm_momentsPsf_13:
+        u_hsm_moments_04:
+        u_hsm_momentsPsf_04:
+        u_hsm_moments_flag:
+        u_hsm_momentsPsf_flag:
+        u_kronFlux:
+        u_kronFluxErr:
+        u_kronFlux_flag:
+        u_kronFlux_flag_bad_radius:
+        u_kronFlux_flag_bad_shape:
+        u_kronFlux_flag_bad_shape_no_psf:
+        u_kronFlux_flag_edge:
+        u_kronFlux_flag_no_fallback_radius:
+        u_kronFlux_flag_no_minimum_radius:
+        u_kronFlux_flag_small_radius:
+        u_kronFlux_flag_used_minimum_radius:
+        u_kronFlux_flag_used_psf_radius:
+        u_kronRad:
+        u_pixelFlags_bad:
+        u_pixelFlags_clipped:
+        u_pixelFlags_clippedCenter:
+        u_pixelFlags_cr:
+        u_pixelFlags_crCenter:
+        u_pixelFlags_edge:
+        u_pixelFlags_inexact_psf:
+        u_pixelFlags_inexact_psfCenter:
+        u_pixelFlags_interpolated:
+        u_pixelFlags_interpolatedCenter:
+        u_pixelFlags_nodata:
+        u_pixelFlags_offimage:
+        u_pixelFlags_saturated:
+        u_pixelFlags_saturatedCenter:
+        u_pixelFlags_sensor_edge:
+        u_pixelFlags_sensor_edgeCenter:
+        u_pixelFlags_suspect:
+        u_pixelFlags_suspectCenter:
+        u_invalidPsfFlag:
+        u_psfFlux:
+        u_psfFluxErr:
+        u_psfFlux_area:
+        u_psfFlux_flag:
+        u_psfFlux_flag_apCorr:
+        u_psfFlux_flag_edge:
+        u_psfFlux_flag_noGoodPixels:
+        u_ra:
+        u_raErr:
+        u_ra_dec_Cov:
+        u_deblend_dataCoverage:
+        u_deblend_blendedness:
+        u_deblend_fluxOverlap:
+        u_deblend_fluxOverlapFraction:
+        u_deblend_zeroFlux:
+        y_ap03Flux:
+        y_ap03FluxErr:
+        y_ap03Flux_flag:
+        y_ap06Flux:
+        y_ap06FluxErr:
+        y_ap06Flux_flag:
+        y_ap09Flux:
+        y_ap09FluxErr:
+        y_ap09Flux_flag:
+        y_ap12Flux:
+        y_ap12FluxErr:
+        y_ap12Flux_flag:
+        y_ap17Flux:
+        y_ap17FluxErr:
+        y_ap17Flux_flag:
+        y_ap25Flux:
+        y_ap25FluxErr:
+        y_ap25Flux_flag:
+        y_ap35Flux:
+        y_ap35FluxErr:
+        y_ap35Flux_flag:
+        y_ap50Flux:
+        y_ap50FluxErr:
+        y_ap50Flux_flag:
+        y_ap70Flux:
+        y_ap70FluxErr:
+        y_ap70Flux_flag:
+        y_apFlux_flag:
+        y_apFlux_flag_apertureTruncated:
+        y_apFlux_flag_sincCoeffsTruncated:
+        y_cModel_chi2:
+        y_cModel_devFlux:
+        y_cModel_devFluxErr:
+        y_cModel_expFlux:
+        y_cModel_expFluxErr:
+        y_cModel_dev_reff_major:
+        y_cModel_dev_reff_minor:
+        y_cModel_dev_theta:
+        y_cModel_exp_reff_major:
+        y_cModel_exp_reff_minor:
+        y_cModel_exp_theta:
+        y_blendedness:
+        y_blendedness_flag:
+        y_cModelFlux:
+        y_cModelFluxErr:
+        y_cModelFlux_inner:
+        y_cModel_fracDev:
+        y_cModel_flag:
+        y_cModel_flag_apCorr:
+        y_calib_astrometry_used:
+        y_calib_photometry_used:
+        y_calib_psf_candidate:
+        y_calib_psf_reserved:
+        y_calib_psf_used:
+        y_centroid_flag:
+        y_dec:
+        y_decErr:
+        y_extendedness:
+        y_extendedness_flag:
+        y_sizeExtendedness:
+        y_sizeExtendedness_flag:
+        y_model_extendedness:
+        y_free_cModelFlux:
+        y_free_cModelFluxErr:
+        y_free_cModelFlux_flag:
+        y_free_cModelFlux_inner:
+        y_free_cModel_fracDev:
+        y_free_cModel_devFlux:
+        y_free_cModel_devFluxErr:
+        y_free_cModel_expFlux:
+        y_free_cModel_expFluxErr:
+        y_free_psfFlux:
+        y_free_psfFluxErr:
+        y_free_psfFlux_flag:
+        y_gaap0p7Flux:
+        y_gaap0p7FluxErr:
+        y_gaap1p0Flux:
+        y_gaap1p0FluxErr:
+        y_gaapFlux_flag:
+        y_gaapFlux_flag_edge:
+        y_gaapPsfFlux:
+        y_gaapPsfFluxErr:
+        y_moments_g1:
+        y_moments_g2:
+        y_moments_trace:
+        y_moments_flag:
+        y_moments_psf_g1:
+        y_moments_psf_g2:
+        y_moments_psf_trace:
+        y_moments_psf_flag:
+        y_moments_psf_debiased_g1:
+        y_moments_psf_debiased_g2:
+        y_moments_psf_debiased_trace:
+        y_moments_psf_debiased_flag:
+        y_hsmShapeRegauss_e1:
+        y_hsmShapeRegauss_e2:
+        y_hsmShapeRegauss_flag:
+        y_hsmShapeRegauss_sigma:
+        y_iPSF_flag:
+        y_i_flag:
+        y_inputCount:
+        y_inputCount_flag:
+        y_ixx:
+        y_ixxPSF:
+        y_ixy:
+        y_ixyPSF:
+        y_iyy:
+        y_iyyPSF:
+        y_inputCount_flag_noInputs:
+        y_hsm_moments_30:
+        y_hsm_momentsPsf_30:
+        y_hsm_moments_21:
+        y_hsm_momentsPsf_21:
+        y_hsm_moments_12:
+        y_hsm_momentsPsf_12:
+        y_hsm_moments_03:
+        y_hsm_momentsPsf_03:
+        y_hsm_moments_40:
+        y_hsm_momentsPsf_40:
+        y_hsm_moments_31:
+        y_hsm_momentsPsf_31:
+        y_hsm_moments_22:
+        y_hsm_momentsPsf_22:
+        y_hsm_moments_13:
+        y_hsm_momentsPsf_13:
+        y_hsm_moments_04:
+        y_hsm_momentsPsf_04:
+        y_hsm_moments_flag:
+        y_hsm_momentsPsf_flag:
+        y_kronFlux:
+        y_kronFluxErr:
+        y_kronFlux_flag:
+        y_kronFlux_flag_bad_radius:
+        y_kronFlux_flag_bad_shape:
+        y_kronFlux_flag_bad_shape_no_psf:
+        y_kronFlux_flag_edge:
+        y_kronFlux_flag_no_fallback_radius:
+        y_kronFlux_flag_no_minimum_radius:
+        y_kronFlux_flag_small_radius:
+        y_kronFlux_flag_used_minimum_radius:
+        y_kronFlux_flag_used_psf_radius:
+        y_kronRad:
+        y_pixelFlags_bad:
+        y_pixelFlags_clipped:
+        y_pixelFlags_clippedCenter:
+        y_pixelFlags_cr:
+        y_pixelFlags_crCenter:
+        y_pixelFlags_edge:
+        y_pixelFlags_inexact_psf:
+        y_pixelFlags_inexact_psfCenter:
+        y_pixelFlags_interpolated:
+        y_pixelFlags_interpolatedCenter:
+        y_pixelFlags_nodata:
+        y_pixelFlags_offimage:
+        y_pixelFlags_saturated:
+        y_pixelFlags_saturatedCenter:
+        y_pixelFlags_sensor_edge:
+        y_pixelFlags_sensor_edgeCenter:
+        y_pixelFlags_suspect:
+        y_pixelFlags_suspectCenter:
+        y_invalidPsfFlag:
+        y_psfFlux:
+        y_psfFluxErr:
+        y_psfFlux_area:
+        y_psfFlux_flag:
+        y_psfFlux_flag_apCorr:
+        y_psfFlux_flag_edge:
+        y_psfFlux_flag_noGoodPixels:
+        y_ra:
+        y_raErr:
+        y_ra_dec_Cov:
+        y_deblend_dataCoverage:
+        y_deblend_blendedness:
+        y_deblend_fluxOverlap:
+        y_deblend_fluxOverlapFraction:
+        y_deblend_zeroFlux:
+        z_ap03Flux:
+        z_ap03FluxErr:
+        z_ap03Flux_flag:
+        z_ap06Flux:
+        z_ap06FluxErr:
+        z_ap06Flux_flag:
+        z_ap09Flux:
+        z_ap09FluxErr:
+        z_ap09Flux_flag:
+        z_ap12Flux:
+        z_ap12FluxErr:
+        z_ap12Flux_flag:
+        z_ap17Flux:
+        z_ap17FluxErr:
+        z_ap17Flux_flag:
+        z_ap25Flux:
+        z_ap25FluxErr:
+        z_ap25Flux_flag:
+        z_ap35Flux:
+        z_ap35FluxErr:
+        z_ap35Flux_flag:
+        z_ap50Flux:
+        z_ap50FluxErr:
+        z_ap50Flux_flag:
+        z_ap70Flux:
+        z_ap70FluxErr:
+        z_ap70Flux_flag:
+        z_apFlux_flag:
+        z_apFlux_flag_apertureTruncated:
+        z_apFlux_flag_sincCoeffsTruncated:
+        z_cModel_chi2:
+        z_cModel_devFlux:
+        z_cModel_devFluxErr:
+        z_cModel_expFlux:
+        z_cModel_expFluxErr:
+        z_cModel_dev_reff_major:
+        z_cModel_dev_reff_minor:
+        z_cModel_dev_theta:
+        z_cModel_exp_reff_major:
+        z_cModel_exp_reff_minor:
+        z_cModel_exp_theta:
+        z_blendedness:
+        z_blendedness_flag:
+        z_cModelFlux:
+        z_cModelFluxErr:
+        z_cModelFlux_inner:
+        z_cModel_fracDev:
+        z_cModel_flag:
+        z_cModel_flag_apCorr:
+        z_calib_astrometry_used:
+        z_calib_photometry_used:
+        z_calib_psf_candidate:
+        z_calib_psf_reserved:
+        z_calib_psf_used:
+        z_centroid_flag:
+        z_dec:
+        z_decErr:
+        z_extendedness:
+        z_extendedness_flag:
+        z_sizeExtendedness:
+        z_sizeExtendedness_flag:
+        z_model_extendedness:
+        z_free_cModelFlux:
+        z_free_cModelFluxErr:
+        z_free_cModelFlux_flag:
+        z_free_cModelFlux_inner:
+        z_free_cModel_fracDev:
+        z_free_cModel_devFlux:
+        z_free_cModel_devFluxErr:
+        z_free_cModel_expFlux:
+        z_free_cModel_expFluxErr:
+        z_free_psfFlux:
+        z_free_psfFluxErr:
+        z_free_psfFlux_flag:
+        z_gaap0p7Flux:
+        z_gaap0p7FluxErr:
+        z_gaap1p0Flux:
+        z_gaap1p0FluxErr:
+        z_gaapFlux_flag:
+        z_gaapFlux_flag_edge:
+        z_gaapPsfFlux:
+        z_gaapPsfFluxErr:
+        z_moments_g1:
+        z_moments_g2:
+        z_moments_trace:
+        z_moments_flag:
+        z_moments_psf_g1:
+        z_moments_psf_g2:
+        z_moments_psf_trace:
+        z_moments_psf_flag:
+        z_moments_psf_debiased_g1:
+        z_moments_psf_debiased_g2:
+        z_moments_psf_debiased_trace:
+        z_moments_psf_debiased_flag:
+        z_hsmShapeRegauss_e1:
+        z_hsmShapeRegauss_e2:
+        z_hsmShapeRegauss_flag:
+        z_hsmShapeRegauss_sigma:
+        z_iPSF_flag:
+        z_i_flag:
+        z_inputCount:
+        z_inputCount_flag:
+        z_inputCount_flag_noInputs:
+        z_ixx:
+        z_ixxPSF:
+        z_ixy:
+        z_ixyPSF:
+        z_iyy:
+        z_iyyPSF:
+        z_hsm_moments_30:
+        z_hsm_momentsPsf_30:
+        z_hsm_moments_21:
+        z_hsm_momentsPsf_21:
+        z_hsm_moments_12:
+        z_hsm_momentsPsf_12:
+        z_hsm_moments_03:
+        z_hsm_momentsPsf_03:
+        z_hsm_moments_40:
+        z_hsm_momentsPsf_40:
+        z_hsm_moments_31:
+        z_hsm_momentsPsf_31:
+        z_hsm_moments_22:
+        z_hsm_momentsPsf_22:
+        z_hsm_moments_13:
+        z_hsm_momentsPsf_13:
+        z_hsm_moments_04:
+        z_hsm_momentsPsf_04:
+        z_hsm_moments_flag:
+        z_hsm_momentsPsf_flag:
+        z_kronFlux:
+        z_kronFluxErr:
+        z_kronFlux_flag:
+        z_kronFlux_flag_bad_radius:
+        z_kronFlux_flag_bad_shape:
+        z_kronFlux_flag_bad_shape_no_psf:
+        z_kronFlux_flag_edge:
+        z_kronFlux_flag_no_fallback_radius:
+        z_kronFlux_flag_no_minimum_radius:
+        z_kronFlux_flag_small_radius:
+        z_kronFlux_flag_used_minimum_radius:
+        z_kronFlux_flag_used_psf_radius:
+        z_kronRad:
+        z_pixelFlags_bad:
+        z_pixelFlags_clipped:
+        z_pixelFlags_clippedCenter:
+        z_pixelFlags_cr:
+        z_pixelFlags_crCenter:
+        z_pixelFlags_edge:
+        z_pixelFlags_inexact_psf:
+        z_pixelFlags_inexact_psfCenter:
+        z_pixelFlags_interpolated:
+        z_pixelFlags_interpolatedCenter:
+        z_pixelFlags_nodata:
+        z_pixelFlags_offimage:
+        z_pixelFlags_saturated:
+        z_pixelFlags_saturatedCenter:
+        z_pixelFlags_sensor_edge:
+        z_pixelFlags_sensor_edgeCenter:
+        z_pixelFlags_suspect:
+        z_pixelFlags_suspectCenter:
+        z_invalidPsfFlag:
+        z_psfFlux:
+        z_psfFluxErr:
+        z_psfFlux_area:
+        z_psfFlux_flag:
+        z_psfFlux_flag_apCorr:
+        z_psfFlux_flag_edge:
+        z_psfFlux_flag_noGoodPixels:
+        z_ra:
+        z_raErr:
+        z_ra_dec_Cov:
+        z_deblend_dataCoverage:
+        z_deblend_blendedness:
+        z_deblend_fluxOverlap:
+        z_deblend_fluxOverlapFraction:
+        z_deblend_zeroFlux:
+        g_psfModel_TwoGaussian_gauss1_sigma_x:
+        g_psfModel_TwoGaussian_gauss1_sigma_y:
+        g_psfModel_TwoGaussian_gauss1_rho:
+        g_psfModel_TwoGaussian_gauss1_fluxfrac:
+        g_psfModel_TwoGaussian_gauss2_sigma_x:
+        g_psfModel_TwoGaussian_gauss2_sigma_y:
+        g_psfModel_TwoGaussian_gauss2_rho:
+        g_psfModel_TwoGaussian_n_iter:
+        g_psfModel_TwoGaussian_chi2_reduced:
+        g_psfModel_TwoGaussian_unknown_flag:
+        g_psfModel_TwoGaussian_no_inputs_flag:
+        i_psfModel_TwoGaussian_gauss1_sigma_x:
+        i_psfModel_TwoGaussian_gauss1_sigma_y:
+        i_psfModel_TwoGaussian_gauss1_rho:
+        i_psfModel_TwoGaussian_gauss1_fluxfrac:
+        i_psfModel_TwoGaussian_gauss2_sigma_x:
+        i_psfModel_TwoGaussian_gauss2_sigma_y:
+        i_psfModel_TwoGaussian_gauss2_rho:
+        i_psfModel_TwoGaussian_n_iter:
+        i_psfModel_TwoGaussian_chi2_reduced:
+        i_psfModel_TwoGaussian_unknown_flag:
+        i_psfModel_TwoGaussian_no_inputs_flag:
+        r_psfModel_TwoGaussian_gauss1_sigma_x:
+        r_psfModel_TwoGaussian_gauss1_sigma_y:
+        r_psfModel_TwoGaussian_gauss1_rho:
+        r_psfModel_TwoGaussian_gauss1_fluxfrac:
+        r_psfModel_TwoGaussian_gauss2_sigma_x:
+        r_psfModel_TwoGaussian_gauss2_sigma_y:
+        r_psfModel_TwoGaussian_gauss2_rho:
+        r_psfModel_TwoGaussian_n_iter:
+        r_psfModel_TwoGaussian_chi2_reduced:
+        r_psfModel_TwoGaussian_unknown_flag:
+        r_psfModel_TwoGaussian_no_inputs_flag:
+        u_psfModel_TwoGaussian_gauss1_sigma_x:
+        u_psfModel_TwoGaussian_gauss1_sigma_y:
+        u_psfModel_TwoGaussian_gauss1_rho:
+        u_psfModel_TwoGaussian_gauss1_fluxfrac:
+        u_psfModel_TwoGaussian_gauss2_sigma_x:
+        u_psfModel_TwoGaussian_gauss2_sigma_y:
+        u_psfModel_TwoGaussian_gauss2_rho:
+        u_psfModel_TwoGaussian_n_iter:
+        u_psfModel_TwoGaussian_chi2_reduced:
+        u_psfModel_TwoGaussian_unknown_flag:
+        u_psfModel_TwoGaussian_no_inputs_flag:
+        y_psfModel_TwoGaussian_gauss1_sigma_x:
+        y_psfModel_TwoGaussian_gauss1_sigma_y:
+        y_psfModel_TwoGaussian_gauss1_rho:
+        y_psfModel_TwoGaussian_gauss1_fluxfrac:
+        y_psfModel_TwoGaussian_gauss2_sigma_x:
+        y_psfModel_TwoGaussian_gauss2_sigma_y:
+        y_psfModel_TwoGaussian_gauss2_rho:
+        y_psfModel_TwoGaussian_n_iter:
+        y_psfModel_TwoGaussian_chi2_reduced:
+        y_psfModel_TwoGaussian_unknown_flag:
+        y_psfModel_TwoGaussian_no_inputs_flag:
+        z_psfModel_TwoGaussian_gauss1_sigma_x:
+        z_psfModel_TwoGaussian_gauss1_sigma_y:
+        z_psfModel_TwoGaussian_gauss1_rho:
+        z_psfModel_TwoGaussian_gauss1_fluxfrac:
+        z_psfModel_TwoGaussian_gauss2_sigma_x:
+        z_psfModel_TwoGaussian_gauss2_sigma_y:
+        z_psfModel_TwoGaussian_gauss2_rho:
+        z_psfModel_TwoGaussian_n_iter:
+        z_psfModel_TwoGaussian_chi2_reduced:
+        z_psfModel_TwoGaussian_unknown_flag:
+        z_psfModel_TwoGaussian_no_inputs_flag:
+        exponential_ra:
+        exponential_raErr:
+        exponential_dec:
+        exponential_decErr:
+        exponential_ra_dec_Cov:
+        exponential_reff_x:
+        exponential_reff_xErr:
+        exponential_reff_y:
+        exponential_reff_yErr:
+        exponential_rho:
+        exponential_rhoErr:
+        exponential_reff_major:
+        exponential_reff_minor:
+        exponential_theta:
+        g_exponentialFlux:
+        g_exponentialFluxErr:
+        i_exponentialFlux:
+        i_exponentialFluxErr:
+        r_exponentialFlux:
+        r_exponentialFluxErr:
+        u_exponentialFlux:
+        u_exponentialFluxErr:
+        y_exponentialFlux:
+        y_exponentialFluxErr:
+        z_exponentialFlux:
+        z_exponentialFluxErr:
+        exponential_n_eval_jac:
+        exponential_n_iter:
+        exponential_chi2_reduced:
+        exponential_delta_lnL_fit_linear:
+        exponential_delta_lnL_fit_ps:
+        exponential_no_data_flag:
+        exponential_unknown_flag:
+        sersic_ra:
+        sersic_raErr:
+        sersic_dec:
+        sersic_decErr:
+        sersic_ra_dec_Cov:
+        sersic_reff_x:
+        sersic_reff_xErr:
+        sersic_reff_y:
+        sersic_reff_yErr:
+        sersic_rho:
+        sersic_rhoErr:
+        sersic_reff_major:
+        sersic_reff_minor:
+        sersic_theta:
+        g_sersicFlux:
+        g_sersicFluxErr:
+        i_sersicFlux:
+        i_sersicFluxErr:
+        r_sersicFlux:
+        r_sersicFluxErr:
+        u_sersicFlux:
+        u_sersicFluxErr:
+        y_sersicFlux:
+        y_sersicFluxErr:
+        z_sersicFlux:
+        z_sersicFluxErr:
+        sersic_index:
+        sersic_indexErr:
+        sersic_n_eval_jac:
+        sersic_n_iter:
+        sersic_chi2_reduced:
+        sersic_no_data_flag:
+        sersic_unknown_flag:
+        g_epoch:
+        i_epoch:
+        r_epoch:
+        u_epoch:
+        y_epoch:
+        z_epoch:
   columns:
-  - name: objectId
-    datatype: long
-    description: Unique id. Unique ObjectID
-    ivoa:ucd: meta.id;src
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: coord_decErr
-    datatype: float
-    description: Error in fiducial ICRS Declination of centroid
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec;meta.main
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: coord_raErr
-    datatype: float
-    description: Error in fiducial ICRS Right Ascension of centroid
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra;meta.main
-  - name: coord_ra_dec_Cov
-    datatype: float
-    description: Covariance between fiducial ICRS Right Ascension and Declination of centroid
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec;meta.main
-  - name: coord_flag
-    description: Centroid failure flag on reference band centroid used for database indexing
+  - name: detect_isPrimary
     datatype: boolean
-  - name: deblend_parentNChild
-    datatype: int
-    description: Number of children in deblended from the parent footprint.
-    fits:tunit:
-  - name: deblend_parentNPeaks
-    datatype: int
-    description: Number of peaks the parent footprint has (even if the deblender
-      failed or skipped this blend)
-    fits:tunit:
-  - name: deblend_peak_center_x
-    datatype: int
-    description: x-coordinate of the peak after source detection
-    fits:tunit: pixel
-  - name: deblend_peak_center_y
-    datatype: int
-    description: y-coordinate of the peak after source detection
-    fits:tunit: pixel
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-    fits:tunit:
-  - name: deblend_blendId
-    description: Unique ID of the deconvolved parent source that this source was deblended from.
-    datatype: long
-    fits:tunit:
-  - name: deblend_blendNChild
-    description: Number of children in the deconvolved parent source that this source
-      was deblended from.
-    datatype: int
-    fits:tunit:
-  - name: detect_fromBlend
-    datatype: boolean
-    description: This source is deblended from a parent with more than one child.
-    fits:tunit:
-  - name: detect_isDeblendedModelSource
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is a deblended child
+    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
     fits:tunit:
   - name: detect_isDeblendedSource
     datatype: boolean
     description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
     fits:tunit:
-  - name: detect_isIsolated
-    datatype: boolean
-    description: This source is not a part of a blend.
-    fits:tunit:
   - name: detect_isPatchInner
     datatype: boolean
     description: True if source is in the inner region of a coadd patch
-    fits:tunit:
-  - name: detect_isPrimary
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
     fits:tunit:
   - name: detect_isTractInner
     datatype: boolean
     description: True if source is in the inner region of a coadd tract
     fits:tunit:
-  - name: ebv
-    datatype: float
-    description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
-    fits:tunit: mag
-  - name: footprintArea
-    datatype: int
-    description: Number of pixels in the sources detection footprint. Reference band.
-    fits:tunit: pixel
   - name: merge_peak_sky
     datatype: boolean
     description: Peak detected in filter sky
     fits:tunit:
-  - name: parentObjectId
-    datatype: long
-    description: Unique ID of parent source. Reference band.
-    fits:tunit:
-  - name: patch
-    datatype: long
-    description: Skymap patch ID
-    fits:tunit:
-  - name: refBand
-    datatype: char
-    length: 1
-    description: Reference band - parameters measured on coadds of this band were used for multi-band forced photometry
-    fits:tunit:
-  - name: refExtendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Reference band.
-    fits:tunit:
-  - name: refSizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Reference band.
-    fits:tunit:
-  - name: shape_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Reference band.
-    fits:tunit:
-  - name: shape_xx
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
-  - name: shape_xy
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
-  - name: shape_yy
-    datatype: float
-    description: HSM moments. Reference band.
-    fits:tunit: pixel**2
   - name: sky_object
     datatype: boolean
     description: No source was detected here. This object exists to characterize properties of the sky background
     fits:tunit:
-  - name: tract
-    datatype: long
-    description: Skymap tract ID
-    fits:tunit:
-  - name: g_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on g-band.
-    fits:tunit:
-  - name: g_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on g-band.
-    fits:tunit:
-  - name: g_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on g-band.
-    fits:tunit: arcsec
-  - name: g_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on g-band.
-    fits:tunit:
-  - name: g_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    fits:tunit:
-  - name: g_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on g-band.
-    fits:tunit:
-  - name: g_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on g-band.
-    fits:tunit:
-  - name: g_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on g-band.
-    fits:tunit:
-  - name: g_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on g-band.
-    fits:tunit:
-  - name: g_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_dec
-    datatype: double
-    description: Position in declination, measured on g-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: g_decErr
-    datatype: float
-    description: Error in declination, measured on g-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: g_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on g-band.
-    fits:tunit:
-  - name: g_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on g-band.
-    fits:tunit:
-  - name: g_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on g-band.
-    fits:tunit:
-  - name: g_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on g-band.
-    fits:tunit:
-  - name: g_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
-    fits:tunit:
-  - name: griz_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
-    fits:tunit:
-  - name: g_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on g-band.
-    fits:tunit:
-  - name: g_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on g-band.
-    fits:tunit:
-  - name: g_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on g-band.
-    fits:tunit:
-  - name: g_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on g-band.
-    fits:tunit:
-  - name: g_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on g-band.
-    fits:tunit:
-  - name: g_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_trace
-    description: Moments-based trace radius (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_flag
-    description: Failure flag for moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_trace
-    description: Moments-based trace radius of the PSF (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_flag
-    description: Failure flag for PSF moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (g-band)
-    datatype: boolean
-  - name: g_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on g-band.
-    fits:tunit:
-  - name: g_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on g-band.
-    fits:tunit:
-  - name: g_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on g-band.
-    fits:tunit:
-  - name: g_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on g-band.
-    fits:tunit:
-  - name: g_ixx
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixy
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_iyy
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on g-band.
-    fits:tunit: pixel**2
-  - name: g_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with g_i_flag. Measured on g-band.
-    fits:tunit:
-  - name: g_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with g_iPSF_flag. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    fits:tunit: nJy
-  - name: g_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on g-band.
-    fits:tunit:
-  - name: g_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on g-band.
-    fits:tunit:
-  - name: g_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on g-band.
-    fits:tunit:
-  - name: g_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on g-band.
-    fits:tunit:
-  # - name: g_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on g-band.
-  #   fits:tunit:
-  # - name: g_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on g-band.
-  #   fits:tunit:
-  - name: g_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on g-band.
-    fits:tunit:
-  - name: g_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on g-band.
-    fits:tunit: nJy
-  - name: g_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on g-band.
-    fits:tunit: pixel
-  - name: g_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on g-band.
-    fits:tunit:
-  - name: g_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on g-band.
-    fits:tunit:
-  - name: g_ra
-    datatype: double
-    description: Position in right ascension, measured on g-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: g_raErr
-    datatype: float
-    description: Error in right ascension, measured on g-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: g_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on g-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: g_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the g-band.
-    fits:tunit:
-  - name: g_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: g_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: g_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: g_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: i_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on i-band.
-    fits:tunit:
-  - name: i_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on i-band.
-    fits:tunit:
-  - name: i_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on i-band.
-    fits:tunit: arcsec
-  - name: i_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on i-band.
-    fits:tunit:
-  - name: i_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    fits:tunit:
-  - name: i_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on i-band.
-    fits:tunit:
-  - name: i_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on i-band.
-    fits:tunit:
-  - name: i_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on i-band.
-    fits:tunit:
-  - name: i_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on i-band.
-    fits:tunit:
-  - name: i_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_dec
-    datatype: double
-    description: Position in declination, measured on i-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: i_decErr
-    datatype: float
-    description: Error in declination, measured on i-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: i_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on i-band.
-    fits:tunit:
-  - name: i_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on i-band.
-    fits:tunit:
-  - name: i_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on i-band.
-    fits:tunit:
-  - name: i_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on i-band.
-    fits:tunit:
-  - name: i_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
-    fits:tunit:
-  - name: i_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on i-band.
-    fits:tunit:
-  - name: i_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on i-band.
-    fits:tunit:
-  - name: i_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on i-band.
-    fits:tunit:
-  - name: i_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on i-band.
-    fits:tunit:
-  - name: i_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on i-band.
-    fits:tunit:
-  - name: i_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_trace
-    description: Moments-based trace radius (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_flag
-    description: Failure flag for moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_trace
-    description: Moments-based trace radius of the PSF (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_flag
-    description: Failure flag for PSF moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (i-band)
-    datatype: boolean
-  - name: i_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on i-band.
-    fits:tunit:
-  - name: i_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on i-band.
-    fits:tunit:
-  - name: i_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on i-band.
-    fits:tunit:
-  - name: i_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on i-band.
-    fits:tunit:
-  - name: i_ixx
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixy
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_iyy
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on i-band.
-    fits:tunit: pixel**2
-  - name: i_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with i_i_flag. Measured on i-band.
-    fits:tunit:
-  - name: i_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with i_iPSF_flag. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    fits:tunit: nJy
-  - name: i_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on i-band.
-    fits:tunit:
-  - name: i_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on i-band.
-    fits:tunit:
-  - name: i_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on i-band.
-    fits:tunit:
-  - name: i_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on i-band.
-    fits:tunit:
-  # - name: i_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on i-band.
-  #   fits:tunit:
-  # - name: i_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on i-band.
-  #   fits:tunit:
-  - name: i_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on i-band.
-    fits:tunit:
-  - name: i_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on i-band.
-    fits:tunit: nJy
-  - name: i_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on i-band.
-    fits:tunit: pixel
-  - name: i_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on i-band.
-    fits:tunit:
-  - name: i_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on i-band.
-    fits:tunit:
-  - name: i_ra
-    datatype: double
-    description: Position in right ascension, measured on i-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: i_raErr
-    datatype: float
-    description: Error in right ascension, measured on i-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: i_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on i-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: i_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the i-band.
-    fits:tunit:
-  - name: i_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: i_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: i_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: i_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: r_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on r-band.
-    fits:tunit:
-  - name: r_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on r-band.
-    fits:tunit:
-  - name: r_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on r-band.
-    fits:tunit: arcsec
-  - name: r_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on r-band.
-    fits:tunit:
-  - name: r_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    fits:tunit:
-  - name: r_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on r-band.
-    fits:tunit:
-  - name: r_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on r-band.
-    fits:tunit:
-  - name: r_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on r-band.
-    fits:tunit:
-  - name: r_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on r-band.
-    fits:tunit:
-  - name: r_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_dec
-    datatype: double
-    description: Position in declination, measured on r-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: r_decErr
-    datatype: float
-    description: Error in declination, measured on r-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: r_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on r-band.
-    fits:tunit:
-  - name: r_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on r-band.
-    fits:tunit:
-  - name: r_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on r-band.
-    fits:tunit:
-  - name: r_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on r-band.
-    fits:tunit:
-  - name: r_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
-    fits:tunit:
-  - name: r_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on r-band.
-    fits:tunit:
-  - name: r_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on r-band.
-    fits:tunit:
-  - name: r_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on r-band.
-    fits:tunit:
-  - name: r_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on r-band.
-    fits:tunit:
-  - name: r_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on r-band.
-    fits:tunit:
-  - name: r_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_trace
-    description: Moments-based trace radius (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_flag
-    description: Failure flag for moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_trace
-    description: Moments-based trace radius of the PSF (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_flag
-    description: Failure flag for PSF moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (r-band)
-    datatype: boolean
-  - name: r_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on r-band.
-    fits:tunit:
-  - name: r_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on r-band.
-    fits:tunit:
-  - name: r_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on r-band.
-    fits:tunit:
-  - name: r_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on r-band.
-    fits:tunit:
-  - name: r_ixx
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixy
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_iyy
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on r-band.
-    fits:tunit: pixel**2
-  - name: r_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with r_i_flag. Measured on r-band.
-    fits:tunit:
-  - name: r_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with r_iPSF_flag. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    fits:tunit: nJy
-  - name: r_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on r-band.
-    fits:tunit:
-  - name: r_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on r-band.
-    fits:tunit:
-  - name: r_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on r-band.
-    fits:tunit:
-  - name: r_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on r-band.
-    fits:tunit:
-  # - name: r_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on r-band.
-  #   fits:tunit:
-  # - name: r_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on r-band.
-  #   fits:tunit:
-  - name: r_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on r-band.
-    fits:tunit:
-  - name: r_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on r-band.
-    fits:tunit: nJy
-  - name: r_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on r-band.
-    fits:tunit: pixel
-  - name: r_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on r-band.
-    fits:tunit:
-  - name: r_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on r-band.
-    fits:tunit:
-  - name: r_ra
-    datatype: double
-    description: Position in right ascension, measured on r-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: r_raErr
-    datatype: float
-    description: Error in right ascension, measured on r-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: r_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on r-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: r_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the r-band.
-    fits:tunit:
-  - name: r_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: r_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: r_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: r_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: u_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on u-band.
-    fits:tunit:
-  - name: u_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on u-band.
-    fits:tunit:
-  - name: u_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on u-band.
-    fits:tunit:
-  - name: u_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on u-band.
-    fits:tunit:
-  - name: u_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on u-band.
-    fits:tunit: arcsec
-  - name: u_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on u-band.
-    fits:tunit: arcsec
-  - name: u_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on u-band.
-    fits:tunit:
-  - name: u_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on u-band.
-    fits:tunit: arcsec
-  - name: u_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on u-band.
-    fits:tunit: arcsec
-  - name: u_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on u-band.
-    fits:tunit:
-  - name: u_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on u-band.
-    fits:tunit:
-  - name: u_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on u-band.
-    fits:tunit:
-  - name: u_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on u-band.
-    fits:tunit:
-  - name: u_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on u-band.
-    fits:tunit:
-  - name: u_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on u-band.
-    fits:tunit:
-  - name: u_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on u-band.
-    fits:tunit:
-  - name: u_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on u-band.
-    fits:tunit:
-  - name: u_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on u-band.
-    fits:tunit:
-  - name: u_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on u-band.
-    fits:tunit:
-  - name: u_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on u-band.
-    fits:tunit:
-  - name: u_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on u-band.
-    fits:tunit:
-  - name: u_dec
-    datatype: double
-    description: Position in declination, measured on u-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: u_decErr
-    datatype: float
-    description: Error in declination, measured on u-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: u_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on u-band.
-    fits:tunit:
-  - name: u_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on u-band.
-    fits:tunit:
-  - name: u_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on u-band.
-    fits:tunit:
-  - name: u_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on u-band.
-    fits:tunit:
-  - name: u_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes.
-    fits:tunit:
-  - name: u_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on u-band.
-    fits:tunit:
-  - name: u_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on u-band.
-    fits:tunit:
-  - name: u_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on u-band.
-    fits:tunit:
-  - name: u_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on u-band.
-    fits:tunit:
-  - name: u_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on u-band.
-    fits:tunit:
-  - name: u_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (u-band)
-    datatype: float
-  - name: u_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (u-band)
-    datatype: float
-  - name: u_moments_trace
-    description: Moments-based trace radius (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_flag
-    description: Failure flag for moments (u-band)
-    datatype: boolean
-  - name: u_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (u-band)
-    datatype: float
-  - name: u_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (u-band)
-    datatype: float
-  - name: u_moments_psf_trace
-    description: Moments-based trace radius of the PSF (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_psf_flag
-    description: Failure flag for PSF moments (u-band)
-    datatype: boolean
-  - name: u_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (u-band)
-    datatype: float
-  - name: u_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (u-band)
-    datatype: float
-  - name: u_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (u-band)
-    datatype: boolean
-  - name: u_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    fits:tunit:
-  - name: u_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    fits:tunit:
-  - name: u_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on u-band.
-    fits:tunit:
-  - name: u_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on u-band.
-    fits:tunit:
-  - name: u_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on u-band.
-    fits:tunit:
-  - name: u_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on u-band.
-    fits:tunit:
-  - name: u_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on u-band.
-    fits:tunit:
-  - name: u_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on u-band.
-    fits:tunit:
-  - name: u_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on u-band.
-    fits:tunit:
-  - name: u_ixx
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_ixy
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_iyy
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on u-band.
-    fits:tunit: pixel**2
-  - name: u_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with u_i_flag. Measured on u-band.
-    fits:tunit:
-  - name: u_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with u_iPSF_flag. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on u-band.
-    fits:tunit: nJy
-  - name: u_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on u-band.
-    fits:tunit:
-  - name: u_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on u-band.
-    fits:tunit:
-  - name: u_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on u-band.
-    fits:tunit:
-  - name: u_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on u-band.
-    fits:tunit:
-  # - name: u_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on u-band.
-  #   fits:tunit:
-  # - name: u_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on u-band.
-  #   fits:tunit:
-  - name: u_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on u-band.
-    fits:tunit:
-  - name: u_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on u-band.
-    fits:tunit: nJy
-  - name: u_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on u-band.
-    fits:tunit: pixel
-  - name: u_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on u-band.
-    fits:tunit:
-  - name: u_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on u-band.
-    fits:tunit:
-  - name: u_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on u-band.
-    fits:tunit:
-  - name: u_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on u-band.
-    fits:tunit:
-  - name: u_ra
-    datatype: double
-    description: Position in right ascension, measured on u-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: u_raErr
-    datatype: float
-    description: Error in right ascension, measured on u-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: u_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on u-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: u_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the u-band.
-    fits:tunit:
-  - name: u_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: u_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: u_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: u_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: y_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on y-band.
-    fits:tunit:
-  - name: y_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on y-band.
-    fits:tunit:
-  - name: y_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on y-band.
-    fits:tunit: arcsec
-  - name: y_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on y-band.
-    fits:tunit:
-  - name: y_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    fits:tunit:
-  - name: y_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on y-band.
-    fits:tunit:
-  - name: y_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on y-band.
-    fits:tunit:
-  - name: y_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on y-band.
-    fits:tunit:
-  - name: y_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on y-band.
-    fits:tunit:
-  - name: y_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_dec
-    datatype: double
-    description: Position in declination, measured on y-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: y_decErr
-    datatype: float
-    description: Error in declination, measured on y-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: y_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on y-band.
-    fits:tunit:
-  - name: y_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on y-band.
-    fits:tunit:
-  - name: y_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on y-band.
-    fits:tunit:
-  - name: y_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on y-band.
-    fits:tunit:
-  - name: y_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
-    fits:tunit:
-  - name: y_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on y-band.
-    fits:tunit:
-  - name: y_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on y-band.
-    fits:tunit:
-  - name: y_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on y-band.
-    fits:tunit:
-  - name: y_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on y-band.
-    fits:tunit:
-  - name: y_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on y-band.
-    fits:tunit:
-  - name: y_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_trace
-    description: Moments-based trace radius (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_flag
-    description: Failure flag for moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_trace
-    description: Moments-based trace radius of the PSF (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_flag
-    description: Failure flag for PSF moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (y-band)
-    datatype: boolean
-  - name: y_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on y-band.
-    fits:tunit:
-  - name: y_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on y-band.
-    fits:tunit:
-  - name: y_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on y-band.
-    fits:tunit:
-  - name: y_ixx
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixy
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_iyy
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on y-band.
-    fits:tunit: pixel**2
-  - name: y_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with y_i_flag. Measured on y-band.
-    fits:tunit:
-  - name: y_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with y_iPSF_flag. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    fits:tunit: nJy
-  - name: y_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on y-band.
-    fits:tunit:
-  - name: y_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on y-band.
-    fits:tunit:
-  - name: y_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on y-band.
-    fits:tunit:
-  - name: y_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on y-band.
-    fits:tunit:
-  # - name: y_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on y-band.
-  #   fits:tunit:
-  # - name: y_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on y-band.
-  #   fits:tunit:
-  - name: y_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on y-band.
-    fits:tunit:
-  - name: y_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on y-band.
-    fits:tunit: nJy
-  - name: y_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on y-band.
-    fits:tunit: pixel
-  - name: y_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on y-band.
-    fits:tunit:
-  - name: y_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on y-band.
-    fits:tunit:
-  - name: y_ra
-    datatype: double
-    description: Position in right ascension, measured on y-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: y_raErr
-    datatype: float
-    description: Error in right ascension, measured on y-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: y_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on y-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: y_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the y-band.
-    fits:tunit:
-  - name: y_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: y_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: y_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: y_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: z_ap03Flux
-    datatype: float
-    description: Flux within 3.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap03FluxErr
-    datatype: float
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap06Flux
-    datatype: float
-    description: Flux within 6.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap06FluxErr
-    datatype: float
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap09Flux
-    datatype: float
-    description: Flux within 9.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap09FluxErr
-    datatype: float
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap12Flux
-    datatype: float
-    description: Flux within 12.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap12FluxErr
-    datatype: float
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap17Flux
-    datatype: float
-    description: Flux within 17.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap17FluxErr
-    datatype: float
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap25Flux
-    datatype: float
-    description: Flux within 25.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap25FluxErr
-    datatype: float
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap35Flux
-    datatype: float
-    description: Flux within 35.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap35FluxErr
-    datatype: float
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap50Flux
-    datatype: float
-    description: Flux within 50.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap50FluxErr
-    datatype: float
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_ap70Flux
-    datatype: float
-    description: Flux within 70.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap70FluxErr
-    datatype: float
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image. Measured on z-band.
-    fits:tunit:
-  - name: z_apFlux_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_chi2
-    datatype: float
-    description: -ln(likelihood) (chi^2) in cmodel fit. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on z-band.
-    fits:tunit:
-  - name: z_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on z-band.
-    fits:tunit: arcsec
-  - name: z_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on z-band.
-    fits:tunit:
-  - name: z_blendedness
-    datatype: float
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    fits:tunit:
-  - name: z_blendedness_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on z-band.
-    fits:tunit:
-  - name: z_cModel_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Forced on z-band.
-    fits:tunit:
-  - name: z_cModel_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct modelfit_CModel. Forced on z-band.
-    fits:tunit:
-  - name: z_calib_astrometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_photometry_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_candidate
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_reserved
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_calib_psf_used
-    datatype: boolean
-    description: Propagated from sources. Measured on z-band.
-    fits:tunit:
-  - name: z_centroid_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_dec
-    datatype: double
-    description: Position in declination, measured on z-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: z_decErr
-    datatype: float
-    description: Error in declination, measured on z-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: z_extendedness
-    datatype: float
-    description: Set to 1 for extended sources, 0 for point sources. Measured on z-band.
-    fits:tunit:
-  - name: z_extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on z-band.
-    fits:tunit:
-  - name: z_sizeExtendedness
-    datatype: float
-    description: Moments-based measure of an object to be a galaxy. Measured on z-band.
-    fits:tunit:
-  - name: z_sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure. Measured on z-band.
-    fits:tunit:
-  - name: z_model_extendedness
-    datatype: float
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
-    fits:tunit:
-  - name: z_free_cModelFlux
-    datatype: float
-    description: Flux from the final cmodel fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModelFluxErr
-    datatype: float
-    description: Flux uncertainty from the final cmodel fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModelFlux_flag
-    datatype: boolean
-    description: Flag set if the final cmodel fit (or any previous fit) failed. Measured on z-band.
-    fits:tunit:
-  - name: z_free_cModelFlux_inner
-    datatype: float
-    description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_fracDev
-    datatype: float
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on z-band.
-    fits:tunit:
-  - name: z_free_cModel_devFlux
-    datatype: float
-    description: Flux from the de Vaucouleurs fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_devFluxErr
-    datatype: float
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_expFlux
-    datatype: float
-    description: Flux from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_cModel_expFluxErr
-    datatype: float
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_free_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Measured on z-band.
-    fits:tunit:
-  - name: z_gaap0p7Flux
-    datatype: float
-    description: GAaP Flux with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap0p7FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 0.7 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap1p0Flux
-    datatype: float
-    description: GAaP Flux with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaap1p0FluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with 1.0 aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaapFlux_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on z-band.
-    fits:tunit:
-  - name: z_gaapFlux_flag_edge
-    datatype: boolean
-    description: Source is too close to the edge. Forced on z-band.
-    fits:tunit:
-  - name: z_gaapPsfFlux
-    datatype: float
-    description: GAaP Flux with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_gaapPsfFluxErr
-    datatype: float
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing by 1.15. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_trace
-    description: Moments-based trace radius (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_flag
-    description: Failure flag for moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_trace
-    description: Moments-based trace radius of the PSF (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_flag
-    description: Failure flag for PSF moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (z-band)
-    datatype: boolean
-  - name: z_hsmShapeRegauss_e1
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_e2
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_hsmShapeRegauss_sigma
-    datatype: float
-    description: PSF-corrected shear using Hirata & Seljak (2003) regaussianization. Measured on z-band.
-    fits:tunit:
-  - name: z_iPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_i_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_inputCount
-    datatype: int
-    description: Number of images contributing at center, not including anyclipping. Forced on z-band.
-    fits:tunit:
-  - name: z_inputCount_flag
-    datatype: boolean
-    description: Set for any fatal failure. Forced on z-band.
-    fits:tunit:
-  - name: z_inputCount_flag_noInputs
-    datatype: boolean
-    description: No coadd inputs available. Forced on z-band.
-    fits:tunit:
-  - name: z_ixx
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixxPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixy
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_ixyPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_iyy
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_iyyPSF
-    datatype: float
-    description: HSM moments. Measured on z-band.
-    fits:tunit: pixel**2
-  - name: z_hsm_moments_30
-    datatype: float
-    description: HSM higher order moments 30. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_30
-    datatype: float
-    description: HSM higher order PSF moments 30. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_21
-    datatype: float
-    description: HSM higher order moments 21. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_21
-    datatype: float
-    description: HSM higher order PSF moments 21. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_12
-    datatype: float
-    description: HSM higher order moments 12. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_12
-    datatype: float
-    description: HSM higher order PSF moments 12. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_03
-    datatype: float
-    description: HSM higher order moments 03. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_03
-    datatype: float
-    description: HSM higher order PSF moments 03. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_40
-    datatype: float
-    description: HSM higher order moments 40. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_40
-    datatype: float
-    description: HSM higher order PSF moments 40. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_31
-    datatype: float
-    description: HSM higher order moments 31. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_31
-    datatype: float
-    description: HSM higher order PSF moments 31. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_22
-    datatype: float
-    description: HSM higher order moments 22. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_22
-    datatype: float
-    description: HSM higher order PSF moments 22. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_13
-    datatype: float
-    description: HSM higher order moments 13. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_13
-    datatype: float
-    description: HSM higher order PSF moments 13. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_04
-    datatype: float
-    description: HSM higher order moments 04. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_04
-    datatype: float
-    description: HSM higher order PSF moments 04. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_moments_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with z_i_flag. Measured on z-band.
-    fits:tunit:
-  - name: z_hsm_momentsPsf_flag
-    datatype: boolean
-    description: General failure flag, to be used in conjunction with z_iPSF_flag. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux
-    datatype: float
-    description: Flux from Kron Flux algorithm. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_kronFluxErr
-    datatype: float
-    description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    fits:tunit: nJy
-  - name: z_kronFlux_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_radius
-    datatype: boolean
-    description: Bad Kron radius. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_shape
-    datatype: boolean
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_bad_shape_no_psf
-    datatype: boolean
-    description: Bad shape and no PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_edge
-    datatype: boolean
-    description: Bad measurement due to image edge. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_no_fallback_radius
-    datatype: boolean
-    description: No minimum radius and no PSF provided. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_no_minimum_radius
-    datatype: boolean
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_small_radius
-    datatype: boolean
-    description: Measured Kron radius was smaller than that of the PSF. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_used_minimum_radius
-    datatype: boolean
-    description: Used the minimum radius for the Kron aperture. Measured on z-band.
-    fits:tunit:
-  - name: z_kronFlux_flag_used_psf_radius
-    datatype: boolean
-    description: Used the PSF Kron radius for the Kron aperture. Measured on z-band.
-    fits:tunit:
-  - name: z_kronRad
-    datatype: float
-    description: Kron radius (sqrt(a*b)). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_clipped
-    datatype: boolean
-    description: Source footprint includes CLIPPED pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_clippedCenter
-    datatype: boolean
-    description: Source center is close to CLIPPED pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_inexact_psf
-    datatype: boolean
-    description: Source footprint includes INEXACT_PSF pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_inexact_psfCenter
-    datatype: boolean
-    description: Source center is close to INEXACT_PSF pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA). Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_sensor_edge
-    datatype: boolean
-    description: Source footprint includes SENSOR_EDGE pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_sensor_edgeCenter
-    datatype: boolean
-    description: Source center is close to SENSOR_EDGE pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels. Measured on z-band.
-    fits:tunit:
-  - name: z_pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels. Measured on z-band.
-    fits:tunit:
-  # - name: z_pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint. Measured on z-band.
-  #   fits:tunit:
-  # - name: z_pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center. Measured on z-band.
-  #   fits:tunit:
-  - name: z_invalidPsfFlag
-    datatype: boolean
-    description: This object has an invalid PSF (usually no inputs). Measured on z-band.
-    fits:tunit:
-  - name: z_psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of PSF model. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_psfFluxErr
-    datatype: float
-    description: Flux uncertainty derived from linear least-squares fit of PSF model. Forced on z-band.
-    fits:tunit: nJy
-  - name: z_psfFlux_area
-    datatype: float
-    description: Effective area of PSF. Forced on z-band.
-    fits:tunit: pixel
-  - name: z_psfFlux_flag
-    datatype: boolean
-    description: General Failure Flag. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model. Forced on z-band.
-    fits:tunit:
-  - name: z_psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced on z-band.
-    fits:tunit:
-  - name: z_ra
-    datatype: double
-    description: Position in right ascension, measured on z-band.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: z_raErr
-    datatype: float
-    description: Error in right ascension, measured on z-band.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: z_ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination, measured on z-band.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: z_deblend_dataCoverage
-    datatype: float
-    description: Fraction of data that contained good data, ie. 1 - number of no data pixels/total number of pixels in the z-band.
-    fits:tunit:
-  - name: z_deblend_blendedness
-    datatype: float
-    description: Blendedness in the deconvolved scarlet space
-    fits:tunit:
-  - name: z_deblend_fluxOverlap
-    datatype: float
-    description: The total flux from neighboring objects that overlaps with this sources footprint in the deconvolved space.
-    fits:tunit:
-  - name: z_deblend_fluxOverlapFraction
-    datatype: float
-    description: Fraction of flux from neighbors / source flux in the deconvolved footprint.
-    fits:tunit:
-  - name: z_deblend_zeroFlux
-    datatype: boolean
-    description: True when there was no flux attributed to this object after flux redistribution in the deblender.
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (g-band).
-    fits:tunit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: g_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (g-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (i-band).
-    fits:tunit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: i_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (i-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (r-band).
-    fits:tunit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: r_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (r-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (u-band).
-    fits:tunit: pixel
-  - name: u_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (u-band).
-    fits:tunit: pixel
-  - name: u_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (u-band).
-    fits:tunit: pixel
-  - name: u_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (u-band).
-    fits:tunit: pixel
-  - name: u_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: u_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (u-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (y-band).
-    fits:tunit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: y_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (y-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_x
-    datatype: float
-    description: Standard deviation of the first Gaussian component (x-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_y
-    datatype: float
-    description: Standard deviation of the first Gaussian component (y-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss1_fluxfrac
-    datatype: float
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_x
-    datatype: float
-    description: Standard deviation of the second Gaussian component (x-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_y
-    datatype: float
-    description: Standard deviation of the second Gaussian component (y-axis) in the two-Gaussian PSF model (z-band).
-    fits:tunit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component in the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: z_psfModel_TwoGaussian_no_inputs_flag
-    datatype: boolean
-    description: Flag set for objects not fit because there were no coadd PSF inputs for the two-Gaussian PSF model (z-band).
-    fits:tunit:
-  - name: exponential_ra
-    datatype: double
-    description: Centroid (right ascension) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_raErr
-    datatype: float
-    description: Error on the centroid (right ascension) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_dec
-    datatype: double
-    description: Centroid (declination) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_decErr
-    datatype: float
-    description: Error on the centroid (declination) from the multiband exponential model fit.
-    fits:tunit: deg
-  - name: exponential_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband exponential model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: exponential_reff_x
-    datatype: float
-    description: Effective radius (x-axis) from the multiband exponential model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: exponential_reff_xErr
-    datatype: float
-    description: Error on the effective radius (x-axis) from the multiband exponential model fit.
-    fits:tunit: pixel
-  - name: exponential_reff_y
-    datatype: float
-    description: Effective radius (y-axis) from the multiband exponential model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: exponential_reff_yErr
-    datatype: float
-    description: Error on the effective radius (y-axis) from the multiband exponential model fit.
-    fits:tunit: pixel
-  - name: exponential_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_rhoErr
-    datatype: float
-    description: Error on ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: exponential_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: exponential_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-    fits:tunit:
-  - name: g_exponentialFlux
-    datatype: float
-    description: g-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: g_exponentialFluxErr
-    datatype: float
-    description: Error on the g-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: i_exponentialFlux
-    datatype: float
-    description: i-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: i_exponentialFluxErr
-    datatype: float
-    description: Error on the i-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: r_exponentialFlux
-    datatype: float
-    description: r-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: r_exponentialFluxErr
-    datatype: float
-    description: Error on the r-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: u_exponentialFlux
-    datatype: float
-    description: u-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: u_exponentialFluxErr
-    datatype: float
-    description: Error on the u-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: y_exponentialFlux
-    datatype: float
-    description: y-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: y_exponentialFluxErr
-    datatype: float
-    description: Error on the y-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: z_exponentialFlux
-    datatype: float
-    description: z-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: z_exponentialFluxErr
-    datatype: float
-    description: Error on the z-band flux from the multiband exponential model fit.
-    fits:tunit: nJy
-  - name: exponential_n_eval_jac
-    datatype: int
-    description: Number of Jacobian evaluations for the multiband exponential model fit.
-    fits:tunit:
-  - name: exponential_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_delta_lnL_fit_linear
-    datatype: float
-    description: The ln-likelihood of the best model non-linear fit parameters minus the ln-likelihood of a subsequent linear least squares fit.
-    fits:tunit:
-  - name: exponential_delta_lnL_fit_ps
-    datatype: float
-    description: The ln-likelihood of the best-fit exponential model minus the ln-likelihood of a point source with the same centroid and PSF model.
-    fits:tunit:
-  - name: exponential_no_data_flag
-    datatype: boolean
-    description: Flag set when there is insufficient data to fit for the multiband exponential model.
-    fits:tunit:
-  - name: exponential_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the multiband exponential model.
-    fits:tunit:
-  - name: sersic_ra
-    datatype: double
-    description: Centroid (right ascension) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_raErr
-    datatype: float
-    description: Error on the centroid (right ascension) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_dec
-    datatype: double
-    description: Centroid (declination) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_decErr
-    datatype: float
-    description: Error on the centroid (declination) from the multiband Sersic model fit.
-    fits:tunit: deg
-  - name: sersic_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband Sersic model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: sersic_reff_x
-    datatype: float
-    description: Effective radius (x-axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: sersic_reff_xErr
-    datatype: float
-    description: Error on the effective radius (x-axis) from the multiband Sersic model fit.
-    fits:tunit: pixel
-  - name: sersic_reff_y
-    datatype: float
-    description: Effective radius (y-axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: pixel
-  - name: sersic_reff_yErr
-    datatype: float
-    description: Error on the effective radius (y-axis) from the multiband Sersic model fit.
-    fits:tunit: pixel
-  - name: sersic_rho
-    datatype: float
-    description: Ellipse rho (correlation coefficient) from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_rhoErr
-    datatype: float
-    description: Error on ellipse rho (correlation coefficient) from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: sersic_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the adjusted (see config) PSF value.
-    fits:tunit: arcsec
-  - name: sersic_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-    fits:tunit:
-  - name: g_sersicFlux
-    datatype: float
-    description: g-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: g_sersicFluxErr
-    datatype: float
-    description: Error on the g-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: i_sersicFlux
-    datatype: float
-    description: i-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: i_sersicFluxErr
-    datatype: float
-    description: Error on the i-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: r_sersicFlux
-    datatype: float
-    description: r-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: r_sersicFluxErr
-    datatype: float
-    description: Error on the r-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: u_sersicFlux
-    datatype: float
-    description: u-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: u_sersicFluxErr
-    datatype: float
-    description: Error on the u-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: y_sersicFlux
-    datatype: float
-    description: y-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: y_sersicFluxErr
-    datatype: float
-    description: Error on the y-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: z_sersicFlux
-    datatype: float
-    description: z-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: z_sersicFluxErr
-    datatype: float
-    description: Error on the z-band flux from the multiband Sersic model fit.
-    fits:tunit: nJy
-  - name: sersic_index
-    datatype: float
-    description: Sersic profile index parameter from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_indexErr
-    datatype: float
-    description: Error on the Sersic profile index parameter from the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_n_eval_jac
-    datatype: int
-    description: Number of Jacobian evaluations for the multiband Sersic model fit.
-    fits:tunit:
-  - name: sersic_n_iter
-    datatype: int
-    description: Number of iterations in the non-linear fit for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_chi2_reduced
-    datatype: float
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_no_data_flag
-    datatype: boolean
-    description: Flag set when there is insufficient data to fit for the multiband Sersic model.
-    fits:tunit:
-  - name: sersic_unknown_flag
-    datatype: boolean
-    description: Flag set for failures with an unexpected or unknown cause for the multiband Sersic model.
-    fits:tunit:
-  - name: g_epoch
-    datatype: double
-    description: Mean epoch of the object in the g-band coadd in MJD TAI
-    fits:tunit: d
-  - name: i_epoch
-    datatype: double
-    description: Mean epoch of the object in the i-band coadd in MJD TAI
-    fits:tunit: d
-  - name: r_epoch
-    datatype: double
-    description: Mean epoch of the object in the r-band coadd in MJD TAI
-    fits:tunit: d
-  - name: u_epoch
-    datatype: double
-    description: Mean epoch of the object in the u-band coadd in MJD TAI
-    fits:tunit: d
-  - name: y_epoch
-    datatype: double
-    description: Mean epoch of the object in the y-band coadd in MJD TAI
-    fits:tunit: d
-  - name: z_epoch
-    datatype: double
-    description: Mean epoch of the object in the z-band coadd in MJD TAI
-    fits:tunit: d
-
-
 - name: Source
-  description: Table to store high signal-to-noise sources;. A source is
+  description: Table to store high signal-to-noise sources. A source is
     a measurement of Object's properties from a single image that contains its footprint
     on the sky.
+  columnRefs:
+    base:
+      Source:
+        sourceId:
+        coord_ra:
+        coord_dec:
+        visit:
+        detector:
+        parentSourceId:
+        x:
+        y:
+        xErr:
+        yErr:
+        ra:
+        dec:
+        raErr:
+        decErr:
+        ra_dec_Cov:
+        calibFlux:
+        calibFluxErr:
+        ap03Flux:
+        ap03FluxErr:
+        ap03Flux_flag:
+        ap06Flux:
+        ap06FluxErr:
+        ap06Flux_flag:
+        ap09Flux:
+        ap09FluxErr:
+        ap09Flux_flag:
+        ap12Flux:
+        ap12FluxErr:
+        ap12Flux_flag:
+        ap17Flux:
+        ap17FluxErr:
+        ap17Flux_flag:
+        ap25Flux:
+        ap25FluxErr:
+        ap25Flux_flag:
+        ap35Flux:
+        ap35FluxErr:
+        ap35Flux_flag:
+        ap50Flux:
+        ap50FluxErr:
+        ap50Flux_flag:
+        ap70Flux:
+        ap70FluxErr:
+        ap70Flux_flag:
+        sky:
+        skyErr:
+        psfFlux:
+        psfFluxErr:
+        ixx:
+        iyy:
+        ixy:
+        ixxPSF:
+        iyyPSF:
+        ixyPSF:
+        ixxDebiasedPSF:
+        iyyDebiasedPSF:
+        ixyDebiasedPSF:
+        gaussianFlux:
+        gaussianFluxErr:
+        extendedness:
+        sizeExtendedness:
+        blendedness_abs:
+        blendedness_flag:
+        blendedness_flag_noCentroid:
+        blendedness_flag_noShape:
+        apFlux_12_0_flag:
+        apFlux_12_0_flag_apertureTruncated:
+        apFlux_12_0_flag_sincCoeffsTruncated:
+        apFlux_12_0_instFlux:
+        apFlux_12_0_instFluxErr:
+        apFlux_17_0_flag:
+        apFlux_17_0_instFlux:
+        apFlux_17_0_instFluxErr:
+        apFlux_35_0_flag:
+        apFlux_35_0_instFlux:
+        apFlux_35_0_instFluxErr:
+        apFlux_50_0_flag:
+        apFlux_50_0_instFlux:
+        apFlux_50_0_instFluxErr:
+        normCompTophatFlux_flag:
+        normCompTophatFlux_instFlux:
+        normCompTophatFlux_instFluxErr:
+        extendedness_flag:
+        sizeExtendedness_flag:
+        footprintArea_value:
+        jacobian_flag:
+        jacobian_value:
+        localBackground_instFlux:
+        localBackground_instFluxErr:
+        localBackground_flag:
+        localBackground_flag_noGoodPixels:
+        localBackground_flag_noPsf:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_offimage:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        invalidPsfFlag:
+        psfFlux_apCorr:
+        psfFlux_apCorrErr:
+        psfFlux_area:
+        psfFlux_flag:
+        psfFlux_flag_apCorr:
+        psfFlux_flag_edge:
+        psfFlux_flag_noGoodPixels:
+        gaussianFlux_flag:
+        centroid_flag:
+        centroid_flag_almostNoSecondDerivative:
+        centroid_flag_badError:
+        centroid_flag_edge:
+        centroid_flag_noSecondDerivative:
+        centroid_flag_notAtMaximum:
+        centroid_flag_resetToPeak:
+        variance_flag:
+        variance_flag_emptyFootprint:
+        variance_value:
+        calib_astrometry_used:
+        calib_photometry_reserved:
+        calib_photometry_used:
+        calib_psf_candidate:
+        calib_psf_reserved:
+        calib_psf_used:
+        deblend_deblendedAsPsf:
+        deblend_hasStrayFlux:
+        deblend_masked:
+        deblend_nChild:
+        deblend_parentTooBig:
+        deblend_patchedTemplate:
+        deblend_rampedTemplate:
+        deblend_skipped:
+        deblend_tooManyPeaks:
+        hsmPsfMoments_flag:
+        hsmPsfMoments_flag_no_pixels:
+        hsmPsfMoments_flag_not_contained:
+        hsmPsfMoments_flag_parent_source:
+        iDebiasedPSF_flag:
+        iDebiasedPSF_flag_no_pixels:
+        iDebiasedPSF_flag_not_contained:
+        iDebiasedPSF_flag_parent_source:
+        iDebiasedPSF_flag_galsim:
+        iDebiasedPSF_flag_edge:
+        hsmShapeRegauss_flag:
+        hsmShapeRegauss_flag_galsim:
+        hsmShapeRegauss_flag_no_pixels:
+        hsmShapeRegauss_flag_not_contained:
+        hsmShapeRegauss_flag_parent_source:
+        sky_source:
+        band:
+        physical_filter:
   columns:
-  - name: sourceId
-    datatype: long
-    nullable: false
-    description: Unique id. Unique Source ID. Primary Key.
-    ivoa:ucd: meta.id;src
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: visit
-    datatype: long
-    nullable: false
-    description: Id of the visit where this source was measured.
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    datatype: short
-    nullable: false
-    description: Id of the detector where this source was measured.
-      Datatype short instead of byte because of DB concerns about unsigned bytes.
-    ivoa:ucd: meta.id;obs.image
-  - name: parentSourceId
-    datatype: long
-    description: Unique ID of parent source
-    fits:tunit:
-  - name: x
-    datatype: double
-    description: Centroid from Sdss Centroid algorithm
-    fits:tunit: pixel
-  - name: y
-    datatype: double
-    description: Centroid from Sdss Centroid algorithm
-    fits:tunit: pixel
-  - name: xErr
-    datatype: float
-    description: 1-sigma uncertainty on x position
-    fits:tunit: pixel
-  - name: yErr
-    datatype: float
-    description: 1-sigma uncertainty on y position
-    fits:tunit: pixel
-  - name: ra
-    datatype: double
-    description: Position in right ascension.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: dec
-    datatype: double
-    description: Position in declination.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: raErr
-    datatype: float
-    description: Error in right ascension.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: decErr
-    datatype: float
-    description: Error in declination.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: calibFlux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: calibFluxErr
-    datatype: double
-    description: Flux uncertainty within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03Flux
-    datatype: double
-    description: Flux within 3.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03FluxErr
-    datatype: double
-    description: Flux uncertainty within 3.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap03Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap06Flux
-    datatype: double
-    description: Flux within 6.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap06FluxErr
-    datatype: double
-    description: Flux uncertainty within 6.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap06Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap09Flux
-    datatype: double
-    description: Flux within 9.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap09FluxErr
-    datatype: double
-    description: Flux uncertainty within 9.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap09Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap12Flux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap12FluxErr
-    datatype: double
-    description: Flux uncertainty within 12.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap12Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap17Flux
-    datatype: double
-    description: Flux within 17.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap17FluxErr
-    datatype: double
-    description: Flux uncertainty within 17.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap17Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap25Flux
-    datatype: double
-    description: Flux within 25.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap25FluxErr
-    datatype: double
-    description: Flux uncertainty within 25.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap25Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap35Flux
-    datatype: double
-    description: Flux within 35.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap35FluxErr
-    datatype: double
-    description: Flux uncertainty within 35.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap35Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap50Flux
-    datatype: double
-    description: Flux within 50.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap50FluxErr
-    datatype: double
-    description: Flux uncertainty within 50.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap50Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: ap70Flux
-    datatype: double
-    description: Flux within 70.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap70FluxErr
-    datatype: double
-    description: Flux uncertainty within 70.0-pixel aperture
-    fits:tunit: nJy
-  - name: ap70Flux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: sky
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: nJy
-  - name: skyErr
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: nJy
-  - name: psfFlux
-    datatype: double
-    description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: psfFluxErr
-    datatype: double
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: ixx
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: iyy
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixy
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixxPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: iyyPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixyPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixxDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: iyyDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: ixyDebiasedPSF
-    datatype: double
-    description: HSM moments
-    fits:tunit: pixel**2
-  - name: gaussianFlux
-    datatype: double
-    description: Flux from Gaussian Flux algorithm
-    fits:tunit: nJy
-  - name: gaussianFluxErr
-    datatype: double
-    description: Flux uncertainty from Gaussian Flux algorithm
-    fits:tunit: nJy
-  - name: extendedness
-    datatype: double
-    description: Set to 1 for extended sources, 0 for point sources.
-    fits:tunit:
-  - name: sizeExtendedness
-    datatype: double
-    description: Moments-based measure of a source to be a galaxy.
-    fits:tunit:
-  - name: blendedness_abs
-    datatype: double
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates on the absolute value of the pixels to try to obtain a de-noised value.  See section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    fits:tunit:
-  - name: blendedness_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: blendedness_flag_noCentroid
-    datatype: boolean
-    description: Object has no centroid
-    fits:tunit:
-  - name: blendedness_flag_noShape
-    datatype: boolean
-    description: Object has no shape
-    fits:tunit:
-  - name: apFlux_12_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_12_0_flag_apertureTruncated
-    datatype: boolean
-    description: Aperture did not fit within measurement image
-    fits:tunit:
-  - name: apFlux_12_0_flag_sincCoeffsTruncated
-    datatype: boolean
-    description: Full sinc coefficient image did not fit within measurement image
-    fits:tunit:
-  - name: apFlux_12_0_instFlux
-    datatype: double
-    description: Flux within 12.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_12_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_17_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_17_0_instFlux
-    datatype: double
-    description: Flux within 17.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_17_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_35_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_35_0_instFlux
-    datatype: double
-    description: Flux within 35.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_35_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: apFlux_50_0_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: apFlux_50_0_instFlux
-    datatype: double
-    description: Flux within 50.0-pixel aperture
-    fits:tunit: count
-  - name: apFlux_50_0_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: normCompTophatFlux_flag
-    datatype: boolean
-    description: General failure flag for normCompTophatFlux.
-    fits:tunit:
-  - name: normCompTophatFlux_instFlux
-    datatype: double
-    description: Normalized compensated tophat flux for calibration
-    fits:tunit: count
-  - name: normCompTophatFlux_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty on normCompTophatFlux_instFlux
-    fits:tunit: count
-  - name: extendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure.
-    fits:tunit:
-  - name: sizeExtendedness_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure.
-    fits:tunit:
-  - name: footprintArea_value
-    datatype: int
-    description: Number of pixels in the sources detection footprint.
-    fits:tunit: pixel
-  - name: jacobian_flag
-    datatype: boolean
-    description: Set to 1 for any fatal failure
-    fits:tunit:
-  - name: jacobian_value
-    datatype: double
-    description: Jacobian correction
-    fits:tunit:
-  - name: localBackground_instFlux
-    datatype: double
-    description: Background in annulus around source
-    fits:tunit: count
-  - name: localBackground_instFluxErr
-    datatype: double
-    description: 1-sigma flux uncertainty
-    fits:tunit: count
-  - name: localBackground_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: localBackground_flag_noGoodPixels
-    datatype: boolean
-    description: No good pixels in the annulus
-    fits:tunit:
-  - name: localBackground_flag_noPsf
-    datatype: boolean
-    description: No PSF provided
-    fits:tunit:
-  - name: pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center
-    fits:tunit:
-  - name: pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE)
-    fits:tunit:
-  - name: pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA)
-    fits:tunit:
-  - name: pixelFlags_offimage
-    datatype: boolean
-    description: Source center is off image
-    fits:tunit:
-  - name: pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels
-    fits:tunit:
-  - name: pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels
-    fits:tunit:
-  # - name: pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint.
-  #   fits:tunit:
-  # - name: pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center.
-  #   fits:tunit:
-  - name: invalidPsfFlag
-    datatype: boolean
-    description: Source has an invalid psf.
-    fits:tunit:
-  - name: psfFlux_apCorr
-    datatype: double
-    description: Aperture correction applied to base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_apCorrErr
-    datatype: double
-    description: Standard deviation of aperture correction applied to base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_area
-    datatype: float
-    description: Effective area of PSF
-    fits:tunit: pixel
-  - name: psfFlux_flag
-    datatype: boolean
-    description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    fits:tunit:
-  - name: psfFlux_flag_apCorr
-    datatype: boolean
-    description: Set if unable to aperture correct base_PsfFlux
-    fits:tunit:
-  - name: psfFlux_flag_edge
-    datatype: boolean
-    description: Object was too close to the edge of the image to use the full PSF model
-    fits:tunit:
-  - name: psfFlux_flag_noGoodPixels
-    datatype: boolean
-    description: Not enough non-rejected pixels in data to attempt the fit
-    fits:tunit:
-  - name: gaussianFlux_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: centroid_flag
-    datatype: boolean
-    description: General Failure Flag
-    fits:tunit:
-  - name: centroid_flag_almostNoSecondDerivative
-    datatype: boolean
-    description: Almost vanishing second derivative
-    fits:tunit:
-  - name: centroid_flag_badError
-    datatype: boolean
-    description: Error on x and/or y position is NaN
-    fits:tunit:
-  - name: centroid_flag_edge
-    datatype: boolean
-    description: Object too close to edge
-    fits:tunit:
-  - name: centroid_flag_noSecondDerivative
-    datatype: boolean
-    description: Vanishing second derivative
-    fits:tunit:
-  - name: centroid_flag_notAtMaximum
-    datatype: boolean
-    description: Object is not at a maximum
-    fits:tunit:
-  - name: centroid_flag_resetToPeak
-    datatype: boolean
-    description: Set if CentroidChecker reset the centroid
-    fits:tunit:
-  - name: variance_flag
-    datatype: boolean
-    description: Set for any fatal failure
-    fits:tunit:
-  - name: variance_flag_emptyFootprint
-    datatype: boolean
-    description: Set to True when the footprint has no usable pixels
-    fits:tunit:
-  - name: variance_value
-    datatype: double
-    description: Variance at object position
-    fits:tunit:
-  - name: calib_astrometry_used
-    datatype: boolean
-    description: Set if source was used in astrometric calibration
-    fits:tunit:
-  - name: calib_photometry_reserved
-    datatype: boolean
-    description: Set if source was reserved from photometric calibration
-    fits:tunit:
-  - name: calib_photometry_used
-    datatype: boolean
-    description: Set if source was used in photometric calibration
-    fits:tunit:
-  - name: calib_psf_candidate
-    datatype: boolean
-    description: Flag set if the source was a candidate for PSF determination, as determined by the star selector.
-    fits:tunit:
-  - name: calib_psf_reserved
-    datatype: boolean
-    description: Set if source was reserved from PSF determination
-    fits:tunit:
-  - name: calib_psf_used
-    datatype: boolean
-    description: Flag set if the source was actually used for PSF determination, as determined by the
-    fits:tunit:
-  - name: deblend_deblendedAsPsf
-    datatype: boolean
-    description: Deblender thought this source looked like a PSF
-    fits:tunit:
-  - name: deblend_hasStrayFlux
-    datatype: boolean
-    description: This source was assigned some stray flux
-    fits:tunit:
-  - name: deblend_masked
-    datatype: boolean
-    description: Parent footprint was predominantly masked
-    fits:tunit:
-  - name: deblend_nChild
-    datatype: int
-    description: Number of children this object has (defaults to 0)
-    fits:tunit:
-  - name: deblend_parentTooBig
-    datatype: boolean
-    description: Parent footprint covered too many pixels
-    fits:tunit:
-  - name: deblend_patchedTemplate
-    datatype: boolean
-    description: This source was near an image edge and the deblender used patched edge-handling.
-    fits:tunit:
-  - name: deblend_rampedTemplate
-    datatype: boolean
-    description: This source was near an image edge and the deblender used ramp edge-handling.
-    fits:tunit:
-  - name: deblend_skipped
-    datatype: boolean
-    description: Deblender skipped this source
-    fits:tunit:
-  - name: deblend_tooManyPeaks
-    datatype: boolean
-    description: Source had too many peaks; only the brightest were included
-    fits:tunit:
-  - name: hsmPsfMoments_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: hsmPsfMoments_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: hsmPsfMoments_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: hsmPsfMoments_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: iDebiasedPSF_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: iDebiasedPSF_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: iDebiasedPSF_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: iDebiasedPSF_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: iDebiasedPSF_flag_galsim
-    datatype: boolean
-    description: GalSim failure
-    fits:tunit:
-  - name: iDebiasedPSF_flag_edge
-    datatype: boolean
-    description: Variance undefined outside image edge
-    fits:tunit:
-  - name: hsmShapeRegauss_flag
-    datatype: boolean
-    description: General failure flag, set if anything went wrong
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_galsim
-    datatype: boolean
-    description: GalSim failure
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_no_pixels
-    datatype: boolean
-    description: No pixels to measure
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_not_contained
-    datatype: boolean
-    description: Center not contained in footprint bounding box
-    fits:tunit:
-  - name: hsmShapeRegauss_flag_parent_source
-    datatype: boolean
-    description: Parent source, ignored
-    fits:tunit:
-  - name: sky_source
-    datatype: boolean
-    description: Sky objects.
-    fits:tunit:
   - name: detect_isPrimary
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the exposure where this source was measured. Abstract filter that is not associated with a particular instrument
-    fits:tunit:
-  - name: physical_filter
-    datatype: char
-    description: ID of physical filter, the filter associated with a particular instrument.
-    length: 9
     fits:tunit:
 - name: ForcedSource
   description: The forced source table contains forced-photometry source
      measurement on an individual Exposure based on a Multifit shape model
      derived from a deep detection.
+  columnRefs:
+    base:
+      ForcedSource:
+        objectId:
+        parentObjectId:
+        visit:
+        detector:
+        coord_ra:
+        coord_dec:
+        tract:
+        patch:
+        band:
+        pixelFlags_bad:
+        pixelFlags_crCenter:
+        pixelFlags_cr:
+        pixelFlags_edge:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_interpolated:
+        pixelFlags_nodata:
+        pixelFlags_saturatedCenter:
+        pixelFlags_saturated:
+        pixelFlags_suspectCenter:
+        pixelFlags_suspect:
+        invalidPsfFlag:
+        psfDiffFluxErr:
+        psfDiffFlux_flag:
+        psfDiffFlux:
+        psfFluxErr:
+        psfFlux_flag:
+        diff_PixelFlags_nodataCenter:
+        psfFlux:
   columns:
-  - name: objectId
-    datatype: long
-    description: Unique Object ID. Primary Key of the Object Table
-    fits:tunit:
-  - name: parentObjectId
-    datatype: long
-    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
-    fits:tunit:
-  - name: visit
-    datatype: long
-    nullable: false
-    description: Id of the visit where this source was measured.
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    datatype: short
-    nullable: false
-    description: Id of the detector where this source was measured.
-      Datatype short instead of byte because of DB concerns about unsigned bytes.
-    ivoa:ucd: meta.id;obs.image
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: tract
-    datatype: long
-    description: Skymap tract ID
-    fits:tunit:
-  - name: patch
-    datatype: long
-    description: Skymap patch ID
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Abstract filter that is not associated with a particular instrument
-    fits:tunit:
   - name: detect_isPatchInner
     datatype: boolean
     description: True if Object seed is in the inner region of a coadd patch
@@ -5679,997 +1481,208 @@ tables:
     datatype: boolean
     description: True if Object seed is in the inner region of a coadd tract
     fits:tunit:
-  - name: pixelFlags_bad
-    datatype: boolean
-    description: Bad pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_crCenter
-    datatype: boolean
-    description: Cosmic ray in the Source center
-    fits:tunit:
-  - name: pixelFlags_cr
-    datatype: boolean
-    description: Cosmic ray in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_edge
-    datatype: boolean
-    description: Source is on the edge of an exposure region (masked EDGE)
-    fits:tunit:
-  - name: pixelFlags_interpolatedCenter
-    datatype: boolean
-    description: Interpolated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_interpolated
-    datatype: boolean
-    description: Interpolated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_nodata
-    datatype: boolean
-    description: Source is outside usable exposure region (masked NO_DATA)
-    fits:tunit:
-  - name: pixelFlags_saturatedCenter
-    datatype: boolean
-    description: Saturated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_saturated
-    datatype: boolean
-    description: Saturated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_suspectCenter
-    datatype: boolean
-    description: Sources center is close to suspect pixels
-    fits:tunit:
-  - name: pixelFlags_suspect
-    datatype: boolean
-    description: Sources footprint includes suspect pixels
-    fits:tunit:
-  # - name: pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint.
-  #   fits:tunit:
-  # - name: pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center.
-  #   fits:tunit:
-  - name: invalidPsfFlag
-    datatype: boolean
-    description: Source has an invalid PSF.
-    fits:tunit:
-  - name: psfDiffFluxErr
-    datatype: float
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
-    fits:tunit: nJy
-  - name: psfDiffFlux_flag
-    datatype: boolean
-    description: Failure to derive linear least-squares fit of psf model forced on the image difference
-    fits:tunit:
-  - name: psfDiffFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of psf model forced on the image difference
-    fits:tunit: nJy
-  - name: psfFluxErr
-    datatype: float
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: psfFlux_flag
-    datatype: boolean
-    description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    fits:tunit:
-  - name: diff_PixelFlags_nodataCenter
-    datatype: boolean
-    description: Source center is outside usable region on image difference (masked NO_DATA)
-    fits:tunit:
-  - name: psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
 - name: DiaObject
   description: The DiaObject table contains descriptions of the astronomical objects
     detected on one or more difference images.
-  columns:
-  - name: diaObjectId
-    datatype: long
-    nullable: false
-    description: Unique identifier of this DiaObject.
-    ivoa:ucd: meta.id;src
-  - name: ra
-    datatype: double
-    nullable: false
-    description: Right ascension coordinate of the position of the object.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: dec
-    datatype: double
-    nullable: false
-    description: Declination coordinate of the position of the object.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: u_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for u filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: u_psfFluxMeanErr
-    datatype: double
-    description: Standard error of u_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: u_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of u_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: u_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of u-band data points.
-  - name: g_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for g filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: g_psfFluxMeanErr
-    datatype: double
-    description: Standard error of g_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: g_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of g_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: g_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of g-band data points.
-  - name: r_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for r filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: r_psfFluxMeanErr
-    datatype: double
-    description: Standard error of r_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: r_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of r_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: r_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of r-band data points.
-  - name: i_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for i filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: i_psfFluxMeanErr
-    datatype: double
-    description: Standard error of i_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: i_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of i_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: i_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of i-band data points.
-  - name: z_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for z filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: z_psfFluxMeanErr
-    datatype: double
-    description: Standard error of z_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: z_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of z_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: z_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of z-band data points.
-  - name: y_psfFluxMean
-    datatype: double
-    description: Weighted mean point-source model magnitude for y filter.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: y_psfFluxMeanErr
-    datatype: double
-    description: Standard error of y_psfFluxMean.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: y_psfFluxSigma
-    datatype: double
-    description: Standard deviation of the distribution of y_psfFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.stdev
-  - name: y_psfFluxNdata
-    datatype: int
-    nullable: false
-    description: The number of y-band data points.
-  - name: u_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for u filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: u_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of u_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: g_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for g filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: g_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of g_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: r_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for r filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: r_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of r_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: i_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for i filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: i_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of i_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: z_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for z filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: z_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of z_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: y_scienceFluxMean
-    datatype: double
-    description: Weighted mean forced photometry flux for y filter.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: y_scienceFluxMeanErr
-    datatype: double
-    description: Standard error of y_scienceFluxMean.
-    ivoa:ucd: stat.error
-    fits:tunit: nJy
-  - name: u_psfFluxMin
-    datatype: double
-    description: Minimum observed u band fluxes.
-    fits:tunit: nJy
-  - name: u_psfFluxMax
-    datatype: double
-    description: Maximum observed u band fluxes.
-    fits:tunit: nJy
-  - name: u_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between u band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: u_psfFluxErrMean
-    datatype: float
-    description: Mean of the u band flux errors.
-    fits:tunit: nJy
-  - name: g_psfFluxMin
-    datatype: double
-    description: Minimum observed g band fluxes.
-    fits:tunit: nJy
-  - name: g_psfFluxMax
-    datatype: double
-    description: Maximum observed g band fluxes.
-    fits:tunit: nJy
-  - name: g_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between g band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: g_psfFluxErrMean
-    datatype: float
-    description: Mean of the g band flux errors.
-    fits:tunit: nJy
-  - name: r_psfFluxMin
-    datatype: double
-    description: Minimum observed r band fluxes.
-    fits:tunit: nJy
-  - name: r_psfFluxMax
-    datatype: double
-    description: Maximum observed r band fluxes.
-    fits:tunit: nJy
-  - name: r_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between r band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: r_psfFluxErrMean
-    datatype: float
-    description: Mean of the r band flux errors.
-    fits:tunit: nJy
-  - name: i_psfFluxMin
-    datatype: double
-    description: Minimum observed i band fluxes.
-    fits:tunit: nJy
-  - name: i_psfFluxMax
-    datatype: double
-    description: Maximum observed i band fluxes.
-    fits:tunit: nJy
-  - name: i_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between i band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: i_psfFluxErrMean
-    datatype: float
-    description: Mean of the i band flux errors.
-    fits:tunit: nJy
-  - name: z_psfFluxMin
-    datatype: double
-    description: Minimum observed z band fluxes.
-    fits:tunit: nJy
-  - name: z_psfFluxMax
-    datatype: double
-    description: Maximum observed z band fluxes.
-    fits:tunit: nJy
-  - name: z_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between z band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: z_psfFluxErrMean
-    datatype: float
-    description: Mean of the z band flux errors.
-    fits:tunit: nJy
-  - name: y_psfFluxMin
-    datatype: double
-    description: Minimum observed y band fluxes.
-    fits:tunit: nJy
-  - name: y_psfFluxMax
-    datatype: double
-    description: Maximum observed y band fluxes.
-    fits:tunit: nJy
-  - name: y_psfFluxMaxSlope
-    datatype: double
-    description: Maximum slope between y band flux obsevations max(delta_flux/delta_time).
-    fits:tunit: nJy/d
-  - name: y_psfFluxErrMean
-    datatype: float
-    description: Mean of the y band flux errors.
-    fits:tunit: nJy
-  - name: nDiaSources
-    datatype: long
-    nullable: false
-    description: Total number of DiaSources associated with this DiaObject.
+  columnRefs:
+    base:
+      DiaObject:
+        diaObjectId:
+        ra:
+        dec:
+        u_psfFluxMean:
+        u_psfFluxMeanErr:
+        u_psfFluxSigma:
+        u_psfFluxNdata:
+        g_psfFluxMean:
+        g_psfFluxMeanErr:
+        g_psfFluxSigma:
+        g_psfFluxNdata:
+        r_psfFluxMean:
+        r_psfFluxMeanErr:
+        r_psfFluxSigma:
+        r_psfFluxNdata:
+        i_psfFluxMean:
+        i_psfFluxMeanErr:
+        i_psfFluxSigma:
+        i_psfFluxNdata:
+        z_psfFluxMean:
+        z_psfFluxMeanErr:
+        z_psfFluxSigma:
+        z_psfFluxNdata:
+        y_psfFluxMean:
+        y_psfFluxMeanErr:
+        y_psfFluxSigma:
+        y_psfFluxNdata:
+        u_scienceFluxMean:
+        u_scienceFluxMeanErr:
+        g_scienceFluxMean:
+        g_scienceFluxMeanErr:
+        r_scienceFluxMean:
+        r_scienceFluxMeanErr:
+        i_scienceFluxMean:
+        i_scienceFluxMeanErr:
+        z_scienceFluxMean:
+        z_scienceFluxMeanErr:
+        y_scienceFluxMean:
+        y_scienceFluxMeanErr:
+        u_psfFluxMin:
+        u_psfFluxMax:
+        u_psfFluxMaxSlope:
+        u_psfFluxErrMean:
+        g_psfFluxMin:
+        g_psfFluxMax:
+        g_psfFluxMaxSlope:
+        g_psfFluxErrMean:
+        r_psfFluxMin:
+        r_psfFluxMax:
+        r_psfFluxMaxSlope:
+        r_psfFluxErrMean:
+        i_psfFluxMin:
+        i_psfFluxMax:
+        i_psfFluxMaxSlope:
+        i_psfFluxErrMean:
+        z_psfFluxMin:
+        z_psfFluxMax:
+        z_psfFluxMaxSlope:
+        z_psfFluxErrMean:
+        y_psfFluxMin:
+        y_psfFluxMax:
+        y_psfFluxMaxSlope:
+        y_psfFluxErrMean:
+        nDiaSources:
 - name: DiaSource
-  description: Table to store 'difference image sources'; - sources detected at
-    SNR >=5 on difference images.
-  columns:
-  - name: diaSourceId
-    datatype: long
-    nullable: false
-    autoincrement: false
-    description: Unique identifier of this DiaSource.
-    ivoa:ucd: meta.id;obs.image
-  - name: visit
-    datatype: long
-    nullable: false
-    description: Id of the visit where this diaSource was measured.
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    datatype: short
-    nullable: false
-    description: Id of the detector where this diaSource was measured.
-      Datatype short instead of byte because of DB concerns about unsigned bytes.
-    ivoa:ucd: meta.id;obs.image
-  - name: diaObjectId
-    datatype: long
-    nullable: false
-    description: Id of the diaObject this source was associated with, if any. If not,
-      it is set to 0.
-    ivoa:ucd: meta.id;src
-  - name: ssObjectId
-    datatype: long
-    nullable: false
-    description: Id of the ssObject this source was associated with, if any. If not,
-      it is set to 0.
-    ivoa:ucd: meta.id;src
-  - name: parentDiaSourceId
-    datatype: long
-    nullable: false
-    description: Id of the parent diaSource this diaSource has been deblended from,
-      if any.
-    ivoa:ucd: meta.id;src
-  - name: midpointMjdTai
-    datatype: double
-    nullable: false
-    description: Effective mid-visit time for this diaSource, expressed as Modified
-      Julian Date, International Atomic Time.
-    fits:tunit: d
-    ivoa:ucd: time.epoch
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: ra
-    datatype: double
-    nullable: false
-    description: Right ascension coordinate of the center of this diaSource.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: dec
-    datatype: double
-    nullable: false
-    description: Declination coordinate of the center of this diaSource.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: raErr
-    datatype: float
-    description: Error in right ascension.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: decErr
-    datatype: float
-    description: Error in declination.
-    fits:tunit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: ra_dec_Cov
-    datatype: float
-    description: Covariance between right ascension and declination.
-    fits:tunit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: x
-    datatype: double
-    nullable: false
-    description: x position computed by a centroiding algorithm.
-    fits:tunit: pixel
-    ivoa:ucd: pos.cartesian.x
-  - name: xErr
-    datatype: float
-    description: Uncertainty of x.
-    fits:tunit: pixel
-    ivoa:ucd: stat.error;pos.cartesian.x
-  - name: y
-    datatype: double
-    nullable: false
-    description: y position computed by a centroiding algorithm.
-    fits:tunit: pixel
-    ivoa:ucd: pos.cartesian.y
-  - name: yErr
-    datatype: float
-    description: Uncertainty of y.
-    fits:tunit: pixel
-    ivoa:ucd: stat.error;pos.cartesian.y
-  - name: centroid_flag
-    datatype: boolean
-    nullable: false
-    description: General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information.
-    fits:tunit:
-  - name: apFlux
-    datatype: float
-    description: Flux in a 12 pixel radius aperture on the difference image.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: apFluxErr
-    datatype: float
-    description: Estimated uncertainty of apFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error;phot.count
-  - name: apFlux_flag
-    datatype: boolean
-    nullable: false
-    description: General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information.
-    fits:tunit:
-  - name: apFlux_flag_apertureTruncated
-    datatype: boolean
-    nullable: false
-    description: Aperture did not fit within measurement image.
-    fits:tunit:
-  - name: isNegative
-    datatype: boolean
-    nullable: false
-    description: Source was detected as significantly negative.
-    fits:tunit:
-  - name: snr
-    datatype: double
-    description: The signal-to-noise ratio at which this source was detected in the
-      difference image.
-    ivoa:ucd: stat.snr
-  - name: psfFlux
-    datatype: float
-    description: Flux for Point Source model. Note this actually measures
-      the flux difference between the template and the visit image.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: psfFluxErr
-    datatype: float
-    description: Uncertainty of psfFlux.
-    fits:tunit: nJy
-  - name: psfChi2
-    datatype: float
-    description: Chi^2 statistic of the point source model fit.
-    ivoa:ucd: stat.fit.chi2
-  - name: psfNdata
-    datatype: int
-    nullable: false
-    description: The number of data points (pixels) used to fit the point source model.
-  - name: psfFlux_flag
-    datatype: boolean
-    nullable: false
-    description: Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information.
-    fits:tunit:
-  - name: psfFlux_flag_edge
-    datatype: boolean
-    nullable: false
-    description: Object was too close to the edge of the image to use the full PSF model.
-    fits:tunit:
-  - name: psfFlux_flag_noGoodPixels
-    datatype: boolean
-    nullable: false
-    description: Not enough non-rejected pixels in data to attempt the fit.
-    fits:tunit:
-  - name: trailFlux
-    datatype: float
-    description: Flux for a trailed source model. Note this actually measures
-      the flux difference between the template and the visit image.
-    fits:tunit: nJy
-  - name: trailFluxErr
-    datatype: float
-    description: Uncertainty of trailFlux.
-    fits:tunit: nJy
-  - name: trailRa
-    datatype: double
-    description: Right ascension coordinate of centroid for trailed source model.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: trailDec
-    datatype: double
-    description: Declination coordinate of centroid for trailed source model.
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: trailLength
-    datatype: double
-    description: Maximum likelihood fit of trail length.
-    fits:tunit: arcsec
-  - name: trailAngle
-    datatype: double
-    description: Maximum likelihood fit of the angle between the meridian through
-      the centroid and the trail direction (bearing).
-    fits:tunit: deg
-  - name: trail_flag_edge
-    datatype: boolean
-    nullable: false
-    description: This flag is set if a trailed source extends onto or past edge pixels.
-    fits:tunit:
-  - name: dipoleMeanFlux
-    datatype: double
-    description: Maximum likelihood value for the mean absolute flux of the two lobes
-      for a dipole model.
-    fits:tunit: nJy
-  - name: dipoleMeanFluxErr
-    datatype: double
-    description: Uncertainty of dipoleMeanFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: dipoleFluxDiff
-    datatype: double
-    description: Maximum likelihood value for the difference of absolute fluxes of
-      the two lobes for a dipole model.
-    fits:tunit: nJy
-  - name: dipoleFluxDiffErr
-    datatype: double
-    description: Uncertainty of dipoleFluxDiff.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error
-  - name: dipoleLength
-    datatype: double
-    description: Maximum likelihood value for the lobe separation in dipole model.
-    fits:tunit: arcsec
-    ivoa:ucd: pos.angDistance
-  - name: dipoleAngle
-    datatype: double
-    description: Maximum likelihood fit of the angle between the meridian through
-      the centroid and the dipole direction (bearing, from negative to positive lobe).
-    fits:tunit: deg
-    ivoa:ucd: pos.posAng
-  - name: dipoleChi2
-    datatype: double
-    description: Chi^2 statistic of the model fit.
-    ivoa:ucd: stat.fit.chi2
-  - name: dipoleNdata
-    datatype: long
-    nullable: false
-    description: The number of data points (pixels) used to fit the model.
-  - name: scienceFlux
-    datatype: float
-    description: Forced photometry flux for a point source model measured on the visit image
-      centered at DiaSource position.
-    fits:tunit: nJy
-    ivoa:ucd: phot.count
-  - name: scienceFluxErr
-    datatype: float
-    description: Estimated uncertainty of scienceFlux.
-    fits:tunit: nJy
-    ivoa:ucd: stat.error;phot.count
-  - name: forced_PsfFlux_flag
-    datatype: boolean
-    nullable: false
-    description: Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.
-    fits:tunit:
-  - name: forced_PsfFlux_flag_edge
-    datatype: boolean
-    nullable: false
-    description: Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.
-    fits:tunit:
-  - name: forced_PsfFlux_flag_noGoodPixels
-    datatype: boolean
-    nullable: false
-    description: Forced PSF flux not enough non-rejected pixels in data to attempt the fit.
-    fits:tunit:
-  - name: templateFlux
-    datatype: float
-    description: Forced photometry flux for a point source model measured on the template image
-      centered at the DiaSource position.
-    ivoa:ucd: phot.count
-    fits:tunit: nJy
-  - name: templateFluxErr
-    datatype: float
-    description: Uncertainty of templateFlux.
-    ivoa:ucd: stat.error;phot.count
-    fits:tunit: nJy
-  - name: ixx
-    datatype: double
-    description: Adaptive second moment of the source intensity.
-    fits:tunit: nJy.arcsec**2
-  - name: iyy
-    datatype: double
-    description: Adaptive second moment of the source intensity.
-    fits:tunit: nJy.arcsec**2
-  - name: ixy
-    datatype: double
-    description: Adaptive second moment of the source intensity.
-    fits:tunit: nJy.arcsec**2
-  - name: ixxPSF
-    datatype: double
-    description: Adaptive second moment for the PSF.
-    fits:tunit: nJy.arcsec**2
-  - name: iyyPSF
-    datatype: double
-    description: Adaptive second moment for the PSF.
-    fits:tunit: nJy.arcsec**2
-  - name: ixyPSF
-    datatype: double
-    description: Adaptive second moment for the PSF.
-    fits:tunit: nJy.arcsec**2
-  - name: shape_flag
-    datatype: boolean
-    nullable: false
-    description: General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information.
-    fits:tunit:
-  - name: shape_flag_no_pixels
-    datatype: boolean
-    nullable: false
-    description: No pixels to measure shape.
-    fits:tunit:
-  - name: shape_flag_not_contained
-    datatype: boolean
-    nullable: false
-    description: Center not contained in footprint bounding box.
-    fits:tunit:
-  - name: shape_flag_parent_source
-    datatype: boolean
-    nullable: false
-    description: This source is a parent source; we should only be measuring on deblended children in difference imaging.
-    fits:tunit:
-  - name: extendedness
-    datatype: double
-    description: A measure of extendedness, computed by comparing an object's moment-based traced radius to
-      the PSF moments. extendedness = 1 implies a high degree of confidence
-      that the source is extended. extendedness = 0 implies a high degree of confidence
-      that the source is point-like.
-  - name: reliability
-    datatype: float
-    description: Probability (0-1) that the diaSource is astrophysical,
-       derived from a machine learning model.
-  - name: band
-    datatype: char
-    length: 1
-    description: Filter band this source was observed with.
-  - name: isDipole
-    datatype: boolean
-    nullable: false
-    description: Source well fit by a dipole.
-  - name: dipoleFitAttempted
-    datatype: boolean
-    nullable: false
-    description: Attempted to fit a dipole model to this source.
-  - name: timeProcessedMjdTai
-    datatype: double
-    nullable: false
-    description: Time when the image was processed and this DiaSource record was generated,
-      expressed as Modified Julian Date, International Atomic Time.
-    ivoa:ucd: time.epoch
-  - name: bboxSize
-    datatype: long
-    nullable: false
-    description: Size of the square bounding box that fully contains the detection footprint.
-    fits:tunit: pixel
-  - name: pixelFlags
-    datatype: boolean
-    nullable: false
-    description: General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.
-    fits:tunit:
-  - name: pixelFlags_bad
-    datatype: boolean
-    nullable: false
-    description: Bad pixel in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_cr
-    datatype: boolean
-    nullable: false
-    description: Cosmic ray in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_crCenter
-    datatype: boolean
-    nullable: false
-    description: Cosmic ray in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_edge
-    datatype: boolean
-    nullable: false
-    description: Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).
-    fits:tunit:
-  - name: pixelFlags_nodata
-    datatype: boolean
-    nullable: false
-    description: NO_DATA pixel in the source footprint.
-    fits:tunit:
-  - name: pixelFlags_nodataCenter
-    datatype: boolean
-    nullable: false
-    description: NO_DATA pixel in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_interpolated
-    datatype: boolean
-    nullable: false
-    description: Interpolated pixel in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_interpolatedCenter
-    datatype: boolean
-    nullable: false
-    description: Interpolated pixel in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_offimage
-    datatype: boolean
-    nullable: false
-    description: DiaSource center is off image.
-    fits:tunit:
-  - name: pixelFlags_saturated
-    datatype: boolean
-    nullable: false
-    description: Saturated pixel in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_saturatedCenter
-    datatype: boolean
-    nullable: false
-    description: Saturated pixel in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_suspect
-    datatype: boolean
-    nullable: false
-    description: DiaSource's footprint includes suspect pixels.
-    fits:tunit:
-  - name: pixelFlags_suspectCenter
-    datatype: boolean
-    nullable: false
-    description: Suspect pixel in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_streak
-    datatype: boolean
-    nullable: false
-    description: Streak in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_streakCenter
-    datatype: boolean
-    nullable: false
-    description: Streak in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_injected
-    datatype: boolean
-    nullable: false
-    description: Injection in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_injectedCenter
-    datatype: boolean
-    nullable: false
-    description: Injection in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: pixelFlags_injected_template
-    datatype: boolean
-    nullable: false
-    description: Template injection in the DiaSource footprint.
-    fits:tunit:
-  - name: pixelFlags_injected_templateCenter
-    datatype: boolean
-    nullable: false
-    description: Template injection in the 3x3 region around the centroid.
-    fits:tunit:
-  - name: glint_trail
-    datatype: boolean
-    nullable: false
-    description: This flag is set if the source is part of a glint trail.
-    fits:tunit:
+  description: |
+    Table to store 'difference image sources', sources detected at SNR >=5 on
+    difference images.
+  columnRefs:
+    base:
+      DiaSource:
+        diaSourceId:
+        visit:
+        detector:
+        diaObjectId:
+        ssObjectId:
+        parentDiaSourceId:
+        midpointMjdTai:
+        coord_dec:
+        coord_ra:
+        ra:
+        dec:
+        raErr:
+        decErr:
+        ra_dec_Cov:
+        x:
+        xErr:
+        y:
+        yErr:
+        centroid_flag:
+        apFlux:
+        apFluxErr:
+        apFlux_flag:
+        apFlux_flag_apertureTruncated:
+        isNegative:
+        snr:
+        psfFlux:
+        psfFluxErr:
+        psfChi2:
+        psfNdata:
+        psfFlux_flag:
+        psfFlux_flag_edge:
+        psfFlux_flag_noGoodPixels:
+        trailFlux:
+        trailFluxErr:
+        trailRa:
+        trailDec:
+        trailLength:
+        trailAngle:
+        trail_flag_edge:
+        dipoleMeanFlux:
+        dipoleMeanFluxErr:
+        dipoleFluxDiff:
+        dipoleFluxDiffErr:
+        dipoleLength:
+        dipoleAngle:
+        dipoleChi2:
+        dipoleNdata:
+        scienceFlux:
+        scienceFluxErr:
+        forced_PsfFlux_flag:
+        forced_PsfFlux_flag_edge:
+        forced_PsfFlux_flag_noGoodPixels:
+        templateFlux:
+        templateFluxErr:
+        ixx:
+        iyy:
+        ixy:
+        ixxPSF:
+        iyyPSF:
+        ixyPSF:
+        shape_flag:
+        shape_flag_no_pixels:
+        shape_flag_not_contained:
+        shape_flag_parent_source:
+        extendedness:
+        reliability:
+        band:
+        isDipole:
+        dipoleFitAttempted:
+        timeProcessedMjdTai:
+        bboxSize:
+        pixelFlags:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_nodata:
+        pixelFlags_nodataCenter:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_offimage:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        pixelFlags_streak:
+        pixelFlags_streakCenter:
+        pixelFlags_injected:
+        pixelFlags_injectedCenter:
+        pixelFlags_injected_template:
+        pixelFlags_injected_templateCenter:
+        glint_trail:
 - name: ForcedSourceOnDiaObject
-  description: this is dia_object_forced_source in the butler repo
-  columns:
-  - name: band
-    datatype: char
-    length: 1
-    description: Abstract filter that is not associated with a particular instrument
-    fits:tunit:
-  - name: visit
-    datatype: long
-    nullable: false
-    description: Id of the visit where this forced source was measured.
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    datatype: short
-    nullable: false
-    description: Id of the detector where this forced source was measured.
-      Datatype short instead of byte because of DB concerns about unsigned bytes.
-    ivoa:ucd: meta.id;obs.image
-  - name: coord_dec
-    datatype: double
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: coord_ra
-    datatype: double
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    fits:tunit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: diaObjectId
-    datatype: long
-    nullable: false
-    description: Id of the DiaObject that this DiaForcedSource was associated with.
-    fits:tunit:
-  - name: parentObjectId
-    datatype: long
-    nullable: false
-    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
-    fits:tunit:
-  - name: patch
-    datatype: long
-    nullable: false
-    description: Skymap patch ID
-    fits:tunit:
-  - name: pixelFlags_bad
-    datatype: boolean
-    nullable: false
-    description: Bad pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_cr
-    datatype: boolean
-    nullable: false
-    description: Cosmic ray in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_crCenter
-    datatype: boolean
-    nullable: false
-    description: Cosmic ray in the Source center
-    fits:tunit:
-  - name: pixelFlags_edge
-    datatype: boolean
-    nullable: false
-    description: Source is on the edge of an exposure region (masked EDGE)
-    fits:tunit:
-  - name: pixelFlags_interpolated
-    datatype: boolean
-    nullable: false
-    description: Interpolated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_interpolatedCenter
-    datatype: boolean
-    nullable: false
-    description: Interpolated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_nodata
-    datatype: boolean
-    nullable: false
-    description: Source is outside usable exposure region (masked NO_DATA)
-    fits:tunit:
-  - name: pixelFlags_saturated
-    datatype: boolean
-    nullable: false
-    description: Saturated pixel in the Source footprint
-    fits:tunit:
-  - name: pixelFlags_saturatedCenter
-    datatype: boolean
-    nullable: false
-    description: Saturated pixel in the Source center
-    fits:tunit:
-  - name: pixelFlags_suspect
-    datatype: boolean
-    nullable: false
-    description: Sources footprint includes suspect pixels
-    fits:tunit:
-  - name: pixelFlags_suspectCenter
-    datatype: boolean
-    nullable: false
-    description: Sources center is close to suspect pixels
-    fits:tunit:
-  # - name: pixelFlags_streak
-  #   datatype: boolean
-  #   description: Streak in the Source footprint.
-  #   fits:tunit:
-  # - name: pixelFlags_streakCenter
-  #   datatype: boolean
-  #   description: Streak in the Source center.
-  #   fits:tunit:
-  - name: invalidPsfFlag
-    datatype: boolean
-    nullable: false
-    description: Forced source has an invalid PSF.
-    fits:tunit:
-  - name: psfDiffFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of psf model forced on the image difference
-    fits:tunit: nJy
-  - name: psfDiffFluxErr
-    datatype: float
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the image difference
-    fits:tunit: nJy
-  - name: psfDiffFlux_flag
-    datatype: boolean
-    nullable: false
-    description: Failure to derive linear least-squares fit of psf model forced on the image difference
-    fits:tunit:
-  - name: diff_PixelFlags_nodataCenter
-    datatype: boolean
-    nullable: false
-    description: Source center is outside usable region on image difference (masked NO_DATA)
-    fits:tunit:
-  - name: psfFlux
-    datatype: float
-    description: Flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: psfFluxErr
-    datatype: float
-    description: Uncertainty on the flux derived from linear least-squares fit of psf model forced on the calexp
-    fits:tunit: nJy
-  - name: psfFlux_flag
-    datatype: boolean
-    nullable: false
-    description: Failure to derive linear least-squares fit of psf model forced on the calexp
-    fits:tunit:
-  - name: tract
-    datatype: long
-    nullable: false
-    description: Skymap tract ID
-    fits:tunit:
+  description: This is dia_object_forced_source in the Butler repo.
+  columnRefs:
+    base:
+      ForcedSourceOnDiaObject:
+        band:
+        visit:
+        detector:
+        coord_dec:
+        coord_ra:
+        diaObjectId:
+        parentObjectId:
+        patch:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        invalidPsfFlag:
+        psfDiffFlux:
+        psfDiffFluxErr:
+        psfDiffFlux_flag:
+        diff_PixelFlags_nodataCenter:
+        psfFlux:
+        psfFluxErr:
+        psfFlux_flag:
+        tract:
 - name: MatchesTruth
   description: Match information for truth_summary sources.
   columns:
@@ -6725,60 +1738,26 @@ tables:
     description: objectId of object
 - name: Visit
   description: Defines a single Visit.
+  columnRefs:
+    base:
+      Visit:
+        visit:
+        physical_filter:
+        band:
+        ra:
+        dec:
+        skyRotation:
+        azimuth:
+        altitude:
+        zenithDistance:
+        airmass:
+        expTime:
+        obsStart:
   columns:
-  - name: visit
-    datatype: long
-    description: Unique identifier.
-    ivoa:ucd: meta.id;obs.image
-  - name: physical_filter
-    datatype: char
-    length: 32
-    description: ID of physical filter, the filter associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: ra
-    datatype: double
-    description: Right Ascension of focal plane center.
-    fits:tunit: deg
-  - name: dec
-    datatype: double
-    description: Declination of focal plane center
-    fits:tunit: deg
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
     fits:tunit: deg
-  - name: skyRotation
-    datatype: double
-    description: Sky rotation angle.
-    fits:tunit: deg
-  - name: azimuth
-    datatype: double
-    description: Azimuth of focal plane center at the middle of the visit.
-    fits:tunit: deg
-  - name: altitude
-    datatype: double
-    description: Altitude of focal plane center at the middle of the visit.
-    fits:tunit: deg
-  - name: zenithDistance
-    datatype: double
-    description: Zenith distance at the middle of the visit.
-    fits:tunit: deg
-  - name: airmass
-    datatype: double
-    description: Airmass of the observed line of sight.
-    fits:tunit:
-  - name: expTime
-    datatype: double
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    fits:tunit: s
   - name: midpoint
     datatype: timestamp
     precision: 6
@@ -6790,11 +1769,6 @@ tables:
     description: Midpoint time for visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
     fits:tunit: d
-  - name: obsStart
-    datatype: timestamp
-    precision: 6
-    description: Start time of the visit at the fiducial center of the focal plane array,
-      TAI, accurate to 10ms.
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,
@@ -6803,70 +1777,82 @@ tables:
   primaryKey:
   - "#VisitDetector.visit"
   - "#VisitDetector.detector"
-  description: Defines a single detector of a visit
+  description: Defines a single detector of a visit.
+  columnRefs:
+    base:
+      VisitDetector:
+        detector:
+          overrides:
+            # This is still long in the base schema.
+            datatype: short
+        physical_filter:
+        band:
+        ra:
+        dec:
+        pixelScale:
+        zenithDistance:
+        zeroPoint:
+        psfSigma:
+        skyBg:
+        skyNoise:
+        seeing:
+        skyRotation:
+        expTime:
+        obsStart:
+        darkTime:
+        xSize:
+        ySize:
+        llcra:
+        llcdec:
+        ulcra:
+        ulcdec:
+        urcra:
+        urcdec:
+        lrcra:
+        lrcdec:
+        astromOffsetMean:
+        astromOffsetStd:
+        starComa1Median:
+        starComa2Median:
+        starTrefoil1Median:
+        starTrefoil2Median:
+        starKurtosisMedian:
+        starE41Median:
+        starE42Median:
+        nPsfStar:
+        psfStarDeltaE1Median:
+        psfStarDeltaE2Median:
+        psfStarDeltaE1Scatter:
+        psfStarDeltaE2Scatter:
+        psfStarDeltaSizeMedian:
+        psfStarDeltaSizeScatter:
+        psfStarScaledDeltaSizeScatter:
+        psfTraceRadiusDelta:
+        psfApFluxDelta:
+        psfApCorrSigmaScaledDelta:
+        maxDistToNearestPsf:
+        starEMedian:
+        starUnNormalizedEMedian:
+        wcsDetectorPointingResidual:
+        wcsVisitPointingResidual:
+        wcsPreliminaryDetectorPointingResidual:
+        wcsPreliminaryVisitPointingResidual:
+        shapeletsIqScore:
+        centroidDiffShapeletsVsSlotMedian:
+        shapeletsStarEMedian:
+        psfAdaptiveIncludeThresholdMultiplier:
+        shapeletsStarUnNormalizedEMedian:
+        refCatSourceDensity:
+        psfAdaptiveThresholdValue:
+        shapeletsOnlyIqScore:
+        nShapeletsStar:
   columns:
   - name: visit
     datatype: long
     description: Reference to the corresponding entry in the Visit table.
-  - name: detector
-    datatype: short
-    description: Detector ID. A detector associated with a particular instrument (not an observation of that detector).
-  - name: physical_filter
-    datatype: char
-    length: 32
-    description: ID of physical filter, the filter associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: band
-    datatype: char
-    length: 1
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    votable:arraysize: "*"
-    fits:tunit:
-  - name: ra
-    datatype: double
-    description: Right Ascension of Ccd center.
-    fits:tunit: deg
-  - name: dec
-    datatype: double
-    description: Declination of Ccd center.
-    fits:tunit: deg
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
-  - name: pixelScale
-    datatype: float
-    description: Measured detector pixel scale.
-    fits:tunit: arcsec/pixel
-  - name: zenithDistance
-    datatype: float
-    description: Zenith distance at observation mid-point.
-    fits:tunit: deg
-  - name: zeroPoint
-    datatype: float
-    description: Zero-point for the Ccd, estimated at Ccd center.
-    fits:tunit: mag
-  - name: psfSigma
-    datatype: float
-    description: PSF model second-moments determinant radius (center of chip)
-    fits:tunit: pixel
-  - name: skyBg
-    datatype: float
-    description: Average sky background.
-    fits:tunit: adu
-  - name: skyNoise
-    datatype: float
-    description: RMS noise of the sky background.
-    fits:tunit: adu
-  - name: seeing
-    datatype: double
-    description: Mean measured FWHM of the PSF.
-    fits:tunit: arcsec
-  - name: skyRotation
-    datatype: double
-    description: Sky rotation angle.
     fits:tunit: deg
   - name: midpoint
     datatype: timestamp
@@ -6877,301 +1863,32 @@ tables:
     description: Midpoint of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
     fits:tunit: d
-  - name: expTime
-    datatype: double
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    fits:tunit: s
-  - name: obsStart
-    datatype: timestamp
-    precision: 6
-    description: Start of the visit, TAI, accurate to 10ms.
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-  - name: darkTime
-    datatype: double
-    description: Average dark current accumulation time, accurate to 10ms.
-    fits:tunit: s
-  - name: xSize
-    datatype: long
-    description: Number of columns in the image.
-    fits:tunit: pixel
-  - name: ySize
-    datatype: long
-    description: Number of rows in the image.
-    fits:tunit: pixel
-  - name: llcra
-    datatype: double
-    description: Right Ascension of lower left corner.
-    fits:tunit: deg
-  - name: llcdec
-    datatype: double
-    description: Declination of lower left corner.
-    fits:tunit: deg
-  - name: ulcra
-    datatype: double
-    description: Right Ascension of upper left corner.
-    fits:tunit: deg
-  - name: ulcdec
-    datatype: double
-    description: Declination of upper left corner.
-    fits:tunit: deg
-  - name: urcra
-    datatype: double
-    description: Right Ascension of upper right corner.
-    fits:tunit: deg
-  - name: urcdec
-    datatype: double
-    description: Declination of upper right corner.
-    fits:tunit: deg
-  - name: lrcra
-    datatype: double
-    description: Right Ascension of lower right corner.
-    fits:tunit: deg
-  - name: lrcdec
-    datatype: double
-    description: Declination of lower right corner.
-    fits:tunit: deg
-  - name: psfAdaptiveThresholdValue
-    datatype: double
-    description: Threshold value used in the adaptive threshold detection pass for PSF modelling.
-  - name: psfAdaptiveIncludeThresholdMultiplier
-    datatype: double
-    description: Threshold multiplier used in the adaptive threshold detection pass for PSF modelling.
-  - name: nShapeletsStar
-    datatype: int
-    description: Number of sources used in the shapelet decomposition.
-  - name: shapeletsOnlyIqScore
-    datatype: double
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power only from the non-atmospheric decomposition coefficients. The
-      score spans the range [0.0, 1.0] with lower values indicating better image quality.
-  - name: shapeletsIqScore
-    datatype: double
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power from the median centroid offset between those used in the decomposition
-      and those of the centroid slot in addition to non-atmospheric decomposition coefficients.
-      The score spans the range [0.0, 1.0] with lower values indicating better image quality.
-  - name: centroidDiffShapeletsVsSlotMedian
-    datatype: double
-    description: Median centroid difference (sqrt((slot_x - shapelet_x)**2 + (slot_y - shapelet_y)**2))
-      for sources used in the shapelet decomposition.
-    fits:tunit: pixel
-  - name: shapeletsStarEMedian
-    datatype: double
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the sources used in the
-      shapelet decomposition.
-  - name: shapeletsStarUnNormalizedEMedian
-    datatype: double
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
-      of the sources used in the shapelet decomposition.
-    fits:tunit: pixel**2
-  - name: refCatSourceDensity
-    datatype: float
-    description: Source density for the detector region as computed from the loaded reference catalog
-      (number per degrees**2)
-    fits:tunit: count/deg**2
-  - name: astromOffsetMean
-    datatype: double
-    description: Mean offset of astrometric calibration matches (arcsec)
-    fits:tunit: arcsec
-  - name: astromOffsetStd
-    datatype: double
-    description: Standard deviation of offsets of astrometric calibration matches (arcsec)
-    fits:tunit: arcsec
-  - name: starComa1Median
-    description: Coma-like higher-order moment combination (median M30 + M12 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starComa2Median
-    description: Coma-like higher-order moment combination (median M21 + M03 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starTrefoil1Median
-    description: Trefoil-like higher-order moment combination (median M30 - 3*M12 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starTrefoil2Median
-    description: Trefoil-like higher-order moment combination (median 3*M21 - M03 of the stars used in
-      the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starKurtosisMedian
-    description: Kurtosis-like higher-order moment combination (median M40 + 2*M22 + M04 of the stars
-      used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starE41Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median M40 - M04
-      of the stars used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: starE42Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median 2*(M31 + M13)
-      of the stars used in the PSF model)
-    datatype: double
-    fits:tunit:
-  - name: nPsfStar
-    datatype: int
-    description: Number of stars used for PSF model
-    fits:tunit:
-  - name: psfStarDeltaE1Median
-    datatype: double
-    description: Median E1 residual (starE1 - psfE1) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE2Median
-    datatype: double
-    description: Median E2 residual (starE2 - psfE2) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE1Scatter
-    datatype: double
-    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaE2Scatter
-    datatype: double
-    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for psf stars
-    fits:tunit:
-  - name: psfStarDeltaSizeMedian
-    datatype: double
-    description: Median size residual (starSize - psfSize) for psf stars (pixel)
-    fits:tunit: pixel
-  - name: psfStarDeltaSizeScatter
-    datatype: double
-    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars (pixel)
-    fits:tunit: pixel
-  - name: psfStarScaledDeltaSizeScatter
-    datatype: double
-    description: Scatter (via MAD) of size residual scaled by median size squared
-    fits:tunit:
-  - name: psfTraceRadiusDelta
-    datatype: double
-    description: Delta (max - min) of model psf trace radius values evaluated on a grid of unmasked pixels (pixel)
-    fits:tunit: pixel
-  - name: psfApFluxDelta
-    datatype: double
-    description: Delta (max - min) of model psf aperture flux (with aperture radius of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels
-    fits:tunit:
-  - name: psfApCorrSigmaScaledDelta
-    datatype: double
-    description: Delta (max - min) of psf flux aperture correction factors scaled (divided) by the psfSigma evaluated on a grid of unmasked pixels
-    fits:tunit:
-  - name: maxDistToNearestPsf
-    datatype: double
-    description: Maximum distance of an unmasked pixel to its nearest model psf star (pixel)
-    fits:tunit: pixel
-  - name: starEMedian
-    datatype: double
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the stars used in the PSF model
-  - name: starUnNormalizedEMedian
-    datatype: double
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0)) of the stars used in the PSF model
-    fits:tunit: pixel**2
-  - name: wcsDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the prelimnary WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the preliminary WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-
 - name: Parent
-  description: "Descriptions of the parent objects in the deblending hierarchy."
+  description: Descriptions of the parent objects in the deblending hierarchy.
   tap:table_index: 130
   primaryKey: '#Parent.objectId'
-  columns:
-  - name: objectId
-    datatype: long
-    description: Unique id. Unique ObjectID
-    ivoa:ucd: meta.id;src
-  - name: parentObjectId
-    datatype: long
-    description: Unique ID of parent source. Reference band.
-    fits:tunit:
-  - name: merge_peak_sky
-    datatype: boolean
-    description: Peak detected in filter sky
-    fits:tunit:
-  - name: deblend_nChild
-    datatype: int
-    description: Number of children this object has (defaults to 0)
-    fits:tunit:
-  - name: deblend_nPeaks
-    datatype: int
-    description: Number of peaks this parent footprint has (even if the deblender failed or skipped this blend)
-    fits:tunit:
-  - name: deblend_failed
-    datatype: boolean
-    description: Deblender failed to deblend this source
-    fits:tunit:
-  - name: deblend_skipped
-    datatype: boolean
-    description: Deblender skipped this source
-    fits:tunit:
-  - name: deblend_skipped_isolatedParent
-    datatype: boolean
-    description: Deblender skipped this footprint because there was only a single peak
-    fits:tunit:
-  - name: deblend_skipped_parentTooBig
-    datatype: boolean
-    description: Deblender skipped this source because the parent footprint was too large.
-    fits:tunit:
-  - name: deblend_skipped_tooManyPeaks
-    datatype: boolean
-    description: Deblender skipped this source because there were too many peaks in the Footprint.
-    fits:tunit:
-  - name: deblend_skipped_masked
-    datatype: boolean
-    description: Deblender skipped this source because there were too many masked pixels.
-    fits:tunit:
-  - name: deblend_skipped_isPseudo
-    datatype: boolean
-    description: Deblender skipped this source because it was a pseudo source like a sky object
-    fits:tunit:
-  - name: deblend_incompleteData
-    datatype: boolean
-    description: One or more bands were not deblended due to an inability to model the PSF.
-    fits:tunit:
-  - name: deblend_iterations
-    datatype: int
-    description: Number of iterations during deblending
-    fits:tunit:
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-    fits:tunit:
+  columnRefs:
+    base:
+      Parent:
+        objectId:
+        parentObjectId:
+        merge_peak_sky:
+        deblend_nChild:
+        deblend_nPeaks:
+        deblend_failed:
+        deblend_skipped:
+        deblend_skipped_isolatedParent:
+        deblend_skipped_parentTooBig:
+        deblend_skipped_tooManyPeaks:
+        deblend_skipped_masked:
+        deblend_skipped_isPseudo:
+        deblend_incompleteData:
+        deblend_iterations:
+        deblend_chi2:
   indexes:
   - name: idx_Parent_objectId
     description: Unique index on objectId column

--- a/python/lsst/sdm/schemas/imsim.yaml
+++ b/python/lsst/sdm/schemas/imsim.yaml
@@ -33,6 +33,12 @@ tables:
         detect_fromBlend:
         detect_isDeblendedModelSource:
         detect_isIsolated:
+        detect_isPrimary:
+        detect_isDeblendedSource:
+        detect_isPatchInner:
+        detect_isTractInner:
+        merge_peak_sky:
+        sky_object:
         ebv:
         footprintArea:
         parentObjectId:
@@ -1240,31 +1246,6 @@ tables:
         u_epoch:
         y_epoch:
         z_epoch:
-  columns:
-  - name: detect_isPrimary
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList)
-    fits:tunit:
-  - name: detect_isDeblendedSource
-    datatype: boolean
-    description: True if source has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter (see config.pseudoFilterList) and is either an unblended isolated source or a deblended child from a parent with
-    fits:tunit:
-  - name: detect_isPatchInner
-    datatype: boolean
-    description: True if source is in the inner region of a coadd patch
-    fits:tunit:
-  - name: detect_isTractInner
-    datatype: boolean
-    description: True if source is in the inner region of a coadd tract
-    fits:tunit:
-  - name: merge_peak_sky
-    datatype: boolean
-    description: Peak detected in filter sky
-    fits:tunit:
-  - name: sky_object
-    datatype: boolean
-    description: No source was detected here. This object exists to characterize properties of the sky background
-    fits:tunit:
 - name: Source
   description: Table to store high signal-to-noise sources. A source is
     a measurement of Object's properties from a single image that contains its footprint
@@ -1337,6 +1318,7 @@ tables:
         blendedness_flag:
         blendedness_flag_noCentroid:
         blendedness_flag_noShape:
+        detect_isPrimary:
         apFlux_12_0_flag:
         apFlux_12_0_flag_apertureTruncated:
         apFlux_12_0_flag_sincCoeffsTruncated:
@@ -1428,11 +1410,6 @@ tables:
         sky_source:
         band:
         physical_filter:
-  columns:
-  - name: detect_isPrimary
-    datatype: boolean
-    description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    fits:tunit:
 - name: ForcedSource
   description: The forced source table contains forced-photometry source
      measurement on an individual Exposure based on a Multifit shape model

--- a/python/lsst/sdm/schemas/imsim.yaml
+++ b/python/lsst/sdm/schemas/imsim.yaml
@@ -1449,15 +1449,15 @@ tables:
   - name: detect_isPatchInner
     datatype: boolean
     description: True if Object seed is in the inner region of a coadd patch
-    fits:tunit:
+    ivoa:unit:
   - name: detect_isPrimary
     datatype: boolean
     description: True if Object seed has no children and is in the inner region of a coadd patch and is in the inner region of a coadd tract and is not a sky object
-    fits:tunit:
+    ivoa:unit:
   - name: detect_isTractInner
     datatype: boolean
     description: True if Object seed is in the inner region of a coadd tract
-    fits:tunit:
+    ivoa:unit:
 - name: DiaObject
   description: The DiaObject table contains descriptions of the astronomical objects
     detected on one or more difference images.
@@ -1734,18 +1734,18 @@ tables:
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
+    ivoa:unit: deg
   - name: midpoint
     datatype: timestamp
     precision: 6
     description: Midpoint time for visit at the fiducial center of the focal plane array.
       TAI, accurate to 10ms.
-    fits:tunit:
+    ivoa:unit:
   - name: midpointMjdTai
     datatype: double
     description: Midpoint time for visit at the fiducial center of the focal plane array,
       expressed as Modified Julian Date, International Atomic Time, accurate to 10ms.
-    fits:tunit: d
+    ivoa:unit: d
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,
@@ -1830,7 +1830,7 @@ tables:
   - name: decl
     datatype: double
     description: Deprecated duplicate of dec.
-    fits:tunit: deg
+    ivoa:unit: deg
   - name: midpoint
     datatype: timestamp
     precision: 6
@@ -1839,7 +1839,7 @@ tables:
     datatype: double
     description: Midpoint of the visit, expressed as Modified Julian Date,
       International Atomic Time, accurate to 10ms.
-    fits:tunit: d
+    ivoa:unit: d
   - name: obsStartMjdTai
     datatype: double
     description: Start of the visit, expressed as Modified Julian Date,

--- a/python/lsst/sdm/schemas/lsstcam.yaml
+++ b/python/lsst/sdm/schemas/lsstcam.yaml
@@ -4,4610 +4,1266 @@ description: |
   Default schema for outputs of the LSSTCam Data Release Production Pipeline.
   It is used in the CI testing of the pipelines, and as basis for
   specific data release schemas.
+resources:
+  base:
+    uri: "drp_base.yaml"
 tables:
 - name: Object
   description: "Descriptions of static astronomical objects (or the static aspects
     of variable and slowly-moving objects) detected and measured on coadds."
   tap:table_index: 10
   primaryKey: '#Object.objectId'
-  columns:
-  - name: tract
-    description: Skymap tract ID
-    datatype: long
-    tap:principal: 1
-  - name: patch
-    description: Skymap patch ID
-    datatype: long
-    tap:principal: 1
-  - name: z_ra
-    description: Position in right ascension, measured on z-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: z_dec
-    description: Position in declination, measured on z-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: z_raErr
-    description: Error in right ascension, measured on z-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: z_decErr
-    description: Error in declination, measured on z-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: z_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on z-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: z_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_psfMag
-    description: AB magnitude of the z-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: z_psfMagErr
-    description: Uncertainty in magnitudes of the z-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: z_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on z-band.
-    datatype: boolean
-  - name: z_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ixx
-    description: Gaussian-weighted adaptive moments. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_iyy
-    description: Gaussian-weighted adaptive moments. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_ixy
-    description: Gaussian-weighted adaptive moments. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_i_flag
-    description: General failure flag, set if anything went wrong. Measured on z-band.
-    datatype: boolean
-  - name: z_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on z-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: z_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on z-band.
-    datatype: boolean
-  - name: z_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on z-band.
-    datatype: float
-  - name: z_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on z-band.
-    datatype: boolean
-  - name: z_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on z-band.
-    datatype: float
-  - name: z_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on z-band.
-    datatype: float
-  - name: z_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
-    datatype: float
-  - name: z_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on z-band.
-    datatype: float
-  - name: z_cModelFlux
-    description: Flux from the final CModel fit. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModelMag
-    description: AB magnitude of cModelFlux. Forced on z-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: z_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on z-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: z_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on z-band.
-    datatype: float
-  - name: z_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on z-band.
-    datatype: float
-  - name: z_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on z-band.
-    datatype: boolean
-  - name: z_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on z-band.
-    ivoa:unit: arcsec
-  - name: z_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on z-band.
-    ivoa:unit: arcsec
-  - name: z_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on z-band.
-    ivoa:unit:
-  - name: z_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on z-band.
-    ivoa:unit: arcsec
-  - name: z_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on z-band.
-    ivoa:unit: arcsec
-  - name: z_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on z-band.
-    ivoa:unit:
-  - name: z_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on z-band.
-    datatype: float
-  - name: z_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModel_expFlux
-    description: Flux from the exponential fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on z-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (z-band)
-    datatype: float
-  - name: z_moments_trace
-    description: Moments-based trace radius (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_flag
-    description: Failure flag for moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (z-band)
-    datatype: float
-  - name: z_moments_psf_trace
-    description: Moments-based trace radius of the PSF (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_flag
-    description: Failure flag for PSF moments (z-band)
-    datatype: boolean
-  - name: z_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (z-band)
-    datatype: float
-  - name: z_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (z-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: z_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (z-band)
-    datatype: boolean
-  - name: z_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on z-band.
-    datatype: float
-  - name: z_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on z-band.
-    datatype: float
-  - name: z_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on z-band.
-    datatype: float
-  - name: z_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on z-band.
-    datatype: boolean
-  - name: z_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on z-band.
-    datatype: float
-  - name: z_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on z-band.
-    datatype: float
-  - name: z_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on z-band.
-    datatype: boolean
-  - name: z_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on z-band.
-    datatype: boolean
-  - name: z_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on z-band.
-    datatype: int
-  - name: z_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the z-band.
-    datatype: float
-  - name: z_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: z_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: z_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: z_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (z-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (z-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: z_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (z-band).
-    datatype: float
-  - name: z_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (z-band).
-    datatype: float
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (z-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (z-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: z_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (z-band).
-    datatype: float
-  - name: z_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (z-band).
-    datatype: int
-  - name: z_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (z-band).
-    datatype: float
-  - name: z_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (z-band).
-    datatype: boolean
-  - name: z_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (z-band).
-    datatype: boolean
-  - name: z_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on z-band.
-    datatype: boolean
-  - name: z_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on z-band.
-    datatype: boolean
-  - name: z_psfFlux_area
-    description: Effective area of PSF. Forced on z-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: z_psfFlux_flag
-    description: General Failure Flag. Forced on z-band.
-    datatype: boolean
-  - name: z_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on z-band.
-    datatype: boolean
-  - name: z_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on z-band.
-    datatype: boolean
-  - name: z_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on z-band.
-    datatype: boolean
-  - name: z_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on z-band.
-    datatype: boolean
-  - name: z_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on z-band.
-    datatype: boolean
-  - name: z_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on z-band.
-    datatype: boolean
-  - name: z_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on z-band.
-    datatype: boolean
-  - name: z_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_bad
-    description: Deprecated; only set when there is no z-band data.
-    datatype: boolean
-  - name: z_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_edge
-    description: Deprecated; only set when there is no z-band data.
-    datatype: boolean
-  - name: z_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_offimage
-    description: Deprecated; only set when there is no z-band data.
-    datatype: boolean
-  - name: z_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on z-band.
-    datatype: boolean
-  - name: z_pixelFlags_suspect
-    description: Deprecated; only set when there is no z-band data.
-    datatype: boolean
-  - name: z_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no z-band data.
-    datatype: boolean
-  - name: z_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on z-band.
-    datatype: boolean
-  - name: z_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on z-band.
-    datatype: boolean
-  - name: z_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on z-band.
-    datatype: boolean
-  - name: z_calib_astrometry_used
-    description: Propagated from sources. Measured on z-band.
-    datatype: boolean
-  - name: z_calib_photometry_used
-    description: Propagated from sources. Measured on z-band.
-    datatype: boolean
-  - name: z_calib_psf_candidate
-    description: Propagated from sources. Measured on z-band.
-    datatype: boolean
-  - name: z_calib_psf_reserved
-    description: Propagated from sources. Measured on z-band.
-    datatype: boolean
-  - name: z_calib_psf_used
-    description: Propagated from sources. Measured on z-band.
-    datatype: boolean
-  - name: z_apFlux_flag
-    description: Duplicate of z_ap12Flux_flag.
-    datatype: boolean
-  - name: z_apFlux_flag_apertureTruncated
-    description: Duplicate of z_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: z_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of z_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on z-band.
-    datatype: boolean
-  - name: z_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on z-band.
-    datatype: boolean
-  - name: z_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on z-band.
-    datatype: boolean
-  - name: u_ra
-    description: Position in right ascension, measured on u-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: u_dec
-    description: Position in declination, measured on u-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: u_raErr
-    description: Error in right ascension, measured on u-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: u_decErr
-    description: Error in declination, measured on u-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: u_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on u-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: u_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_psfMag
-    description: AB magnitude of the u-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: u_psfMagErr
-    description: Uncertainty in magnitudes of the u-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: u_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on u-band.
-    datatype: boolean
-  - name: u_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on u-band.
-    ivoa:unit: arcsec
-  - name: u_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on u-band.
-    ivoa:unit: arcsec
-  - name: u_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on u-band.
-    ivoa:unit:
-  - name: u_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on u-band.
-    ivoa:unit: arcsec
-  - name: u_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on u-band.
-    ivoa:unit: arcsec
-  - name: u_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on u-band.
-    ivoa:unit:
-  - name: u_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on u-band.
-    datatype: float
-  - name: u_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModel_expFlux
-    description: Flux from the exponential fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ixx
-    description: Gaussian-weighted adaptive moments. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_iyy
-    description: Gaussian-weighted adaptive moments. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_ixy
-    description: Gaussian-weighted adaptive moments. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_i_flag
-    description: General failure flag, set if anything went wrong. Measured on u-band.
-    datatype: boolean
-  - name: u_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on u-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: u_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on u-band.
-    datatype: boolean
-  - name: u_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on u-band.
-    datatype: float
-  - name: u_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on u-band.
-    datatype: boolean
-  - name: u_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on u-band.
-    datatype: float
-  - name: u_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on u-band.
-    datatype: float
-  - name: u_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes.
-    datatype: float
-  - name: u_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on u-band.
-    datatype: float
-  - name: u_cModelFlux
-    description: Flux from the final CModel fit. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModelMag
-    description: AB magnitude of cModelFlux. Forced on u-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: u_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on u-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: u_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on u-band.
-    datatype: float
-  - name: u_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on u-band.
-    datatype: float
-  - name: u_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on u-band.
-    datatype: boolean
-  - name: u_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on u-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (u-band)
-    datatype: float
-  - name: u_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (u-band)
-    datatype: float
-  - name: u_moments_trace
-    description: Moments-based trace radius (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_flag
-    description: Failure flag for moments (u-band)
-    datatype: boolean
-  - name: u_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (u-band)
-    datatype: float
-  - name: u_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (u-band)
-    datatype: float
-  - name: u_moments_psf_trace
-    description: Moments-based trace radius of the PSF (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_psf_flag
-    description: Failure flag for PSF moments (u-band)
-    datatype: boolean
-  - name: u_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (u-band)
-    datatype: float
-  - name: u_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (u-band)
-    datatype: float
-  - name: u_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (u-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: u_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (u-band)
-    datatype: boolean
-  - name: u_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on u-band.
-    datatype: float
-  - name: u_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on u-band.
-    datatype: float
-  - name: u_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on u-band.
-    datatype: float
-  - name: u_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on u-band.
-    datatype: boolean
-  - name: u_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on u-band.
-    datatype: float
-  - name: u_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on u-band.
-    datatype: float
-  - name: u_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on u-band.
-    datatype: boolean
-  - name: u_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on u-band.
-    datatype: boolean
-  - name: u_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on u-band.
-    datatype: int
-  - name: u_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the u-band.
-    datatype: float
-  - name: u_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: u_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: u_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: u_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: u_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (u-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: u_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (u-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: u_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (u-band).
-    datatype: float
-  - name: u_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (u-band).
-    datatype: float
-  - name: u_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (u-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: u_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (u-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: u_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (u-band).
-    datatype: float
-  - name: u_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (u-band).
-    datatype: int
-  - name: u_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (u-band).
-    datatype: float
-  - name: u_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (u-band).
-    datatype: boolean
-  - name: u_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (u-band).
-    datatype: boolean
-  - name: u_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on u-band.
-    datatype: boolean
-  - name: u_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on u-band.
-    datatype: boolean
-  - name: u_psfFlux_area
-    description: Effective area of PSF. Forced on u-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: u_psfFlux_flag
-    description: General Failure Flag. Forced on u-band.
-    datatype: boolean
-  - name: u_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on u-band.
-    datatype: boolean
-  - name: u_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on u-band.
-    datatype: boolean
-  - name: u_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on u-band.
-    datatype: boolean
-  - name: u_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on u-band.
-    datatype: boolean
-  - name: u_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on u-band.
-    datatype: boolean
-  - name: u_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on u-band.
-    datatype: boolean
-  - name: u_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on u-band.
-    datatype: boolean
-  - name: u_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_bad
-    description: Deprecated; only set when there is no u-band data.
-    datatype: boolean
-  - name: u_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_edge
-    description: Deprecated; only set when there is no u-band data.
-    datatype: boolean
-  - name: u_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_offimage
-    description: Deprecated; only set when there is no u-band data.
-    datatype: boolean
-  - name: u_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on u-band.
-    datatype: boolean
-  - name: u_pixelFlags_suspect
-    description: Deprecated; only set when there is no u-band data.
-    datatype: boolean
-  - name: u_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no u-band data.
-    datatype: boolean
-  - name: u_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on u-band.
-    datatype: boolean
-  - name: u_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on u-band.
-    datatype: boolean
-  - name: u_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on u-band.
-    datatype: boolean
-  - name: u_calib_astrometry_used
-    description: Propagated from sources. Measured on u-band.
-    datatype: boolean
-  - name: u_calib_photometry_used
-    description: Propagated from sources. Measured on u-band.
-    datatype: boolean
-  - name: u_calib_psf_candidate
-    description: Propagated from sources. Measured on u-band.
-    datatype: boolean
-  - name: u_calib_psf_reserved
-    description: Propagated from sources. Measured on u-band.
-    datatype: boolean
-  - name: u_calib_psf_used
-    description: Propagated from sources. Measured on u-band.
-    datatype: boolean
-  - name: u_apFlux_flag
-    description: Duplicate of u_ap12Flux_flag.
-    datatype: boolean
-  - name: u_apFlux_flag_apertureTruncated
-    description: Duplicate of u_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: u_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of u_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on u-band.
-    datatype: boolean
-  - name: u_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on u-band.
-    datatype: boolean
-  - name: u_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on u-band.
-    datatype: boolean
-  - name: g_ra
-    description: Position in right ascension, measured on g-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: g_dec
-    description: Position in declination, measured on g-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: g_raErr
-    description: Error in right ascension, measured on g-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: g_decErr
-    description: Error in declination, measured on g-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: g_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on g-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: g_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_psfMag
-    description: AB magnitude of the g-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: g_psfMagErr
-    description: Uncertainty in magnitudes of the g-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: g_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on g-band.
-    datatype: boolean
-  - name: g_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on g-band.
-    ivoa:unit: arcsec
-  - name: g_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on g-band.
-    ivoa:unit: arcsec
-  - name: g_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on g-band.
-    ivoa:unit:
-  - name: g_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on g-band.
-    ivoa:unit: arcsec
-  - name: g_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on g-band.
-    ivoa:unit: arcsec
-  - name: g_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on g-band.
-    ivoa:unit:
-  - name: g_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on g-band.
-    datatype: float
-  - name: g_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModel_expFlux
-    description: Flux from the exponential fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ixx
-    description: Gaussian-weighted adaptive moments. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_iyy
-    description: Gaussian-weighted adaptive moments. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_ixy
-    description: Gaussian-weighted adaptive moments. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_i_flag
-    description: General failure flag, set if anything went wrong. Measured on g-band.
-    datatype: boolean
-  - name: g_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on g-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: g_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on g-band.
-    datatype: boolean
-  - name: g_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on g-band.
-    datatype: float
-  - name: g_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on g-band.
-    datatype: boolean
-  - name: g_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on g-band.
-    datatype: float
-  - name: g_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on g-band.
-    datatype: float
-  - name: g_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
-    datatype: float
-  - name: griz_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
-    datatype: float
-  - name: g_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on g-band.
-    datatype: float
-  - name: g_cModelFlux
-    description: Flux from the final CModel fit. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModelMag
-    description: AB magnitude of cModelFlux. Forced on g-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: g_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on g-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: g_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on g-band.
-    datatype: float
-  - name: g_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on g-band.
-    datatype: float
-  - name: g_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on g-band.
-    datatype: boolean
-  - name: g_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on g-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (g-band)
-    datatype: float
-  - name: g_moments_trace
-    description: Moments-based trace radius (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_flag
-    description: Failure flag for moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (g-band)
-    datatype: float
-  - name: g_moments_psf_trace
-    description: Moments-based trace radius of the PSF (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_flag
-    description: Failure flag for PSF moments (g-band)
-    datatype: boolean
-  - name: g_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (g-band)
-    datatype: float
-  - name: g_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (g-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: g_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (g-band)
-    datatype: boolean
-  - name: g_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on g-band.
-    datatype: float
-  - name: g_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on g-band.
-    datatype: float
-  - name: g_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on g-band.
-    datatype: float
-  - name: g_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on g-band.
-    datatype: boolean
-  - name: g_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on g-band.
-    datatype: float
-  - name: g_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on g-band.
-    datatype: float
-  - name: g_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on g-band.
-    datatype: boolean
-  - name: g_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on g-band.
-    datatype: boolean
-  - name: g_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on g-band.
-    datatype: int
-  - name: g_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the g-band.
-    datatype: float
-  - name: g_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: g_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: g_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: g_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (g-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (g-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: g_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (g-band).
-    datatype: float
-  - name: g_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (g-band).
-    datatype: float
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (g-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (g-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: g_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (g-band).
-    datatype: float
-  - name: g_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (g-band).
-    datatype: int
-  - name: g_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (g-band).
-    datatype: float
-  - name: g_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (g-band).
-    datatype: boolean
-  - name: g_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (g-band).
-    datatype: boolean
-  - name: g_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on g-band.
-    datatype: boolean
-  - name: g_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on g-band.
-    datatype: boolean
-  - name: g_psfFlux_area
-    description: Effective area of PSF. Forced on g-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: g_psfFlux_flag
-    description: General Failure Flag. Forced on g-band.
-    datatype: boolean
-  - name: g_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on g-band.
-    datatype: boolean
-  - name: g_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on g-band.
-    datatype: boolean
-  - name: g_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on g-band.
-    datatype: boolean
-  - name: g_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on g-band.
-    datatype: boolean
-  - name: g_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on g-band.
-    datatype: boolean
-  - name: g_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on g-band.
-    datatype: boolean
-  - name: g_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on g-band.
-    datatype: boolean
-  - name: g_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_bad
-    description: Deprecated; only set when there is no g-band data.
-    datatype: boolean
-  - name: g_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_edge
-    description: Deprecated; only set when there is no g-band data.
-    datatype: boolean
-  - name: g_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_offimage
-    description: Deprecated; only set when there is no g-band data.
-    datatype: boolean
-  - name: g_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on g-band.
-    datatype: boolean
-  - name: g_pixelFlags_suspect
-    description: Deprecated; only set when there is no g-band data.
-    datatype: boolean
-  - name: g_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no g-band data.
-    datatype: boolean
-  - name: g_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on g-band.
-    datatype: boolean
-  - name: g_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on g-band.
-    datatype: boolean
-  - name: g_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on g-band.
-    datatype: boolean
-  - name: g_calib_astrometry_used
-    description: Propagated from sources. Measured on g-band.
-    datatype: boolean
-  - name: g_calib_photometry_used
-    description: Propagated from sources. Measured on g-band.
-    datatype: boolean
-  - name: g_calib_psf_candidate
-    description: Propagated from sources. Measured on g-band.
-    datatype: boolean
-  - name: g_calib_psf_reserved
-    description: Propagated from sources. Measured on g-band.
-    datatype: boolean
-  - name: g_calib_psf_used
-    description: Propagated from sources. Measured on g-band.
-    datatype: boolean
-  - name: g_apFlux_flag
-    description: Duplicate of g_ap12Flux_flag.
-    datatype: boolean
-  - name: g_apFlux_flag_apertureTruncated
-    description: Duplicate of g_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: g_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of g_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on g-band.
-    datatype: boolean
-  - name: g_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on g-band.
-    datatype: boolean
-  - name: g_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on g-band.
-    datatype: boolean
-  - name: r_ra
-    description: Position in right ascension, measured on r-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: r_dec
-    description: Position in declination, measured on r-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: r_raErr
-    description: Error in right ascension, measured on r-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: r_decErr
-    description: Error in declination, measured on r-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: r_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on r-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: r_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_psfMag
-    description: AB magnitude of the r-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: r_psfMagErr
-    description: Uncertainty in magnitudes of the r-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: r_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on r-band.
-    datatype: boolean
-  - name: r_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on r-band.
-    ivoa:unit: arcsec
-  - name: r_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on r-band.
-    ivoa:unit: arcsec
-  - name: r_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on r-band.
-    ivoa:unit:
-  - name: r_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on r-band.
-    ivoa:unit: arcsec
-  - name: r_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on r-band.
-    ivoa:unit: arcsec
-  - name: r_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on r-band.
-    ivoa:unit:
-  - name: r_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on r-band.
-    datatype: float
-  - name: r_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModel_expFlux
-    description: Flux from the exponential fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ixx
-    description: Gaussian-weighted adaptive moments. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_iyy
-    description: Gaussian-weighted adaptive moments. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_ixy
-    description: Gaussian-weighted adaptive moments. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_i_flag
-    description: General failure flag, set if anything went wrong. Measured on r-band.
-    datatype: boolean
-  - name: r_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on r-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: r_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on r-band.
-    datatype: boolean
-  - name: r_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on r-band.
-    datatype: float
-  - name: r_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on r-band.
-    datatype: boolean
-  - name: r_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on r-band.
-    datatype: float
-  - name: r_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on r-band.
-    datatype: float
-  - name: r_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
-    datatype: float
-  - name: r_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on r-band.
-    datatype: float
-  - name: r_cModelFlux
-    description: Flux from the final CModel fit. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModelMag
-    description: AB magnitude of cModelFlux. Forced on r-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: r_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on r-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: r_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on r-band.
-    datatype: float
-  - name: r_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on r-band.
-    datatype: float
-  - name: r_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on r-band.
-    datatype: boolean
-  - name: r_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on r-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (r-band)
-    datatype: float
-  - name: r_moments_trace
-    description: Moments-based trace radius (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_flag
-    description: Failure flag for moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (r-band)
-    datatype: float
-  - name: r_moments_psf_trace
-    description: Moments-based trace radius of the PSF (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_flag
-    description: Failure flag for PSF moments (r-band)
-    datatype: boolean
-  - name: r_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (r-band)
-    datatype: float
-  - name: r_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (r-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: r_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (r-band)
-    datatype: boolean
-  - name: r_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on r-band.
-    datatype: float
-  - name: r_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on r-band.
-    datatype: float
-  - name: r_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on r-band.
-    datatype: float
-  - name: r_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on r-band.
-    datatype: boolean
-  - name: r_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on r-band.
-    datatype: float
-  - name: r_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on r-band.
-    datatype: float
-  - name: r_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on r-band.
-    datatype: boolean
-  - name: r_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on r-band.
-    datatype: boolean
-  - name: r_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on r-band.
-    datatype: int
-  - name: r_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the r-band.
-    datatype: float
-  - name: r_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: r_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: r_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: r_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (r-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (r-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: r_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (r-band).
-    datatype: float
-  - name: r_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (r-band).
-    datatype: float
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (r-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (r-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: r_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (r-band).
-    datatype: float
-  - name: r_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (r-band).
-    datatype: int
-  - name: r_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (r-band).
-    datatype: float
-  - name: r_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (r-band).
-    datatype: boolean
-  - name: r_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (r-band).
-    datatype: boolean
-  - name: r_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on r-band.
-    datatype: boolean
-  - name: r_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on r-band.
-    datatype: boolean
-  - name: r_psfFlux_area
-    description: Effective area of PSF. Forced on r-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: r_psfFlux_flag
-    description: General Failure Flag. Forced on r-band.
-    datatype: boolean
-  - name: r_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on r-band.
-    datatype: boolean
-  - name: r_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on r-band.
-    datatype: boolean
-  - name: r_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on r-band.
-    datatype: boolean
-  - name: r_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on r-band.
-    datatype: boolean
-  - name: r_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on r-band.
-    datatype: boolean
-  - name: r_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on r-band.
-    datatype: boolean
-  - name: r_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on r-band.
-    datatype: boolean
-  - name: r_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_bad
-    description: Deprecated; only set when there is no r-band data.
-    datatype: boolean
-  - name: r_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_edge
-    description: Deprecated; only set when there is no r-band data.
-    datatype: boolean
-  - name: r_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_offimage
-    description: Deprecated; only set when there is no r-band data.
-    datatype: boolean
-  - name: r_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on r-band.
-    datatype: boolean
-  - name: r_pixelFlags_suspect
-    description: Deprecated; only set when there is no r-band data.
-    datatype: boolean
-  - name: r_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no r-band data.
-    datatype: boolean
-  - name: r_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on r-band.
-    datatype: boolean
-  - name: r_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on r-band.
-    datatype: boolean
-  - name: r_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on r-band.
-    datatype: boolean
-  - name: r_calib_astrometry_used
-    description: Propagated from sources. Measured on r-band.
-    datatype: boolean
-  - name: r_calib_photometry_used
-    description: Propagated from sources. Measured on r-band.
-    datatype: boolean
-  - name: r_calib_psf_candidate
-    description: Propagated from sources. Measured on r-band.
-    datatype: boolean
-  - name: r_calib_psf_reserved
-    description: Propagated from sources. Measured on r-band.
-    datatype: boolean
-  - name: r_calib_psf_used
-    description: Propagated from sources. Measured on r-band.
-    datatype: boolean
-  - name: r_apFlux_flag
-    description: Duplicate of r_ap12Flux_flag.
-    datatype: boolean
-  - name: r_apFlux_flag_apertureTruncated
-    description: Duplicate of r_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: r_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of r_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on r-band.
-    datatype: boolean
-  - name: r_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on r-band.
-    datatype: boolean
-  - name: r_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on r-band.
-    datatype: boolean
-  - name: i_ra
-    description: Position in right ascension, measured on i-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: i_dec
-    description: Position in declination, measured on i-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: i_raErr
-    description: Error in right ascension, measured on i-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: i_decErr
-    description: Error in declination, measured on i-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: i_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on i-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: i_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_psfMag
-    description: AB magnitude of the i-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: i_psfMagErr
-    description: Uncertainty in magnitudes of the i-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: i_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on i-band.
-    datatype: boolean
-  - name: i_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on i-band.
-    ivoa:unit: arcsec
-  - name: i_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on i-band.
-    ivoa:unit: arcsec
-  - name: i_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on i-band.
-    ivoa:unit:
-  - name: i_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on i-band.
-    ivoa:unit: arcsec
-  - name: i_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on i-band.
-    ivoa:unit: arcsec
-  - name: i_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on i-band.
-    ivoa:unit:
-  - name: i_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on i-band.
-    datatype: float
-  - name: i_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModel_expFlux
-    description: Flux from the exponential fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ixx
-    description: Gaussian-weighted adaptive moments. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_iyy
-    description: Gaussian-weighted adaptive moments. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_ixy
-    description: Gaussian-weighted adaptive moments. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_i_flag
-    description: General failure flag, set if anything went wrong. Measured on i-band.
-    datatype: boolean
-  - name: i_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on i-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: i_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on i-band.
-    datatype: boolean
-  - name: i_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on i-band.
-    datatype: float
-  - name: i_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on i-band.
-    datatype: boolean
-  - name: i_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on i-band.
-    datatype: float
-  - name: i_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on i-band.
-    datatype: float
-  - name: i_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
-    datatype: float
-  - name: i_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on i-band.
-    datatype: float
-  - name: i_cModelFlux
-    description: Flux from the final CModel fit. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModelMag
-    description: AB magnitude of cModelFlux. Forced on i-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: i_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on i-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: i_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on i-band.
-    datatype: float
-  - name: i_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on i-band.
-    datatype: float
-  - name: i_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on i-band.
-    datatype: boolean
-  - name: i_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on i-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (i-band)
-    datatype: float
-  - name: i_moments_trace
-    description: Moments-based trace radius (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_flag
-    description: Failure flag for moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (i-band)
-    datatype: float
-  - name: i_moments_psf_trace
-    description: Moments-based trace radius of the PSF (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_flag
-    description: Failure flag for PSF moments (i-band)
-    datatype: boolean
-  - name: i_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (i-band)
-    datatype: float
-  - name: i_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (i-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: i_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (i-band)
-    datatype: boolean
-  - name: i_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on i-band.
-    datatype: float
-  - name: i_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on i-band.
-    datatype: float
-  - name: i_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on i-band.
-    datatype: float
-  - name: i_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on i-band.
-    datatype: boolean
-  - name: i_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on i-band.
-    datatype: float
-  - name: i_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on i-band.
-    datatype: float
-  - name: i_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on i-band.
-    datatype: boolean
-  - name: i_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on i-band.
-    datatype: boolean
-  - name: i_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on i-band.
-    datatype: int
-  - name: i_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the i-band.
-    datatype: float
-  - name: i_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: i_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: i_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: i_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (i-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (i-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: i_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (i-band).
-    datatype: float
-  - name: i_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (i-band).
-    datatype: float
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (i-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (i-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: i_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (i-band).
-    datatype: float
-  - name: i_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (i-band).
-    datatype: int
-  - name: i_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (i-band).
-    datatype: float
-  - name: i_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (i-band).
-    datatype: boolean
-  - name: i_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (i-band).
-    datatype: boolean
-  - name: i_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on i-band.
-    datatype: boolean
-  - name: i_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on i-band.
-    datatype: boolean
-  - name: i_psfFlux_area
-    description: Effective area of PSF. Forced on i-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: i_psfFlux_flag
-    description: General Failure Flag. Forced on i-band.
-    datatype: boolean
-  - name: i_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on i-band.
-    datatype: boolean
-  - name: i_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on i-band.
-    datatype: boolean
-  - name: i_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on i-band.
-    datatype: boolean
-  - name: i_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on i-band.
-    datatype: boolean
-  - name: i_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on i-band.
-    datatype: boolean
-  - name: i_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on i-band.
-    datatype: boolean
-  - name: i_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on i-band.
-    datatype: boolean
-  - name: i_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_bad
-    description: Deprecated; only set when there is no i-band data.
-    datatype: boolean
-  - name: i_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_edge
-    description: Deprecated; only set when there is no i-band data.
-    datatype: boolean
-  - name: i_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_offimage
-    description: Deprecated; only set when there is no i-band data.
-    datatype: boolean
-  - name: i_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on i-band.
-    datatype: boolean
-  - name: i_pixelFlags_suspect
-    description: Deprecated; only set when there is no i-band data.
-    datatype: boolean
-  - name: i_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no i-band data.
-    datatype: boolean
-  - name: i_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on i-band.
-    datatype: boolean
-  - name: i_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on i-band.
-    datatype: boolean
-  - name: i_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on i-band.
-    datatype: boolean
-  - name: i_calib_astrometry_used
-    description: Propagated from sources. Measured on i-band.
-    datatype: boolean
-  - name: i_calib_photometry_used
-    description: Propagated from sources. Measured on i-band.
-    datatype: boolean
-  - name: i_calib_psf_candidate
-    description: Propagated from sources. Measured on i-band.
-    datatype: boolean
-  - name: i_calib_psf_reserved
-    description: Propagated from sources. Measured on i-band.
-    datatype: boolean
-  - name: i_calib_psf_used
-    description: Propagated from sources. Measured on i-band.
-    datatype: boolean
-  - name: i_apFlux_flag
-    description: Duplicate of i_ap12Flux_flag.
-    datatype: boolean
-  - name: i_apFlux_flag_apertureTruncated
-    description: Duplicate of i_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: i_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of i_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on i-band.
-    datatype: boolean
-  - name: i_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on i-band.
-    datatype: boolean
-  - name: i_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on i-band.
-    datatype: boolean
-  - name: y_ra
-    description: Position in right ascension, measured on y-band.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: y_dec
-    description: Position in declination, measured on y-band.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: y_raErr
-    description: Error in right ascension, measured on y-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: y_decErr
-    description: Error in declination, measured on y-band.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: y_ra_dec_Cov
-    description: Covariance between right ascension and declination, measured on y-band.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: y_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Forced on
-      y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_psfMag
-    description: AB magnitude of the y-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: y_psfMagErr
-    description: Uncertainty in magnitudes of the y-band psfFlux.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: y_free_psfFlux
-    description: Flux derived from using the PSF model as a weight function. Measured
-      on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_psfFluxErr
-    description: Flux uncertainty derived from using the PSF model as a weight function.
-      Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_psfFlux_flag
-    description: Flag set if the unforced PSF flux failed in this band for any reason. Measured on y-band.
-    datatype: boolean
-  - name: y_cModel_dev_reff_major
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (major axis). Measured on y-band.
-    ivoa:unit: arcsec
-  - name: y_cModel_dev_reff_minor
-    datatype: float
-    description: Half-light ellipse of the de Vaucouleurs fit (minor axis). Measured on y-band.
-    ivoa:unit: arcsec
-  - name: y_cModel_dev_theta
-    datatype: float
-    description: Position angle of the de Vaucouleurs fit ellipse. Measured on y-band.
-    ivoa:unit:
-  - name: y_cModel_exp_reff_major
-    datatype: float
-    description: Half-light ellipse of the exponential fit (major axis). Measured on y-band.
-    ivoa:unit: arcsec
-  - name: y_cModel_exp_reff_minor
-    datatype: float
-    description: Half-light ellipse of the exponential fit (minor axis). Measured on y-band.
-    ivoa:unit: arcsec
-  - name: y_cModel_exp_theta
-    datatype: float
-    description: Position angle of the exponential fit ellipse. Measured on y-band.
-    ivoa:unit:
-  - name: y_cModel_chi2
-    description: -ln(likelihood) (chi^2) in CModel fit. Measured on y-band.
-    datatype: float
-  - name: y_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModel_expFlux
-    description: Flux from the exponential fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaapPsfFlux
-    description: GAaP Flux with PSF aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaapPsfFluxErr
-    description: GAaP Flux uncertainty with PSF aperture after multiplying the seeing
-      by 1.15. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaap0p7Flux
-    description: GAaP Flux with 0.7 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaap0p7FluxErr
-    description: GAaP Flux uncertainty with 0.7 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaap1p0Flux
-    description: GAaP Flux with 1.0 arcsec aperture after reconvolving the image to a Gaussian PSF larger than the original by a factor of 1.15.
-      Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_gaap1p0FluxErr
-    description: GAaP Flux uncertainty with 1.0 arcsec aperture after multiplying the seeing
-      by 1.15. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ixx
-    description: Gaussian-weighted adaptive moments. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_iyy
-    description: Gaussian-weighted adaptive moments. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_ixy
-    description: Gaussian-weighted adaptive moments. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_i_flag
-    description: General failure flag, set if anything went wrong. Measured on y-band.
-    datatype: boolean
-  - name: y_ixxPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_iyyPSF
-    description: Gaussian-weighted adaptive moments of the PSF model at the position of this object. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_ixyPSF
-    description: Gaussian-weighted adaptive moments. Measured on y-band.
-    datatype: float
-    ivoa:unit: pixel**2
-  - name: y_iPSF_flag
-    description: Flag set for any failure in the PSF model moments. Measured on y-band.
-    datatype: boolean
-  - name: y_kronRad
-    description: Kron radius (sqrt(a*b)).  Measured on y-band.
-    datatype: float
-  - name: y_kronFlux
-    description: Flux measured within an elliptical aperture 2.5 times the Kron radius.  Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_kronFluxErr
-    description: Flux uncertainty from Kron Flux algorithm. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced on y-band.
-    datatype: boolean
-  - name: y_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on y-band.
-    datatype: float
-  - name: y_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Measured on y-band.
-    datatype: float
-  - name: y_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
-    datatype: float
-  - name: y_blendedness
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details. Measured on y-band.
-    datatype: float
-  - name: y_cModelFlux
-    description: Flux from the final CModel fit. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModelMag
-    description: AB magnitude of cModelFlux. Forced on y-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: y_cModelMagErr
-    description: Uncertainty in magnitudes on cModelFlux. Forced on y-band.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: y_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Forced on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Forced on y-band.
-    datatype: float
-  - name: y_free_cModelFlux
-    description: Flux from the final CModel fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModelFluxErr
-    description: Flux uncertainty from the final CModel fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModelFlux_inner
-    description: Flux within the fit region, with no extrapolation. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModel_fracDev
-    description: Fraction of the CModel flux from the De Vaucouleurs (n=4) component. Measured on y-band.
-    datatype: float
-  - name: y_free_cModelFlux_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Measured
-      on y-band.
-    datatype: boolean
-  - name: y_free_cModel_devFlux
-    description: Flux from the de Vaucouleurs fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModel_devFluxErr
-    description: Flux uncertainty from the de Vaucouleurs fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModel_expFlux
-    description: Flux from the exponential fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_free_cModel_expFluxErr
-    description: Flux uncertainty from the exponential fit. Measured on y-band.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_moments_g1
-    description: Moments-based G1 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_g2
-    description: Moments-based G2 shear ellipticity parameter (y-band)
-    datatype: float
-  - name: y_moments_trace
-    description: Moments-based trace radius (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_flag
-    description: Failure flag for moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_g1
-    description: Moments-based G1 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_g2
-    description: Moments-based G2 ellipticity of of the PSF (y-band)
-    datatype: float
-  - name: y_moments_psf_trace
-    description: Moments-based trace radius of the PSF (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_flag
-    description: Failure flag for PSF moments (y-band)
-    datatype: boolean
-  - name: y_moments_psf_debiased_g1
-    description: Moments-based G1 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_g2
-    description: Moments-based G2 ellipticity of the PSF, debiased (y-band)
-    datatype: float
-  - name: y_moments_psf_debiased_trace
-    description: Moments-based trace radius of the PSF, debiased (y-band)
-    datatype: float
-    ivoa:unit: arcsec
-  - name: y_moments_psf_debiased_flag
-    description: Failure flag for the debiased PSF moments (y-band)
-    datatype: boolean
-  - name: y_hsmShapeRegauss_e1
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on y-band.
-    datatype: float
-  - name: y_hsmShapeRegauss_e2
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on y-band.
-    datatype: float
-  - name: y_hsmShapeRegauss_sigma
-    description: PSF-corrected shear using the Hirata & Seljak (2003) Regaussianization algorithm.
-      Measured on y-band.
-    datatype: float
-  - name: y_hsmShapeRegauss_flag
-    description: Flag set for any failure with the Regaussianziation shapes. Measured on y-band.
-    datatype: boolean
-  - name: y_hsm_moments_30
-    description: HSM higher-order moment 30. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_30
-    description: HSM higher-order moment 30 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_21
-    description: HSM higher-order moment 21. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_21
-    description: HSM higher-order moment 21 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_12
-    description: HSM higher-order moment 12. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_12
-    description: HSM higher-order moment 12 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_03
-    description: HSM higher-order moment 03. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_03
-    description: HSM higher-order moment 03 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_40
-    description: HSM higher-order moment 40. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_40
-    description: HSM higher-order moment 40 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_31
-    description: HSM higher-order moment 31. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_31
-    description: HSM higher-order moment 31 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_22
-    description: HSM higher-order moment 22. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_22
-    description: HSM higher-order moment 22 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_13
-    description: HSM higher-order moment 13. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_13
-    description: HSM higher-order moment 13 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_04
-    description: HSM higher-order moment 04. Measured on y-band.
-    datatype: float
-  - name: y_hsm_momentsPsf_04
-    description: HSM higher-order moment 04 measured on the PSF model at the position of the object. Measured on y-band.
-    datatype: float
-  - name: y_hsm_moments_flag
-    description: Flag set for any failure in the HSM higher-order moments. Measured
-      on y-band.
-    datatype: boolean
-  - name: y_hsm_momentsPsf_flag
-    description: Flag set for any failure in the HSM higher-order moment on the PSF model.
-      Measured on y-band.
-    datatype: boolean
-  - name: y_inputCount
-    description: Number of images contributing at center, not including any clipping.
-      Forced on y-band.
-    datatype: int
-  - name: y_deblend_dataCoverage
-    description: Fraction of data that contained good data, ie. 1 - number of no data
-      pixels/total number of pixels in the y-band.
-    datatype: float
-  - name: y_deblend_blendedness
-    description: Blendedness in the deconvolved scarlet space.
-    datatype: float
-  - name: y_deblend_fluxOverlap
-    description: The total flux from neighboring objects that overlaps with this sources
-      footprint in the deconvolved space.
-    datatype: float
-  - name: y_deblend_fluxOverlapFraction
-    description: Fraction of flux from neighbors / source flux in the deconvolved
-      footprint.
-    datatype: float
-  - name: y_deblend_zeroFlux
-    description: True when there was no flux attributed to this object after flux
-      redistribution in the deblender.
-    datatype: boolean
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_x
-    description: Standard deviation of the first Gaussian component (x-axis) in the
-      two-Gaussian PSF model (y-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_sigma_y
-    description: Standard deviation of the first Gaussian component (y-axis) in the
-      two-Gaussian PSF model (y-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: y_psfModel_TwoGaussian_gauss1_rho
-    description: Ellipse rho (correlation coefficient) of the first Gaussian component
-      in the two-Gaussian PSF model (y-band).
-    datatype: float
-  - name: y_psfModel_TwoGaussian_gauss1_fluxfrac
-    description: Fraction of the total flux (normalized to unity) of the first Gaussian
-      component in the two-Gaussian PSF model (y-band).
-    datatype: float
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_x
-    description: Standard deviation of the second Gaussian component (x-axis) in the
-      two-Gaussian PSF model (y-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_sigma_y
-    description: Standard deviation of the second Gaussian component (y-axis) in the
-      two-Gaussian PSF model (y-band).
-    datatype: float
-    ivoa:unit: pixel
-  - name: y_psfModel_TwoGaussian_gauss2_rho
-    description: Ellipse rho (correlation coefficient) of the second Gaussian component
-      in the two-Gaussian PSF model (y-band).
-    datatype: float
-  - name: y_psfModel_TwoGaussian_n_iter
-    description: Number of iterations in the non-linear fit for the two-Gaussian PSF
-      model (y-band).
-    datatype: int
-  - name: y_psfModel_TwoGaussian_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the two-Gaussian PSF model (y-band).
-    datatype: float
-  - name: y_psfModel_TwoGaussian_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      two-Gaussian PSF model (y-band).
-    datatype: boolean
-  - name: y_psfModel_TwoGaussian_no_inputs_flag
-    description: Flag set for objects not fit because there were no coadd PSF inputs
-      for the two-Gaussian PSF model (y-band).
-    datatype: boolean
-  - name: y_inputCount_flag
-    description: Flag set for any failure in computing the number of inputs. Forced on y-band.
-    datatype: boolean
-  - name: y_inputCount_flag_noInputs
-    description: No coadd inputs were recorded. Forced on y-band.
-    datatype: boolean
-  - name: y_psfFlux_area
-    description: Effective area of PSF. Forced on y-band.
-    datatype: float
-    ivoa:unit: pixel
-  - name: y_psfFlux_flag
-    description: General Failure Flag. Forced on y-band.
-    datatype: boolean
-  - name: y_psfFlux_flag_apCorr
-    description: Flag set if unable to aperture-correct the PSF flux. Forced on y-band.
-    datatype: boolean
-  - name: y_psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model. Forced on y-band.
-    datatype: boolean
-  - name: y_psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit. Forced
-      on y-band.
-    datatype: boolean
-  - name: y_cModel_flag
-    description: Flag set if the final CModel fit (or any previous fit) failed. Forced
-      on y-band.
-    datatype: boolean
-  - name: y_cModel_flag_apCorr
-    description: Flag set if unable to aperture-correct the CModel flux. Forced on y-band.
-    datatype: boolean
-  - name: y_gaapFlux_flag
-    description: Flag set for any failure in the GAaP photometry. Forced on y-band.
-    datatype: boolean
-  - name: y_gaapFlux_flag_edge
-    description: Source is too close to the edge. Forced on y-band.
-    datatype: boolean
-  - name: y_blendedness_flag
-    description: Flag set for any failure in the blendedness algorithm. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_bad
-    description: Deprecated; only set when there is no y-band data.
-    datatype: boolean
-  - name: y_pixelFlags_clipped
-    description: Artifacts were rejected by warp comparison in this object's footprint. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_clippedCenter
-    description: Artifacts were rejected by warp comparison in this object's center. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_cr
-    description: A cosmic ray was detected and interpolated in this object's footprint. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_crCenter
-    description: A cosmic ray was detected and interpolated in this object's center. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_edge
-    description: Deprecated; only set when there is no y-band data.
-    datatype: boolean
-  - name: y_pixelFlags_inexact_psf
-    description: The PSF model is discontinuous in this object's footprint. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_inexact_psfCenter
-    description: The PSF model is discontinuosu near this object's center. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_interpolated
-    description: An interpolated pixel contributed to the coadd in this object's footprint. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_interpolatedCenter
-    description: An interpolated pixel contributed to the coadd near this object's center. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_nodata
-    description: No pixel data was available in this band for this object. Measured
-      on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_offimage
-    description: Deprecated; only set when there is no y-band data.
-    datatype: boolean
-  - name: y_pixelFlags_saturated
-    description: Saturated pixels were rejected from this object's footprint, but would otherwise have contributed more than 10% of at least one pixel. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_saturatedCenter
-    description: Saturated pixels were rjected from near this object's center, but would otherwise have contributed more than 10% of at least one pixel. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_sensor_edge
-    description: A detector boundary passed through this object's footprint. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_sensor_edgeCenter
-    description: A detector boundary passed close to this object's center. Measured on y-band.
-    datatype: boolean
-  - name: y_pixelFlags_suspect
-    description: Deprecated; only set when there is no y-band data.
-    datatype: boolean
-  - name: y_pixelFlags_suspectCenter
-    description: Deprecated; only set when there is no y-band data.
-    datatype: boolean
-  - name: y_extendedness_flag
-    description: Flag set for any failure in the flux-ratio extendedness. Measured on y-band.
-    datatype: boolean
-  - name: y_sizeExtendedness_flag
-    description: Flag set for any failure in the moments-based extendedness. Measured on y-band.
-    datatype: boolean
-  - name: y_invalidPsfFlag
-    description: This object has an invalid PSF (usually no inputs). Measured on y-band.
-    datatype: boolean
-  - name: y_calib_astrometry_used
-    description: Propagated from sources. Measured on y-band.
-    datatype: boolean
-  - name: y_calib_photometry_used
-    description: Propagated from sources. Measured on y-band.
-    datatype: boolean
-  - name: y_calib_psf_candidate
-    description: Propagated from sources. Measured on y-band.
-    datatype: boolean
-  - name: y_calib_psf_reserved
-    description: Propagated from sources. Measured on y-band.
-    datatype: boolean
-  - name: y_calib_psf_used
-    description: Propagated from sources. Measured on y-band.
-    datatype: boolean
-  - name: y_apFlux_flag
-    description: Duplicate of y_ap12Flux_flag.
-    datatype: boolean
-  - name: y_apFlux_flag_apertureTruncated
-    description: Duplicate of y_ap12Flux_flag_apertureTruncated.
-    datatype: boolean
-  - name: y_apFlux_flag_sincCoeffsTruncated
-    description: Duplicate of y_ap12Flux_flag_sincCoeffsTruncated.
-      Measured on y-band.
-    datatype: boolean
-  - name: y_centroid_flag
-    description: Flag set for any failure in the centroid algorithm. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag
-    description: Flag set for any failure in the Kron photometry. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_bad_radius
-    description: Bad Kron radius. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_bad_shape
-    description: Shape for measuring Kron radius is bad; used PSF shape. Measured
-      on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_bad_shape_no_psf
-    description: Bad shape and no PSF. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_edge
-    description: Bad measurement due to image edge. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_no_fallback_radius
-    description: No minimum radius and no PSF provided. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_no_minimum_radius
-    description: Minimum radius could not enforced, no minimum value or PSF. Measured
-      on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_small_radius
-    description: Measured Kron radius was smaller than that of the PSF. Measured on
-      y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_used_minimum_radius
-    description: Used the minimum radius for the Kron radius. Measured on y-band.
-    datatype: boolean
-  - name: y_kronFlux_flag_used_psf_radius
-    description: Kron radius fell back to being derived from the PSF radius. Measured on y-band.
-    datatype: boolean
-  - name: g_epoch
-    description: Mean epoch of the object in the g-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: i_epoch
-    description: Mean epoch of the object in the i-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: r_epoch
-    description: Mean epoch of the object in the r-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: u_epoch
-    description: Mean epoch of the object in the u-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: y_epoch
-    description: Mean epoch of the object in the y-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: z_epoch
-    description: Mean epoch of the object in the z-band coadd in MJD TAI
-    datatype: double
-    ivoa:unit: d
-  - name: parentObjectId
-    description: Unique ID of parent source. Reference band.
-    datatype: long
-    tap:principal: 1
-  - name: coord_ra
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: coord_dec
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: coord_raErr
-    description: Error in fiducial ICRS Right Ascension of centroid
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra;meta.main
-    ivoa:unit: deg
-  - name: coord_decErr
-    description: Error in fiducial ICRS Declination of centroid
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec;meta.main
-    ivoa:unit: deg
-  - name: coord_ra_dec_Cov
-    description: Covariance between fiducial ICRS Right Ascension and Declination
-      of centroid
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec;meta.main
-    ivoa:unit: deg**2
-  - name: coord_flag
-    description: General Failure Flag. Reference band.
-    datatype: boolean
-  - name: refBand
-    description: Reference band - parameters measured on coadds of this band were
-      used for multi-band forced photometry
-    datatype: char
-    length: 1
-    tap:principal: 1
-  - name: refExtendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1). Reference band.
-    datatype: float
-    tap:principal: 1
-  - name: refSizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended (1). Reference band.
-    datatype: float
-    tap:principal: 1
-  - name: footprintArea
-    description: Number of pixels in the sources detection footprint. Reference band.
-    datatype: int
-    ivoa:unit: pixel
-  - name: ebv
-    description: E(B-V) at coord_ra/coord_dec per Schlegel, Finkbeiner & Davis (1998)
-    datatype: float
-    ivoa:unit: mag
-  - name: shape_xx
-    description: Gaussian-weighted adaptive moments. Reference band.
-    datatype: float
-    ivoa:unit: pixel**2
-    tap:principal: 1
-  - name: shape_yy
-    description: Gaussian-weighted adaptive moments. Reference band.
-    datatype: float
-    ivoa:unit: pixel**2
-    tap:principal: 1
-  - name: shape_xy
-    description: Gaussian-weighted adaptive moments. Reference band.
-    datatype: float
-    ivoa:unit: pixel**2
-    tap:principal: 1
-  - name: detect_isIsolated
-    description: This source is not a part of a blend.
-    datatype: boolean
-    tap:principal: 1
-  - name: detect_fromBlend
-    description: This source is deblended from a parent with more than one child.
-    datatype: boolean
-    tap:principal: 1
-  - name: detect_isDeblendedModelSource
-    description: True if source has no children and is in the inner region of a coadd
-      patch and is in the inner region of a coadd tract and is not detected in a pseudo-filter
-      (see config.pseudoFilterList) and is a deblended child
-    datatype: boolean
-  - name: deblend_parentNChild
-    description: Number of children in deblended from the parent footprint.
-    datatype: int
-    tap:principal: 1
-  - name: deblend_parentNPeaks
-    description: Number of peaks the parent footprint has (even if the deblender
-      failed or skipped this blend)
-    datatype: int
-  - name: deblend_peak_center_x
-    description: x-coordinate of the peak after source detection
-    datatype: int
-    ivoa:unit: pixel
-  - name: deblend_peak_center_y
-    description: y-coordinate of the peak after source detection
-    datatype: int
-    ivoa:unit: pixel
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-  - name: deblend_blendId
-    description: Unique ID of the deconvolved parent source that this source was deblended from.
-    datatype: long
-  - name: deblend_blendNChild
-    description: Number of children in the deconvolved parent source that this source
-      was deblended from.
-    datatype: int
-  - name: shape_flag
-    description: General failure flag, set if anything went wrong. Reference band.
-    datatype: boolean
-  - name: exponential_ra
-    description: Centroid (right ascension) from the multiband exponential model fit.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: exponential_raErr
-    description: Error on the centroid (right ascension) from the multiband exponential model fit.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: exponential_dec
-    description: Centroid (declination) from the multiband exponential model fit.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: exponential_decErr
-    description: Error on the centroid (declination) from the multiband exponential model fit.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: exponential_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband exponential model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: exponential_reff_x
-    description: Effective radius (x-axis) from the multiband exponential model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    datatype: float
-    ivoa:unit: pixel
-  - name: exponential_reff_xErr
-    description: Error on the effective radius (x-axis) from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: pixel
-  - name: exponential_reff_y
-    description: Effective radius (y-axis) from the multiband exponential model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    datatype: float
-    ivoa:unit: pixel
-  - name: exponential_reff_yErr
-    description: Error on the effective radius (y-axis) from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: pixel
-  - name: exponential_rho
-    description: Ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    datatype: float
-  - name: exponential_rhoErr
-    description: Error on ellipse rho (correlation coefficient) from the multiband exponential model fit.
-    datatype: float
-  - name: exponential_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    ivoa:unit: arcsec
-  - name: exponential_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    ivoa:unit: arcsec
-  - name: exponential_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-  - name: g_exponentialFlux
-    description: g-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_exponentialFluxErr
-    description: Error on the g-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_exponentialFlux
-    description: i-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_exponentialFluxErr
-    description: Error on the i-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_exponentialFlux
-    description: r-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_exponentialFluxErr
-    description: Error on the r-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_exponentialFlux
-    description: u-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_exponentialFluxErr
-    description: Error on the u-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_exponentialFlux
-    description: y-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_exponentialFluxErr
-    description: Error on the y-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_exponentialFlux
-    description: z-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_exponentialFluxErr
-    description: Error on the z-band flux from the multiband exponential model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: exponential_n_eval_jac
-    description: Number of Jacobian evaluations for the multiband exponential model fit.
-    datatype: int
-  - name: exponential_n_iter
-    description: Number of iterations in the non-linear fit for the multiband exponential model.
-    datatype: int
-  - name: exponential_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided the number of data points) for the multiband exponential model.
-    datatype: float
-  - name: exponential_delta_lnL_fit_linear
-    description: The ln-likelihood of the best model non-linear fit parameters minus the ln-likelihood of a subsequent linear least squares fit.
-    datatype: float
-  - name: exponential_delta_lnL_fit_ps
-    description: The ln-likelihood of the best-fit exponential model minus the ln-likelihood of a point source with the same centroid and PSF model.
-    datatype: float
-  - name: exponential_no_data_flag
-    description: Flag set when there is insufficient data to fit for the multiband exponential model.
-    datatype: boolean
-  - name: exponential_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the multiband exponential model.
-    datatype: boolean
-  - name: sersic_ra
-    description: Centroid (right ascension) from the multiband Sersic model fit.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: sersic_raErr
-    description: Error on the centroid (right ascension) from the multiband Sersic model fit.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: sersic_dec
-    description: Centroid (declination) from the multiband Sersic model fit.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: sersic_decErr
-    description: Error on the centroid (declination) from the multiband Sersic model fit.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: sersic_ra_dec_Cov
-    description: Covariance between right ascension and declination from the multiband Sersic model fit.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: sersic_reff_x
-    description: Effective radius (x-axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    datatype: float
-    ivoa:unit: pixel
-  - name: sersic_reff_xErr
-    description: Error on the effective radius (x-axis) from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: pixel
-  - name: sersic_reff_y
-    description: Effective radius (y-axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    datatype: float
-    ivoa:unit: pixel
-  - name: sersic_reff_yErr
-    description: Error on the effective radius (y-axis) from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: pixel
-  - name: sersic_rho
-    description: Ellipse rho (correlation coefficient) from the multiband Sersic model fit.
-    datatype: float
-  - name: sersic_rhoErr
-    description: Error on ellipse rho (correlation coefficient) from the multiband Sersic
-      model fit.
-    datatype: float
-  - name: sersic_reff_major
-    datatype: float
-    description: Effective radius (major axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    ivoa:unit: arcsec
-  - name: sersic_reff_minor
-    datatype: float
-    description: Effective radius (minor axis) from the multiband Sersic model fit, prior to convolution with the PSF model (which is shrunk by 0.1 pixels in quadrature by default).
-    ivoa:unit: arcsec
-  - name: sersic_theta
-    datatype: float
-    description: Position angle of the multiband Sersic fit ellipse.
-    ivoa:unit:
-  - name: g_sersicFlux
-    description: g-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_sersicFluxErr
-    description: Error on the g-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_sersicFlux
-    description: i-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_sersicFluxErr
-    description: Error on the i-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_sersicFlux
-    description: r-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_sersicFluxErr
-    description: Error on the r-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_sersicFlux
-    description: u-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: u_sersicFluxErr
-    description: Error on the u-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_sersicFlux
-    description: y-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_sersicFluxErr
-    description: Error on the y-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_sersicFlux
-    description: z-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_sersicFluxErr
-    description: Error on the z-band flux from the multiband Sersic model fit.
-    datatype: float
-    ivoa:unit: nJy
-  - name: sersic_index
-    description: Sersic profile index parameter from the multiband Sersic model fit.
-    datatype: float
-  - name: sersic_indexErr
-    description: Error on the Sersic profile index parameter from the multiband Sersic
-      model fit.
-    datatype: float
-  - name: sersic_n_eval_jac
-    description: Number of Jacobian evaluations for the multiband Sersic model fit.
-    datatype: int
-  - name: sersic_n_iter
-    description: Number of iterations in the non-linear fit for the multiband Sersic
-      model.
-    datatype: int
-  - name: sersic_chi2_reduced
-    description: Reduced chi-squared of the best-fit model parameters (chi divided
-      the number of data points) for the multiband Sersic model.
-    datatype: float
-  - name: sersic_unknown_flag
-    description: Flag set for failures with an unexpected or unknown cause for the
-      multiband Sersic model.
-    datatype: boolean
-  - name: sersic_no_data_flag
-    description: Flag set when there is insufficient data to fit for the multiband
-      Sersic model.
-    datatype: boolean
-  - name: objectId
-    description: Unique id. Unique ObjectID
-    datatype: long
-    ivoa:ucd: meta.id;src
-    tap:principal: 1
+  columnRefs:
+    base:
+      Object:
+        tract:
+        patch:
+        z_ra:
+        z_dec:
+        z_raErr:
+        z_decErr:
+        z_ra_dec_Cov:
+        z_psfFlux:
+        z_psfFluxErr:
+        z_psfMag:
+        z_psfMagErr:
+        z_free_psfFlux:
+        z_free_psfFluxErr:
+        z_free_psfFlux_flag:
+        z_gaapPsfFlux:
+        z_gaapPsfFluxErr:
+        z_gaap0p7Flux:
+        z_gaap0p7FluxErr:
+        z_gaap1p0Flux:
+        z_gaap1p0FluxErr:
+        z_ixx:
+        z_iyy:
+        z_ixy:
+        z_i_flag:
+        z_ixxPSF:
+        z_iyyPSF:
+        z_ixyPSF:
+        z_iPSF_flag:
+        z_kronRad:
+        z_kronFlux:
+        z_kronFluxErr:
+        z_ap03Flux:
+        z_ap03FluxErr:
+        z_ap03Flux_flag:
+        z_ap06Flux:
+        z_ap06FluxErr:
+        z_ap06Flux_flag:
+        z_ap09Flux:
+        z_ap09FluxErr:
+        z_ap09Flux_flag:
+        z_ap12Flux:
+        z_ap12FluxErr:
+        z_ap12Flux_flag:
+        z_ap17Flux:
+        z_ap17FluxErr:
+        z_ap17Flux_flag:
+        z_ap25Flux:
+        z_ap25FluxErr:
+        z_ap25Flux_flag:
+        z_ap35Flux:
+        z_ap35FluxErr:
+        z_ap35Flux_flag:
+        z_ap50Flux:
+        z_ap50FluxErr:
+        z_ap50Flux_flag:
+        z_ap70Flux:
+        z_ap70FluxErr:
+        z_ap70Flux_flag:
+        z_extendedness:
+        z_sizeExtendedness:
+        z_model_extendedness:
+        z_blendedness:
+        z_cModelFlux:
+        z_cModelFluxErr:
+        z_cModelMag:
+        z_cModelMagErr:
+        z_cModelFlux_inner:
+        z_cModel_fracDev:
+        z_free_cModelFlux:
+        z_free_cModelFluxErr:
+        z_free_cModelFlux_inner:
+        z_free_cModel_fracDev:
+        z_free_cModelFlux_flag:
+        z_free_cModel_devFlux:
+        z_free_cModel_devFluxErr:
+        z_free_cModel_expFlux:
+        z_free_cModel_expFluxErr:
+        z_cModel_dev_reff_major:
+        z_cModel_dev_reff_minor:
+        z_cModel_dev_theta:
+        z_cModel_exp_reff_major:
+        z_cModel_exp_reff_minor:
+        z_cModel_exp_theta:
+        z_cModel_chi2:
+        z_cModel_devFlux:
+        z_cModel_devFluxErr:
+        z_cModel_expFlux:
+        z_cModel_expFluxErr:
+        z_moments_g1:
+        z_moments_g2:
+        z_moments_trace:
+        z_moments_flag:
+        z_moments_psf_g1:
+        z_moments_psf_g2:
+        z_moments_psf_trace:
+        z_moments_psf_flag:
+        z_moments_psf_debiased_g1:
+        z_moments_psf_debiased_g2:
+        z_moments_psf_debiased_trace:
+        z_moments_psf_debiased_flag:
+        z_hsmShapeRegauss_e1:
+        z_hsmShapeRegauss_e2:
+        z_hsmShapeRegauss_sigma:
+        z_hsmShapeRegauss_flag:
+        z_hsm_moments_30:
+        z_hsm_momentsPsf_30:
+        z_hsm_moments_21:
+        z_hsm_momentsPsf_21:
+        z_hsm_moments_12:
+        z_hsm_momentsPsf_12:
+        z_hsm_moments_03:
+        z_hsm_momentsPsf_03:
+        z_hsm_moments_40:
+        z_hsm_momentsPsf_40:
+        z_hsm_moments_31:
+        z_hsm_momentsPsf_31:
+        z_hsm_moments_22:
+        z_hsm_momentsPsf_22:
+        z_hsm_moments_13:
+        z_hsm_momentsPsf_13:
+        z_hsm_moments_04:
+        z_hsm_momentsPsf_04:
+        z_hsm_moments_flag:
+        z_hsm_momentsPsf_flag:
+        z_inputCount:
+        z_deblend_dataCoverage:
+        z_deblend_blendedness:
+        z_deblend_fluxOverlap:
+        z_deblend_fluxOverlapFraction:
+        z_deblend_zeroFlux:
+        z_psfModel_TwoGaussian_gauss1_sigma_x:
+        z_psfModel_TwoGaussian_gauss1_sigma_y:
+        z_psfModel_TwoGaussian_gauss1_rho:
+        z_psfModel_TwoGaussian_gauss1_fluxfrac:
+        z_psfModel_TwoGaussian_gauss2_sigma_x:
+        z_psfModel_TwoGaussian_gauss2_sigma_y:
+        z_psfModel_TwoGaussian_gauss2_rho:
+        z_psfModel_TwoGaussian_n_iter:
+        z_psfModel_TwoGaussian_chi2_reduced:
+        z_psfModel_TwoGaussian_unknown_flag:
+        z_psfModel_TwoGaussian_no_inputs_flag:
+        z_inputCount_flag:
+        z_inputCount_flag_noInputs:
+        z_psfFlux_area:
+        z_psfFlux_flag:
+        z_psfFlux_flag_apCorr:
+        z_psfFlux_flag_edge:
+        z_psfFlux_flag_noGoodPixels:
+        z_cModel_flag:
+        z_cModel_flag_apCorr:
+        z_gaapFlux_flag:
+        z_gaapFlux_flag_edge:
+        z_blendedness_flag:
+        z_pixelFlags_bad:
+        z_pixelFlags_clipped:
+        z_pixelFlags_clippedCenter:
+        z_pixelFlags_cr:
+        z_pixelFlags_crCenter:
+        z_pixelFlags_edge:
+        z_pixelFlags_inexact_psf:
+        z_pixelFlags_inexact_psfCenter:
+        z_pixelFlags_interpolated:
+        z_pixelFlags_interpolatedCenter:
+        z_pixelFlags_nodata:
+        z_pixelFlags_offimage:
+        z_pixelFlags_saturated:
+        z_pixelFlags_saturatedCenter:
+        z_pixelFlags_sensor_edge:
+        z_pixelFlags_sensor_edgeCenter:
+        z_pixelFlags_suspect:
+        z_pixelFlags_suspectCenter:
+        z_extendedness_flag:
+        z_sizeExtendedness_flag:
+        z_invalidPsfFlag:
+        z_calib_astrometry_used:
+        z_calib_photometry_used:
+        z_calib_psf_candidate:
+        z_calib_psf_reserved:
+        z_calib_psf_used:
+        z_apFlux_flag:
+        z_apFlux_flag_apertureTruncated:
+        z_apFlux_flag_sincCoeffsTruncated:
+        z_centroid_flag:
+        z_kronFlux_flag:
+        z_kronFlux_flag_bad_radius:
+        z_kronFlux_flag_bad_shape:
+        z_kronFlux_flag_bad_shape_no_psf:
+        z_kronFlux_flag_edge:
+        z_kronFlux_flag_no_fallback_radius:
+        z_kronFlux_flag_no_minimum_radius:
+        z_kronFlux_flag_small_radius:
+        z_kronFlux_flag_used_minimum_radius:
+        z_kronFlux_flag_used_psf_radius:
+        u_ra:
+        u_dec:
+        u_raErr:
+        u_decErr:
+        u_ra_dec_Cov:
+        u_psfFlux:
+        u_psfFluxErr:
+        u_psfMag:
+        u_psfMagErr:
+        u_free_psfFlux:
+        u_free_psfFluxErr:
+        u_free_psfFlux_flag:
+        u_cModel_dev_reff_major:
+        u_cModel_dev_reff_minor:
+        u_cModel_dev_theta:
+        u_cModel_exp_reff_major:
+        u_cModel_exp_reff_minor:
+        u_cModel_exp_theta:
+        u_cModel_chi2:
+        u_cModel_devFlux:
+        u_cModel_devFluxErr:
+        u_cModel_expFlux:
+        u_cModel_expFluxErr:
+        u_gaapPsfFlux:
+        u_gaapPsfFluxErr:
+        u_gaap0p7Flux:
+        u_gaap0p7FluxErr:
+        u_gaap1p0Flux:
+        u_gaap1p0FluxErr:
+        u_ixx:
+        u_iyy:
+        u_ixy:
+        u_i_flag:
+        u_ixxPSF:
+        u_iyyPSF:
+        u_ixyPSF:
+        u_iPSF_flag:
+        u_kronRad:
+        u_kronFlux:
+        u_kronFluxErr:
+        u_ap03Flux:
+        u_ap03FluxErr:
+        u_ap03Flux_flag:
+        u_ap06Flux:
+        u_ap06FluxErr:
+        u_ap06Flux_flag:
+        u_ap09Flux:
+        u_ap09FluxErr:
+        u_ap09Flux_flag:
+        u_ap12Flux:
+        u_ap12FluxErr:
+        u_ap12Flux_flag:
+        u_ap17Flux:
+        u_ap17FluxErr:
+        u_ap17Flux_flag:
+        u_ap25Flux:
+        u_ap25FluxErr:
+        u_ap25Flux_flag:
+        u_ap35Flux:
+        u_ap35FluxErr:
+        u_ap35Flux_flag:
+        u_ap50Flux:
+        u_ap50FluxErr:
+        u_ap50Flux_flag:
+        u_ap70Flux:
+        u_ap70FluxErr:
+        u_ap70Flux_flag:
+        u_extendedness:
+        u_sizeExtendedness:
+        u_model_extendedness:
+        u_blendedness:
+        u_cModelFlux:
+        u_cModelFluxErr:
+        u_cModelMag:
+        u_cModelMagErr:
+        u_cModelFlux_inner:
+        u_cModel_fracDev:
+        u_free_cModelFlux:
+        u_free_cModelFluxErr:
+        u_free_cModelFlux_inner:
+        u_free_cModel_fracDev:
+        u_free_cModelFlux_flag:
+        u_free_cModel_devFlux:
+        u_free_cModel_devFluxErr:
+        u_free_cModel_expFlux:
+        u_free_cModel_expFluxErr:
+        u_moments_g1:
+        u_moments_g2:
+        u_moments_trace:
+        u_moments_flag:
+        u_moments_psf_g1:
+        u_moments_psf_g2:
+        u_moments_psf_trace:
+        u_moments_psf_flag:
+        u_moments_psf_debiased_g1:
+        u_moments_psf_debiased_g2:
+        u_moments_psf_debiased_trace:
+        u_moments_psf_debiased_flag:
+        u_hsmShapeRegauss_e1:
+        u_hsmShapeRegauss_e2:
+        u_hsmShapeRegauss_sigma:
+        u_hsmShapeRegauss_flag:
+        u_hsm_moments_30:
+        u_hsm_momentsPsf_30:
+        u_hsm_moments_21:
+        u_hsm_momentsPsf_21:
+        u_hsm_moments_12:
+        u_hsm_momentsPsf_12:
+        u_hsm_moments_03:
+        u_hsm_momentsPsf_03:
+        u_hsm_moments_40:
+        u_hsm_momentsPsf_40:
+        u_hsm_moments_31:
+        u_hsm_momentsPsf_31:
+        u_hsm_moments_22:
+        u_hsm_momentsPsf_22:
+        u_hsm_moments_13:
+        u_hsm_momentsPsf_13:
+        u_hsm_moments_04:
+        u_hsm_momentsPsf_04:
+        u_hsm_moments_flag:
+        u_hsm_momentsPsf_flag:
+        u_inputCount:
+        u_deblend_dataCoverage:
+        u_deblend_blendedness:
+        u_deblend_fluxOverlap:
+        u_deblend_fluxOverlapFraction:
+        u_deblend_zeroFlux:
+        u_psfModel_TwoGaussian_gauss1_sigma_x:
+        u_psfModel_TwoGaussian_gauss1_sigma_y:
+        u_psfModel_TwoGaussian_gauss1_rho:
+        u_psfModel_TwoGaussian_gauss1_fluxfrac:
+        u_psfModel_TwoGaussian_gauss2_sigma_x:
+        u_psfModel_TwoGaussian_gauss2_sigma_y:
+        u_psfModel_TwoGaussian_gauss2_rho:
+        u_psfModel_TwoGaussian_n_iter:
+        u_psfModel_TwoGaussian_chi2_reduced:
+        u_psfModel_TwoGaussian_unknown_flag:
+        u_psfModel_TwoGaussian_no_inputs_flag:
+        u_inputCount_flag:
+        u_inputCount_flag_noInputs:
+        u_psfFlux_area:
+        u_psfFlux_flag:
+        u_psfFlux_flag_apCorr:
+        u_psfFlux_flag_edge:
+        u_psfFlux_flag_noGoodPixels:
+        u_cModel_flag:
+        u_cModel_flag_apCorr:
+        u_gaapFlux_flag:
+        u_gaapFlux_flag_edge:
+        u_blendedness_flag:
+        u_pixelFlags_bad:
+        u_pixelFlags_clipped:
+        u_pixelFlags_clippedCenter:
+        u_pixelFlags_cr:
+        u_pixelFlags_crCenter:
+        u_pixelFlags_edge:
+        u_pixelFlags_inexact_psf:
+        u_pixelFlags_inexact_psfCenter:
+        u_pixelFlags_interpolated:
+        u_pixelFlags_interpolatedCenter:
+        u_pixelFlags_nodata:
+        u_pixelFlags_offimage:
+        u_pixelFlags_saturated:
+        u_pixelFlags_saturatedCenter:
+        u_pixelFlags_sensor_edge:
+        u_pixelFlags_sensor_edgeCenter:
+        u_pixelFlags_suspect:
+        u_pixelFlags_suspectCenter:
+        u_extendedness_flag:
+        u_sizeExtendedness_flag:
+        u_invalidPsfFlag:
+        u_calib_astrometry_used:
+        u_calib_photometry_used:
+        u_calib_psf_candidate:
+        u_calib_psf_reserved:
+        u_calib_psf_used:
+        u_apFlux_flag:
+        u_apFlux_flag_apertureTruncated:
+        u_apFlux_flag_sincCoeffsTruncated:
+        u_centroid_flag:
+        u_kronFlux_flag:
+        u_kronFlux_flag_bad_radius:
+        u_kronFlux_flag_bad_shape:
+        u_kronFlux_flag_bad_shape_no_psf:
+        u_kronFlux_flag_edge:
+        u_kronFlux_flag_no_fallback_radius:
+        u_kronFlux_flag_no_minimum_radius:
+        u_kronFlux_flag_small_radius:
+        u_kronFlux_flag_used_minimum_radius:
+        u_kronFlux_flag_used_psf_radius:
+        g_ra:
+        g_dec:
+        g_raErr:
+        g_decErr:
+        g_ra_dec_Cov:
+        g_psfFlux:
+        g_psfFluxErr:
+        g_psfMag:
+        g_psfMagErr:
+        g_free_psfFlux:
+        g_free_psfFluxErr:
+        g_free_psfFlux_flag:
+        g_cModel_dev_reff_major:
+        g_cModel_dev_reff_minor:
+        g_cModel_dev_theta:
+        g_cModel_exp_reff_major:
+        g_cModel_exp_reff_minor:
+        g_cModel_exp_theta:
+        g_cModel_chi2:
+        g_cModel_devFlux:
+        g_cModel_devFluxErr:
+        g_cModel_expFlux:
+        g_cModel_expFluxErr:
+        g_gaapPsfFlux:
+        g_gaapPsfFluxErr:
+        g_gaap0p7Flux:
+        g_gaap0p7FluxErr:
+        g_gaap1p0Flux:
+        g_gaap1p0FluxErr:
+        g_ixx:
+        g_iyy:
+        g_ixy:
+        g_i_flag:
+        g_ixxPSF:
+        g_iyyPSF:
+        g_ixyPSF:
+        g_iPSF_flag:
+        g_kronRad:
+        g_kronFlux:
+        g_kronFluxErr:
+        g_ap03Flux:
+        g_ap03FluxErr:
+        g_ap03Flux_flag:
+        g_ap06Flux:
+        g_ap06FluxErr:
+        g_ap06Flux_flag:
+        g_ap09Flux:
+        g_ap09FluxErr:
+        g_ap09Flux_flag:
+        g_ap12Flux:
+        g_ap12FluxErr:
+        g_ap12Flux_flag:
+        g_ap17Flux:
+        g_ap17FluxErr:
+        g_ap17Flux_flag:
+        g_ap25Flux:
+        g_ap25FluxErr:
+        g_ap25Flux_flag:
+        g_ap35Flux:
+        g_ap35FluxErr:
+        g_ap35Flux_flag:
+        g_ap50Flux:
+        g_ap50FluxErr:
+        g_ap50Flux_flag:
+        g_ap70Flux:
+        g_ap70FluxErr:
+        g_ap70Flux_flag:
+        g_extendedness:
+        g_sizeExtendedness:
+        g_model_extendedness:
+        griz_model_extendedness:
+        g_blendedness:
+        g_cModelFlux:
+        g_cModelFluxErr:
+        g_cModelMag:
+        g_cModelMagErr:
+        g_cModelFlux_inner:
+        g_cModel_fracDev:
+        g_free_cModelFlux:
+        g_free_cModelFluxErr:
+        g_free_cModelFlux_inner:
+        g_free_cModel_fracDev:
+        g_free_cModelFlux_flag:
+        g_free_cModel_devFlux:
+        g_free_cModel_devFluxErr:
+        g_free_cModel_expFlux:
+        g_free_cModel_expFluxErr:
+        g_moments_g1:
+        g_moments_g2:
+        g_moments_trace:
+        g_moments_flag:
+        g_moments_psf_g1:
+        g_moments_psf_g2:
+        g_moments_psf_trace:
+        g_moments_psf_flag:
+        g_moments_psf_debiased_g1:
+        g_moments_psf_debiased_g2:
+        g_moments_psf_debiased_trace:
+        g_moments_psf_debiased_flag:
+        g_hsmShapeRegauss_e1:
+        g_hsmShapeRegauss_e2:
+        g_hsmShapeRegauss_sigma:
+        g_hsmShapeRegauss_flag:
+        g_hsm_moments_30:
+        g_hsm_momentsPsf_30:
+        g_hsm_moments_21:
+        g_hsm_momentsPsf_21:
+        g_hsm_moments_12:
+        g_hsm_momentsPsf_12:
+        g_hsm_moments_03:
+        g_hsm_momentsPsf_03:
+        g_hsm_moments_40:
+        g_hsm_momentsPsf_40:
+        g_hsm_moments_31:
+        g_hsm_momentsPsf_31:
+        g_hsm_moments_22:
+        g_hsm_momentsPsf_22:
+        g_hsm_moments_13:
+        g_hsm_momentsPsf_13:
+        g_hsm_moments_04:
+        g_hsm_momentsPsf_04:
+        g_hsm_moments_flag:
+        g_hsm_momentsPsf_flag:
+        g_inputCount:
+        g_deblend_dataCoverage:
+        g_deblend_blendedness:
+        g_deblend_fluxOverlap:
+        g_deblend_fluxOverlapFraction:
+        g_deblend_zeroFlux:
+        g_psfModel_TwoGaussian_gauss1_sigma_x:
+        g_psfModel_TwoGaussian_gauss1_sigma_y:
+        g_psfModel_TwoGaussian_gauss1_rho:
+        g_psfModel_TwoGaussian_gauss1_fluxfrac:
+        g_psfModel_TwoGaussian_gauss2_sigma_x:
+        g_psfModel_TwoGaussian_gauss2_sigma_y:
+        g_psfModel_TwoGaussian_gauss2_rho:
+        g_psfModel_TwoGaussian_n_iter:
+        g_psfModel_TwoGaussian_chi2_reduced:
+        g_psfModel_TwoGaussian_unknown_flag:
+        g_psfModel_TwoGaussian_no_inputs_flag:
+        g_inputCount_flag:
+        g_inputCount_flag_noInputs:
+        g_psfFlux_area:
+        g_psfFlux_flag:
+        g_psfFlux_flag_apCorr:
+        g_psfFlux_flag_edge:
+        g_psfFlux_flag_noGoodPixels:
+        g_cModel_flag:
+        g_cModel_flag_apCorr:
+        g_gaapFlux_flag:
+        g_gaapFlux_flag_edge:
+        g_blendedness_flag:
+        g_pixelFlags_bad:
+        g_pixelFlags_clipped:
+        g_pixelFlags_clippedCenter:
+        g_pixelFlags_cr:
+        g_pixelFlags_crCenter:
+        g_pixelFlags_edge:
+        g_pixelFlags_inexact_psf:
+        g_pixelFlags_inexact_psfCenter:
+        g_pixelFlags_interpolated:
+        g_pixelFlags_interpolatedCenter:
+        g_pixelFlags_nodata:
+        g_pixelFlags_offimage:
+        g_pixelFlags_saturated:
+        g_pixelFlags_saturatedCenter:
+        g_pixelFlags_sensor_edge:
+        g_pixelFlags_sensor_edgeCenter:
+        g_pixelFlags_suspect:
+        g_pixelFlags_suspectCenter:
+        g_extendedness_flag:
+        g_sizeExtendedness_flag:
+        g_invalidPsfFlag:
+        g_calib_astrometry_used:
+        g_calib_photometry_used:
+        g_calib_psf_candidate:
+        g_calib_psf_reserved:
+        g_calib_psf_used:
+        g_apFlux_flag:
+        g_apFlux_flag_apertureTruncated:
+        g_apFlux_flag_sincCoeffsTruncated:
+        g_centroid_flag:
+        g_kronFlux_flag:
+        g_kronFlux_flag_bad_radius:
+        g_kronFlux_flag_bad_shape:
+        g_kronFlux_flag_bad_shape_no_psf:
+        g_kronFlux_flag_edge:
+        g_kronFlux_flag_no_fallback_radius:
+        g_kronFlux_flag_no_minimum_radius:
+        g_kronFlux_flag_small_radius:
+        g_kronFlux_flag_used_minimum_radius:
+        g_kronFlux_flag_used_psf_radius:
+        r_ra:
+        r_dec:
+        r_raErr:
+        r_decErr:
+        r_ra_dec_Cov:
+        r_psfFlux:
+        r_psfFluxErr:
+        r_psfMag:
+        r_psfMagErr:
+        r_free_psfFlux:
+        r_free_psfFluxErr:
+        r_free_psfFlux_flag:
+        r_cModel_dev_reff_major:
+        r_cModel_dev_reff_minor:
+        r_cModel_dev_theta:
+        r_cModel_exp_reff_major:
+        r_cModel_exp_reff_minor:
+        r_cModel_exp_theta:
+        r_cModel_chi2:
+        r_cModel_devFlux:
+        r_cModel_devFluxErr:
+        r_cModel_expFlux:
+        r_cModel_expFluxErr:
+        r_gaapPsfFlux:
+        r_gaapPsfFluxErr:
+        r_gaap0p7Flux:
+        r_gaap0p7FluxErr:
+        r_gaap1p0Flux:
+        r_gaap1p0FluxErr:
+        r_ixx:
+        r_iyy:
+        r_ixy:
+        r_i_flag:
+        r_ixxPSF:
+        r_iyyPSF:
+        r_ixyPSF:
+        r_iPSF_flag:
+        r_kronRad:
+        r_kronFlux:
+        r_kronFluxErr:
+        r_ap03Flux:
+        r_ap03FluxErr:
+        r_ap03Flux_flag:
+        r_ap06Flux:
+        r_ap06FluxErr:
+        r_ap06Flux_flag:
+        r_ap09Flux:
+        r_ap09FluxErr:
+        r_ap09Flux_flag:
+        r_ap12Flux:
+        r_ap12FluxErr:
+        r_ap12Flux_flag:
+        r_ap17Flux:
+        r_ap17FluxErr:
+        r_ap17Flux_flag:
+        r_ap25Flux:
+        r_ap25FluxErr:
+        r_ap25Flux_flag:
+        r_ap35Flux:
+        r_ap35FluxErr:
+        r_ap35Flux_flag:
+        r_ap50Flux:
+        r_ap50FluxErr:
+        r_ap50Flux_flag:
+        r_ap70Flux:
+        r_ap70FluxErr:
+        r_ap70Flux_flag:
+        r_extendedness:
+        r_sizeExtendedness:
+        r_model_extendedness:
+        r_blendedness:
+        r_cModelFlux:
+        r_cModelFluxErr:
+        r_cModelMag:
+        r_cModelMagErr:
+        r_cModelFlux_inner:
+        r_cModel_fracDev:
+        r_free_cModelFlux:
+        r_free_cModelFluxErr:
+        r_free_cModelFlux_inner:
+        r_free_cModel_fracDev:
+        r_free_cModelFlux_flag:
+        r_free_cModel_devFlux:
+        r_free_cModel_devFluxErr:
+        r_free_cModel_expFlux:
+        r_free_cModel_expFluxErr:
+        r_moments_g1:
+        r_moments_g2:
+        r_moments_trace:
+        r_moments_flag:
+        r_moments_psf_g1:
+        r_moments_psf_g2:
+        r_moments_psf_trace:
+        r_moments_psf_flag:
+        r_moments_psf_debiased_g1:
+        r_moments_psf_debiased_g2:
+        r_moments_psf_debiased_trace:
+        r_moments_psf_debiased_flag:
+        r_hsmShapeRegauss_e1:
+        r_hsmShapeRegauss_e2:
+        r_hsmShapeRegauss_sigma:
+        r_hsmShapeRegauss_flag:
+        r_hsm_moments_30:
+        r_hsm_momentsPsf_30:
+        r_hsm_moments_21:
+        r_hsm_momentsPsf_21:
+        r_hsm_moments_12:
+        r_hsm_momentsPsf_12:
+        r_hsm_moments_03:
+        r_hsm_momentsPsf_03:
+        r_hsm_moments_40:
+        r_hsm_momentsPsf_40:
+        r_hsm_moments_31:
+        r_hsm_momentsPsf_31:
+        r_hsm_moments_22:
+        r_hsm_momentsPsf_22:
+        r_hsm_moments_13:
+        r_hsm_momentsPsf_13:
+        r_hsm_moments_04:
+        r_hsm_momentsPsf_04:
+        r_hsm_moments_flag:
+        r_hsm_momentsPsf_flag:
+        r_inputCount:
+        r_deblend_dataCoverage:
+        r_deblend_blendedness:
+        r_deblend_fluxOverlap:
+        r_deblend_fluxOverlapFraction:
+        r_deblend_zeroFlux:
+        r_psfModel_TwoGaussian_gauss1_sigma_x:
+        r_psfModel_TwoGaussian_gauss1_sigma_y:
+        r_psfModel_TwoGaussian_gauss1_rho:
+        r_psfModel_TwoGaussian_gauss1_fluxfrac:
+        r_psfModel_TwoGaussian_gauss2_sigma_x:
+        r_psfModel_TwoGaussian_gauss2_sigma_y:
+        r_psfModel_TwoGaussian_gauss2_rho:
+        r_psfModel_TwoGaussian_n_iter:
+        r_psfModel_TwoGaussian_chi2_reduced:
+        r_psfModel_TwoGaussian_unknown_flag:
+        r_psfModel_TwoGaussian_no_inputs_flag:
+        r_inputCount_flag:
+        r_inputCount_flag_noInputs:
+        r_psfFlux_area:
+        r_psfFlux_flag:
+        r_psfFlux_flag_apCorr:
+        r_psfFlux_flag_edge:
+        r_psfFlux_flag_noGoodPixels:
+        r_cModel_flag:
+        r_cModel_flag_apCorr:
+        r_gaapFlux_flag:
+        r_gaapFlux_flag_edge:
+        r_blendedness_flag:
+        r_pixelFlags_bad:
+        r_pixelFlags_clipped:
+        r_pixelFlags_clippedCenter:
+        r_pixelFlags_cr:
+        r_pixelFlags_crCenter:
+        r_pixelFlags_edge:
+        r_pixelFlags_inexact_psf:
+        r_pixelFlags_inexact_psfCenter:
+        r_pixelFlags_interpolated:
+        r_pixelFlags_interpolatedCenter:
+        r_pixelFlags_nodata:
+        r_pixelFlags_offimage:
+        r_pixelFlags_saturated:
+        r_pixelFlags_saturatedCenter:
+        r_pixelFlags_sensor_edge:
+        r_pixelFlags_sensor_edgeCenter:
+        r_pixelFlags_suspect:
+        r_pixelFlags_suspectCenter:
+        r_extendedness_flag:
+        r_sizeExtendedness_flag:
+        r_invalidPsfFlag:
+        r_calib_astrometry_used:
+        r_calib_photometry_used:
+        r_calib_psf_candidate:
+        r_calib_psf_reserved:
+        r_calib_psf_used:
+        r_apFlux_flag:
+        r_apFlux_flag_apertureTruncated:
+        r_apFlux_flag_sincCoeffsTruncated:
+        r_centroid_flag:
+        r_kronFlux_flag:
+        r_kronFlux_flag_bad_radius:
+        r_kronFlux_flag_bad_shape:
+        r_kronFlux_flag_bad_shape_no_psf:
+        r_kronFlux_flag_edge:
+        r_kronFlux_flag_no_fallback_radius:
+        r_kronFlux_flag_no_minimum_radius:
+        r_kronFlux_flag_small_radius:
+        r_kronFlux_flag_used_minimum_radius:
+        r_kronFlux_flag_used_psf_radius:
+        i_ra:
+        i_dec:
+        i_raErr:
+        i_decErr:
+        i_ra_dec_Cov:
+        i_psfFlux:
+        i_psfFluxErr:
+        i_psfMag:
+        i_psfMagErr:
+        i_free_psfFlux:
+        i_free_psfFluxErr:
+        i_free_psfFlux_flag:
+        i_cModel_dev_reff_major:
+        i_cModel_dev_reff_minor:
+        i_cModel_dev_theta:
+        i_cModel_exp_reff_major:
+        i_cModel_exp_reff_minor:
+        i_cModel_exp_theta:
+        i_cModel_chi2:
+        i_cModel_devFlux:
+        i_cModel_devFluxErr:
+        i_cModel_expFlux:
+        i_cModel_expFluxErr:
+        i_gaapPsfFlux:
+        i_gaapPsfFluxErr:
+        i_gaap0p7Flux:
+        i_gaap0p7FluxErr:
+        i_gaap1p0Flux:
+        i_gaap1p0FluxErr:
+        i_ixx:
+        i_iyy:
+        i_ixy:
+        i_i_flag:
+        i_ixxPSF:
+        i_iyyPSF:
+        i_ixyPSF:
+        i_iPSF_flag:
+        i_kronRad:
+        i_kronFlux:
+        i_kronFluxErr:
+        i_ap03Flux:
+        i_ap03FluxErr:
+        i_ap03Flux_flag:
+        i_ap06Flux:
+        i_ap06FluxErr:
+        i_ap06Flux_flag:
+        i_ap09Flux:
+        i_ap09FluxErr:
+        i_ap09Flux_flag:
+        i_ap12Flux:
+        i_ap12FluxErr:
+        i_ap12Flux_flag:
+        i_ap17Flux:
+        i_ap17FluxErr:
+        i_ap17Flux_flag:
+        i_ap25Flux:
+        i_ap25FluxErr:
+        i_ap25Flux_flag:
+        i_ap35Flux:
+        i_ap35FluxErr:
+        i_ap35Flux_flag:
+        i_ap50Flux:
+        i_ap50FluxErr:
+        i_ap50Flux_flag:
+        i_ap70Flux:
+        i_ap70FluxErr:
+        i_ap70Flux_flag:
+        i_extendedness:
+        i_sizeExtendedness:
+        i_model_extendedness:
+        i_blendedness:
+        i_cModelFlux:
+        i_cModelFluxErr:
+        i_cModelMag:
+        i_cModelMagErr:
+        i_cModelFlux_inner:
+        i_cModel_fracDev:
+        i_free_cModelFlux:
+        i_free_cModelFluxErr:
+        i_free_cModelFlux_inner:
+        i_free_cModel_fracDev:
+        i_free_cModelFlux_flag:
+        i_free_cModel_devFlux:
+        i_free_cModel_devFluxErr:
+        i_free_cModel_expFlux:
+        i_free_cModel_expFluxErr:
+        i_moments_g1:
+        i_moments_g2:
+        i_moments_trace:
+        i_moments_flag:
+        i_moments_psf_g1:
+        i_moments_psf_g2:
+        i_moments_psf_trace:
+        i_moments_psf_flag:
+        i_moments_psf_debiased_g1:
+        i_moments_psf_debiased_g2:
+        i_moments_psf_debiased_trace:
+        i_moments_psf_debiased_flag:
+        i_hsmShapeRegauss_e1:
+        i_hsmShapeRegauss_e2:
+        i_hsmShapeRegauss_sigma:
+        i_hsmShapeRegauss_flag:
+        i_hsm_moments_30:
+        i_hsm_momentsPsf_30:
+        i_hsm_moments_21:
+        i_hsm_momentsPsf_21:
+        i_hsm_moments_12:
+        i_hsm_momentsPsf_12:
+        i_hsm_moments_03:
+        i_hsm_momentsPsf_03:
+        i_hsm_moments_40:
+        i_hsm_momentsPsf_40:
+        i_hsm_moments_31:
+        i_hsm_momentsPsf_31:
+        i_hsm_moments_22:
+        i_hsm_momentsPsf_22:
+        i_hsm_moments_13:
+        i_hsm_momentsPsf_13:
+        i_hsm_moments_04:
+        i_hsm_momentsPsf_04:
+        i_hsm_moments_flag:
+        i_hsm_momentsPsf_flag:
+        i_inputCount:
+        i_deblend_dataCoverage:
+        i_deblend_blendedness:
+        i_deblend_fluxOverlap:
+        i_deblend_fluxOverlapFraction:
+        i_deblend_zeroFlux:
+        i_psfModel_TwoGaussian_gauss1_sigma_x:
+        i_psfModel_TwoGaussian_gauss1_sigma_y:
+        i_psfModel_TwoGaussian_gauss1_rho:
+        i_psfModel_TwoGaussian_gauss1_fluxfrac:
+        i_psfModel_TwoGaussian_gauss2_sigma_x:
+        i_psfModel_TwoGaussian_gauss2_sigma_y:
+        i_psfModel_TwoGaussian_gauss2_rho:
+        i_psfModel_TwoGaussian_n_iter:
+        i_psfModel_TwoGaussian_chi2_reduced:
+        i_psfModel_TwoGaussian_unknown_flag:
+        i_psfModel_TwoGaussian_no_inputs_flag:
+        i_inputCount_flag:
+        i_inputCount_flag_noInputs:
+        i_psfFlux_area:
+        i_psfFlux_flag:
+        i_psfFlux_flag_apCorr:
+        i_psfFlux_flag_edge:
+        i_psfFlux_flag_noGoodPixels:
+        i_cModel_flag:
+        i_cModel_flag_apCorr:
+        i_gaapFlux_flag:
+        i_gaapFlux_flag_edge:
+        i_blendedness_flag:
+        i_pixelFlags_bad:
+        i_pixelFlags_clipped:
+        i_pixelFlags_clippedCenter:
+        i_pixelFlags_cr:
+        i_pixelFlags_crCenter:
+        i_pixelFlags_edge:
+        i_pixelFlags_inexact_psf:
+        i_pixelFlags_inexact_psfCenter:
+        i_pixelFlags_interpolated:
+        i_pixelFlags_interpolatedCenter:
+        i_pixelFlags_nodata:
+        i_pixelFlags_offimage:
+        i_pixelFlags_saturated:
+        i_pixelFlags_saturatedCenter:
+        i_pixelFlags_sensor_edge:
+        i_pixelFlags_sensor_edgeCenter:
+        i_pixelFlags_suspect:
+        i_pixelFlags_suspectCenter:
+        i_extendedness_flag:
+        i_sizeExtendedness_flag:
+        i_invalidPsfFlag:
+        i_calib_astrometry_used:
+        i_calib_photometry_used:
+        i_calib_psf_candidate:
+        i_calib_psf_reserved:
+        i_calib_psf_used:
+        i_apFlux_flag:
+        i_apFlux_flag_apertureTruncated:
+        i_apFlux_flag_sincCoeffsTruncated:
+        i_centroid_flag:
+        i_kronFlux_flag:
+        i_kronFlux_flag_bad_radius:
+        i_kronFlux_flag_bad_shape:
+        i_kronFlux_flag_bad_shape_no_psf:
+        i_kronFlux_flag_edge:
+        i_kronFlux_flag_no_fallback_radius:
+        i_kronFlux_flag_no_minimum_radius:
+        i_kronFlux_flag_small_radius:
+        i_kronFlux_flag_used_minimum_radius:
+        i_kronFlux_flag_used_psf_radius:
+        y_ra:
+        y_dec:
+        y_raErr:
+        y_decErr:
+        y_ra_dec_Cov:
+        y_psfFlux:
+        y_psfFluxErr:
+        y_psfMag:
+        y_psfMagErr:
+        y_free_psfFlux:
+        y_free_psfFluxErr:
+        y_free_psfFlux_flag:
+        y_cModel_dev_reff_major:
+        y_cModel_dev_reff_minor:
+        y_cModel_dev_theta:
+        y_cModel_exp_reff_major:
+        y_cModel_exp_reff_minor:
+        y_cModel_exp_theta:
+        y_cModel_chi2:
+        y_cModel_devFlux:
+        y_cModel_devFluxErr:
+        y_cModel_expFlux:
+        y_cModel_expFluxErr:
+        y_gaapPsfFlux:
+        y_gaapPsfFluxErr:
+        y_gaap0p7Flux:
+        y_gaap0p7FluxErr:
+        y_gaap1p0Flux:
+        y_gaap1p0FluxErr:
+        y_ixx:
+        y_iyy:
+        y_ixy:
+        y_i_flag:
+        y_ixxPSF:
+        y_iyyPSF:
+        y_ixyPSF:
+        y_iPSF_flag:
+        y_kronRad:
+        y_kronFlux:
+        y_kronFluxErr:
+        y_ap03Flux:
+        y_ap03FluxErr:
+        y_ap03Flux_flag:
+        y_ap06Flux:
+        y_ap06FluxErr:
+        y_ap06Flux_flag:
+        y_ap09Flux:
+        y_ap09FluxErr:
+        y_ap09Flux_flag:
+        y_ap12Flux:
+        y_ap12FluxErr:
+        y_ap12Flux_flag:
+        y_ap17Flux:
+        y_ap17FluxErr:
+        y_ap17Flux_flag:
+        y_ap25Flux:
+        y_ap25FluxErr:
+        y_ap25Flux_flag:
+        y_ap35Flux:
+        y_ap35FluxErr:
+        y_ap35Flux_flag:
+        y_ap50Flux:
+        y_ap50FluxErr:
+        y_ap50Flux_flag:
+        y_ap70Flux:
+        y_ap70FluxErr:
+        y_ap70Flux_flag:
+        y_extendedness:
+        y_sizeExtendedness:
+        y_model_extendedness:
+        y_blendedness:
+        y_cModelFlux:
+        y_cModelFluxErr:
+        y_cModelMag:
+        y_cModelMagErr:
+        y_cModelFlux_inner:
+        y_cModel_fracDev:
+        y_free_cModelFlux:
+        y_free_cModelFluxErr:
+        y_free_cModelFlux_inner:
+        y_free_cModel_fracDev:
+        y_free_cModelFlux_flag:
+        y_free_cModel_devFlux:
+        y_free_cModel_devFluxErr:
+        y_free_cModel_expFlux:
+        y_free_cModel_expFluxErr:
+        y_moments_g1:
+        y_moments_g2:
+        y_moments_trace:
+        y_moments_flag:
+        y_moments_psf_g1:
+        y_moments_psf_g2:
+        y_moments_psf_trace:
+        y_moments_psf_flag:
+        y_moments_psf_debiased_g1:
+        y_moments_psf_debiased_g2:
+        y_moments_psf_debiased_trace:
+        y_moments_psf_debiased_flag:
+        y_hsmShapeRegauss_e1:
+        y_hsmShapeRegauss_e2:
+        y_hsmShapeRegauss_sigma:
+        y_hsmShapeRegauss_flag:
+        y_hsm_moments_30:
+        y_hsm_momentsPsf_30:
+        y_hsm_moments_21:
+        y_hsm_momentsPsf_21:
+        y_hsm_moments_12:
+        y_hsm_momentsPsf_12:
+        y_hsm_moments_03:
+        y_hsm_momentsPsf_03:
+        y_hsm_moments_40:
+        y_hsm_momentsPsf_40:
+        y_hsm_moments_31:
+        y_hsm_momentsPsf_31:
+        y_hsm_moments_22:
+        y_hsm_momentsPsf_22:
+        y_hsm_moments_13:
+        y_hsm_momentsPsf_13:
+        y_hsm_moments_04:
+        y_hsm_momentsPsf_04:
+        y_hsm_moments_flag:
+        y_hsm_momentsPsf_flag:
+        y_inputCount:
+        y_deblend_dataCoverage:
+        y_deblend_blendedness:
+        y_deblend_fluxOverlap:
+        y_deblend_fluxOverlapFraction:
+        y_deblend_zeroFlux:
+        y_psfModel_TwoGaussian_gauss1_sigma_x:
+        y_psfModel_TwoGaussian_gauss1_sigma_y:
+        y_psfModel_TwoGaussian_gauss1_rho:
+        y_psfModel_TwoGaussian_gauss1_fluxfrac:
+        y_psfModel_TwoGaussian_gauss2_sigma_x:
+        y_psfModel_TwoGaussian_gauss2_sigma_y:
+        y_psfModel_TwoGaussian_gauss2_rho:
+        y_psfModel_TwoGaussian_n_iter:
+        y_psfModel_TwoGaussian_chi2_reduced:
+        y_psfModel_TwoGaussian_unknown_flag:
+        y_psfModel_TwoGaussian_no_inputs_flag:
+        y_inputCount_flag:
+        y_inputCount_flag_noInputs:
+        y_psfFlux_area:
+        y_psfFlux_flag:
+        y_psfFlux_flag_apCorr:
+        y_psfFlux_flag_edge:
+        y_psfFlux_flag_noGoodPixels:
+        y_cModel_flag:
+        y_cModel_flag_apCorr:
+        y_gaapFlux_flag:
+        y_gaapFlux_flag_edge:
+        y_blendedness_flag:
+        y_pixelFlags_bad:
+        y_pixelFlags_clipped:
+        y_pixelFlags_clippedCenter:
+        y_pixelFlags_cr:
+        y_pixelFlags_crCenter:
+        y_pixelFlags_edge:
+        y_pixelFlags_inexact_psf:
+        y_pixelFlags_inexact_psfCenter:
+        y_pixelFlags_interpolated:
+        y_pixelFlags_interpolatedCenter:
+        y_pixelFlags_nodata:
+        y_pixelFlags_offimage:
+        y_pixelFlags_saturated:
+        y_pixelFlags_saturatedCenter:
+        y_pixelFlags_sensor_edge:
+        y_pixelFlags_sensor_edgeCenter:
+        y_pixelFlags_suspect:
+        y_pixelFlags_suspectCenter:
+        y_extendedness_flag:
+        y_sizeExtendedness_flag:
+        y_invalidPsfFlag:
+        y_calib_astrometry_used:
+        y_calib_photometry_used:
+        y_calib_psf_candidate:
+        y_calib_psf_reserved:
+        y_calib_psf_used:
+        y_apFlux_flag:
+        y_apFlux_flag_apertureTruncated:
+        y_apFlux_flag_sincCoeffsTruncated:
+        y_centroid_flag:
+        y_kronFlux_flag:
+        y_kronFlux_flag_bad_radius:
+        y_kronFlux_flag_bad_shape:
+        y_kronFlux_flag_bad_shape_no_psf:
+        y_kronFlux_flag_edge:
+        y_kronFlux_flag_no_fallback_radius:
+        y_kronFlux_flag_no_minimum_radius:
+        y_kronFlux_flag_small_radius:
+        y_kronFlux_flag_used_minimum_radius:
+        y_kronFlux_flag_used_psf_radius:
+        g_epoch:
+        i_epoch:
+        r_epoch:
+        u_epoch:
+        y_epoch:
+        z_epoch:
+        parentObjectId:
+        coord_ra:
+        coord_dec:
+        coord_raErr:
+        coord_decErr:
+        coord_ra_dec_Cov:
+        coord_flag:
+        refBand:
+        refExtendedness:
+        refSizeExtendedness:
+        footprintArea:
+        ebv:
+        shape_xx:
+        shape_yy:
+        shape_xy:
+        detect_isIsolated:
+        detect_fromBlend:
+        detect_isDeblendedModelSource:
+        deblend_parentNChild:
+        deblend_parentNPeaks:
+        deblend_peak_center_x:
+        deblend_peak_center_y:
+        deblend_chi2:
+        deblend_blendId:
+        deblend_blendNChild:
+        shape_flag:
+        exponential_ra:
+        exponential_raErr:
+        exponential_dec:
+        exponential_decErr:
+        exponential_ra_dec_Cov:
+        exponential_reff_x:
+        exponential_reff_xErr:
+        exponential_reff_y:
+        exponential_reff_yErr:
+        exponential_rho:
+        exponential_rhoErr:
+        exponential_reff_major:
+        exponential_reff_minor:
+        exponential_theta:
+        g_exponentialFlux:
+        g_exponentialFluxErr:
+        i_exponentialFlux:
+        i_exponentialFluxErr:
+        r_exponentialFlux:
+        r_exponentialFluxErr:
+        u_exponentialFlux:
+        u_exponentialFluxErr:
+        y_exponentialFlux:
+        y_exponentialFluxErr:
+        z_exponentialFlux:
+        z_exponentialFluxErr:
+        exponential_n_eval_jac:
+        exponential_n_iter:
+        exponential_chi2_reduced:
+        exponential_delta_lnL_fit_linear:
+        exponential_delta_lnL_fit_ps:
+        exponential_no_data_flag:
+        exponential_unknown_flag:
+        sersic_ra:
+        sersic_raErr:
+        sersic_dec:
+        sersic_decErr:
+        sersic_ra_dec_Cov:
+        sersic_reff_x:
+        sersic_reff_xErr:
+        sersic_reff_y:
+        sersic_reff_yErr:
+        sersic_rho:
+        sersic_rhoErr:
+        sersic_reff_major:
+        sersic_reff_minor:
+        sersic_theta:
+        g_sersicFlux:
+        g_sersicFluxErr:
+        i_sersicFlux:
+        i_sersicFluxErr:
+        r_sersicFlux:
+        r_sersicFluxErr:
+        u_sersicFlux:
+        u_sersicFluxErr:
+        y_sersicFlux:
+        y_sersicFluxErr:
+        z_sersicFlux:
+        z_sersicFluxErr:
+        sersic_index:
+        sersic_indexErr:
+        sersic_n_eval_jac:
+        sersic_n_iter:
+        sersic_chi2_reduced:
+        sersic_unknown_flag:
+        sersic_no_data_flag:
+        objectId:
   indexes:
   - name: idx_Object_objectId
     description: Unique index on objectId column
@@ -4618,561 +1274,165 @@ tables:
     independently of the Object detections on coadded images."
   tap:table_index: 20
   primaryKey: '#Source.sourceId'
-  columns:
-  - name: coord_ra
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
-    ivoa:unit: deg
-  - name: coord_dec
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
-    ivoa:unit: deg
-  - name: parentSourceId
-    description: Unique ID of parent source
-    datatype: long
-  - name: x
-    description: Centroid from Sdss Centroid algorithm
-    datatype: double
-    ivoa:unit: pixel
-  - name: y
-    description: Centroid from Sdss Centroid algorithm
-    datatype: double
-    ivoa:unit: pixel
-  - name: xErr
-    description: 1-sigma uncertainty on x position
-    datatype: float
-    ivoa:unit: pixel
-  - name: yErr
-    description: 1-sigma uncertainty on y position
-    datatype: float
-    ivoa:unit: pixel
-  - name: ra
-    description: Position in right ascension.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: dec
-    description: Position in declination.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: raErr
-    description: Error in right ascension.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-  - name: decErr
-    description: Error in declination.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-  - name: ra_dec_Cov
-    description: Covariance between right ascension and declination.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-  - name: calibFlux
-    description: Flux within 12.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: calibFluxErr
-    description: Flux uncertainty within 12.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap03Flux
-    description: Flux within 3.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap03Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap06Flux
-    description: Flux within 6.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap06Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap09Flux
-    description: Flux within 9.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap09Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap12Flux
-    description: Flux within 12.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap12Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap17Flux
-    description: Flux within 17.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap17Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap25Flux
-    description: Flux within 25.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap25Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap35Flux
-    description: Flux within 35.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap35Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap50Flux
-    description: Flux within 50.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap50Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: ap70Flux
-    description: Flux within 70.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture
-    datatype: double
-    ivoa:unit: nJy
-  - name: ap70Flux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: sky
-    description: Background in annulus around source
-    datatype: double
-    ivoa:unit: nJy
-  - name: skyErr
-    description: Background in annulus around source
-    datatype: double
-    ivoa:unit: nJy
-  - name: psfFlux
-    description: Flux derived from linear least-squares fit of psf model forced on
-      the calexp
-    datatype: double
-    ivoa:unit: nJy
-  - name: psfFluxErr
-    description: Uncertainty on the flux derived from linear least-squares fit of
-      psf model forced on the calexp
-    datatype: double
-    ivoa:unit: nJy
-  - name: ixx
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: iyy
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: ixy
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: ixxPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: iyyPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: ixyPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: ixxDebiasedPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: iyyDebiasedPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: ixyDebiasedPSF
-    description: HSM moments
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: gaussianFlux
-    description: Flux from Gaussian Flux algorithm
-    datatype: double
-    ivoa:unit: nJy
-  - name: gaussianFluxErr
-    description: Flux uncertainty from Gaussian Flux algorithm
-    datatype: double
-    ivoa:unit: nJy
-  - name: extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended (1).
-    datatype: double
-  - name: sizeExtendedness
-    description: Moments-based measure of a source to be a galaxy.
-    datatype: double
-  - name: blendedness_abs
-    description: Measure of how much the flux is affected by neighbors, (1 - child_flux/parent_flux).  Operates
-      on the absolute value of the pixels to try to obtain a de-noised value.  See
-      section 4.9.11 of Bosch et al. 2018, PASJ, 70, S5 for details.
-    datatype: double
-  - name: blendedness_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: blendedness_flag_noCentroid
-    description: Object has no centroid
-    datatype: boolean
-  - name: blendedness_flag_noShape
-    description: Object has no shape
-    datatype: boolean
-  - name: apFlux_12_0_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: apFlux_12_0_flag_apertureTruncated
-    description: Aperture did not fit within measurement image
-    datatype: boolean
-  - name: apFlux_12_0_flag_sincCoeffsTruncated
-    description: Full sinc coefficient image did not fit within measurement image
-    datatype: boolean
-  - name: apFlux_12_0_instFlux
-    description: Flux within 12.0-pixel aperture
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_12_0_instFluxErr
-    description: 1-sigma flux uncertainty
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_17_0_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: apFlux_17_0_instFlux
-    description: Flux within 17.0-pixel aperture
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_17_0_instFluxErr
-    description: 1-sigma flux uncertainty
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_35_0_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: apFlux_35_0_instFlux
-    description: Flux within 35.0-pixel aperture
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_35_0_instFluxErr
-    description: 1-sigma flux uncertainty
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_50_0_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: apFlux_50_0_instFlux
-    description: Flux within 50.0-pixel aperture
-    datatype: double
-    ivoa:unit: count
-  - name: apFlux_50_0_instFluxErr
-    description: 1-sigma flux uncertainty
-    datatype: double
-    ivoa:unit: count
-  - name: normCompTophatFlux_flag
-    description: General failure flag for normCompTophatFlux.
-    datatype: boolean
-  - name: normCompTophatFlux_instFlux
-    description: Normalized compensated tophat flux for calibration
-    datatype: double
-    ivoa:unit: count
-  - name: normCompTophatFlux_instFluxErr
-    description: 1-sigma flux uncertainty on normCompTophatFlux_instFlux
-    datatype: double
-    ivoa:unit: count
-  - name: extendedness_flag
-    description: Set to 1 for any fatal failure.
-    datatype: boolean
-  - name: sizeExtendedness_flag
-    description: Set to 1 for any fatal failure.
-    datatype: boolean
-  - name: footprintArea_value
-    description: Number of pixels in the sources detection footprint.
-    datatype: int
-    ivoa:unit: pixel
-  - name: invalidPsfFlag
-    description: Source has an invalid psf.
-    datatype: boolean
-  - name: jacobian_flag
-    description: Set to 1 for any fatal failure
-    datatype: boolean
-  - name: jacobian_value
-    description: Jacobian correction
-    datatype: double
-  - name: localBackground_instFlux
-    description: Background in annulus around source
-    datatype: double
-    ivoa:unit: count
-  - name: localBackground_instFluxErr
-    description: 1-sigma flux uncertainty
-    datatype: double
-    ivoa:unit: count
-  - name: localBackground_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: localBackground_flag_noGoodPixels
-    description: No good pixels in the annulus
-    datatype: boolean
-  - name: localBackground_flag_noPsf
-    description: No PSF provided
-    datatype: boolean
-  - name: pixelFlags_bad
-    description: Bad pixel in the Source footprint
-    datatype: boolean
-  - name: pixelFlags_cr
-    description: Cosmic ray in the Source footprint
-    datatype: boolean
-  - name: pixelFlags_crCenter
-    description: Cosmic ray in the Source center
-    datatype: boolean
-  - name: pixelFlags_edge
-    description: Source is on the edge of an exposure region (masked EDGE)
-    datatype: boolean
-  - name: pixelFlags_interpolated
-    description: Interpolated pixel in the Source footprint
-    datatype: boolean
-  - name: pixelFlags_interpolatedCenter
-    description: Interpolated pixel in the Source center
-    datatype: boolean
-  - name: pixelFlags_nodata
-    description: Source is outside usable exposure region (masked NO_DATA)
-    datatype: boolean
-  - name: pixelFlags_offimage
-    description: Source center is off image
-    datatype: boolean
-  - name: pixelFlags_saturated
-    description: Saturated pixel in the Source footprint
-    datatype: boolean
-  - name: pixelFlags_saturatedCenter
-    description: Saturated pixel in the Source center
-    datatype: boolean
-  - name: pixelFlags_suspect
-    description: Sources footprint includes suspect pixels
-    datatype: boolean
-  - name: pixelFlags_suspectCenter
-    description: Sources center is close to suspect pixels
-    datatype: boolean
-  - name: psfFlux_apCorr
-    description: Aperture correction applied to base_PsfFlux
-    datatype: double
-  - name: psfFlux_apCorrErr
-    description: Standard deviation of aperture correction applied to base_PsfFlux
-    datatype: double
-  - name: psfFlux_area
-    description: Effective area of PSF
-    datatype: float
-    ivoa:unit: pixel
-  - name: psfFlux_flag
-    description: Failure to derive linear least-squares fit of psf model forced on
-      the calexp
-    datatype: boolean
-  - name: psfFlux_flag_apCorr
-    description: Set if unable to aperture correct base_PsfFlux
-    datatype: boolean
-  - name: psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF
-      model
-    datatype: boolean
-  - name: psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit
-    datatype: boolean
-  - name: gaussianFlux_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: centroid_flag
-    description: General Failure Flag
-    datatype: boolean
-  - name: centroid_flag_almostNoSecondDerivative
-    description: Almost vanishing second derivative
-    datatype: boolean
-  - name: centroid_flag_badError
-    description: Error on x and/or y position is NaN
-    datatype: boolean
-  - name: centroid_flag_edge
-    description: Object too close to edge
-    datatype: boolean
-  - name: centroid_flag_noSecondDerivative
-    description: Vanishing second derivative
-    datatype: boolean
-  - name: centroid_flag_notAtMaximum
-    description: Object is not at a maximum
-    datatype: boolean
-  - name: centroid_flag_resetToPeak
-    description: Set if CentroidChecker reset the centroid
-    datatype: boolean
-  - name: variance_flag
-    description: Set for any fatal failure
-    datatype: boolean
-  - name: variance_flag_emptyFootprint
-    description: Set to True when the footprint has no usable pixels
-    datatype: boolean
-  - name: variance_value
-    description: Variance at object position
-    datatype: double
-  - name: calib_astrometry_used
-    description: Set if source was used in astrometric calibration
-    datatype: boolean
-  - name: calib_photometry_reserved
-    description: Set if source was reserved from photometric calibration
-    datatype: boolean
-  - name: calib_photometry_used
-    description: Set if source was used in photometric calibration
-    datatype: boolean
-  - name: calib_psf_candidate
-    description: Flag set if the source was a candidate for PSF determination, as
-      determined by the star selector.
-    datatype: boolean
-  - name: calib_psf_reserved
-    description: Set if source was reserved from PSF determination
-    datatype: boolean
-  - name: calib_psf_used
-    description: Flag set if the source was actually used for PSF determination, as
-      determined by the
-    datatype: boolean
-  - name: deblend_deblendedAsPsf
-    description: Deblender thought this source looked like a PSF
-    datatype: boolean
-  - name: deblend_hasStrayFlux
-    description: This source was assigned some stray flux
-    datatype: boolean
-  - name: deblend_masked
-    description: Parent footprint was predominantly masked
-    datatype: boolean
-  - name: deblend_nChild
-    description: Number of children this object has (defaults to 0)
-    datatype: int
-  - name: deblend_parentTooBig
-    description: Parent footprint covered too many pixels
-    datatype: boolean
-  - name: deblend_patchedTemplate
-    description: This source was near an image edge and the deblender used patched
-      edge-handling.
-    datatype: boolean
-  - name: deblend_rampedTemplate
-    description: This source was near an image edge and the deblender used ramp edge-handling.
-    datatype: boolean
-  - name: deblend_skipped
-    description: Deblender skipped this source
-    datatype: boolean
-  - name: deblend_tooManyPeaks
-    description: Source had too many peaks; only the brightest were included
-    datatype: boolean
-  - name: hsmPsfMoments_flag
-    description: General failure flag, set if anything went wrong
-    datatype: boolean
-  - name: hsmPsfMoments_flag_no_pixels
-    description: No pixels to measure
-    datatype: boolean
-  - name: hsmPsfMoments_flag_not_contained
-    description: Center not contained in footprint bounding box
-    datatype: boolean
-  - name: hsmPsfMoments_flag_parent_source
-    description: Parent source, ignored
-    datatype: boolean
-  - name: iDebiasedPSF_flag
-    description: General failure flag, set if anything went wrong
-    datatype: boolean
-  - name: iDebiasedPSF_flag_no_pixels
-    description: No pixels to measure
-    datatype: boolean
-  - name: iDebiasedPSF_flag_not_contained
-    description: Center not contained in footprint bounding box
-    datatype: boolean
-  - name: iDebiasedPSF_flag_parent_source
-    description: Parent source, ignored
-    datatype: boolean
-  - name: iDebiasedPSF_flag_galsim
-    description: GalSim failure
-    datatype: boolean
-  - name: iDebiasedPSF_flag_edge
-    description: Variance undefined outside image edge
-    datatype: boolean
-  - name: hsmShapeRegauss_flag
-    description: General failure flag, set if anything went wrong
-    datatype: boolean
-  - name: hsmShapeRegauss_flag_galsim
-    description: GalSim failure
-    datatype: boolean
-  - name: hsmShapeRegauss_flag_no_pixels
-    description: No pixels to measure
-    datatype: boolean
-  - name: hsmShapeRegauss_flag_not_contained
-    description: Center not contained in footprint bounding box
-    datatype: boolean
-  - name: hsmShapeRegauss_flag_parent_source
-    description: Parent source, ignored
-    datatype: boolean
-  - name: sky_source
-    description: Sky objects.
-    datatype: boolean
-  - name: visit
-    description: Id of the visit where this source was measured.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    description: Id of the detector where this source was measured.
-    datatype: short
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-  - name: band
-    description: Name of the band used to take the exposure where this source was
-      measured. Abstract filter that is not associated with a particular instrument
-    datatype: char
-    length: 1
-  - name: physical_filter
-    description: ID of physical filter, the filter associated with a particular instrument.
-    datatype: char
-    length: 9
-    votable:arraysize: '9'
-  - name: sourceId
-    description: Unique id. Unique Source ID. Primary Key.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
+  columnRefs:
+    base:
+      Source:
+        coord_ra:
+        coord_dec:
+        parentSourceId:
+        x:
+        y:
+        xErr:
+        yErr:
+        ra:
+        dec:
+        raErr:
+        decErr:
+        ra_dec_Cov:
+        calibFlux:
+        calibFluxErr:
+        ap03Flux:
+        ap03FluxErr:
+        ap03Flux_flag:
+        ap06Flux:
+        ap06FluxErr:
+        ap06Flux_flag:
+        ap09Flux:
+        ap09FluxErr:
+        ap09Flux_flag:
+        ap12Flux:
+        ap12FluxErr:
+        ap12Flux_flag:
+        ap17Flux:
+        ap17FluxErr:
+        ap17Flux_flag:
+        ap25Flux:
+        ap25FluxErr:
+        ap25Flux_flag:
+        ap35Flux:
+        ap35FluxErr:
+        ap35Flux_flag:
+        ap50Flux:
+        ap50FluxErr:
+        ap50Flux_flag:
+        ap70Flux:
+        ap70FluxErr:
+        ap70Flux_flag:
+        sky:
+        skyErr:
+        psfFlux:
+        psfFluxErr:
+        ixx:
+        iyy:
+        ixy:
+        ixxPSF:
+        iyyPSF:
+        ixyPSF:
+        ixxDebiasedPSF:
+        iyyDebiasedPSF:
+        ixyDebiasedPSF:
+        gaussianFlux:
+        gaussianFluxErr:
+        extendedness:
+        sizeExtendedness:
+        blendedness_abs:
+        blendedness_flag:
+        blendedness_flag_noCentroid:
+        blendedness_flag_noShape:
+        apFlux_12_0_flag:
+        apFlux_12_0_flag_apertureTruncated:
+        apFlux_12_0_flag_sincCoeffsTruncated:
+        apFlux_12_0_instFlux:
+        apFlux_12_0_instFluxErr:
+        apFlux_17_0_flag:
+        apFlux_17_0_instFlux:
+        apFlux_17_0_instFluxErr:
+        apFlux_35_0_flag:
+        apFlux_35_0_instFlux:
+        apFlux_35_0_instFluxErr:
+        apFlux_50_0_flag:
+        apFlux_50_0_instFlux:
+        apFlux_50_0_instFluxErr:
+        normCompTophatFlux_flag:
+        normCompTophatFlux_instFlux:
+        normCompTophatFlux_instFluxErr:
+        extendedness_flag:
+        sizeExtendedness_flag:
+        footprintArea_value:
+        invalidPsfFlag:
+        jacobian_flag:
+        jacobian_value:
+        localBackground_instFlux:
+        localBackground_instFluxErr:
+        localBackground_flag:
+        localBackground_flag_noGoodPixels:
+        localBackground_flag_noPsf:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_offimage:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        psfFlux_apCorr:
+        psfFlux_apCorrErr:
+        psfFlux_area:
+        psfFlux_flag:
+        psfFlux_flag_apCorr:
+        psfFlux_flag_edge:
+        psfFlux_flag_noGoodPixels:
+        gaussianFlux_flag:
+        centroid_flag:
+        centroid_flag_almostNoSecondDerivative:
+        centroid_flag_badError:
+        centroid_flag_edge:
+        centroid_flag_noSecondDerivative:
+        centroid_flag_notAtMaximum:
+        centroid_flag_resetToPeak:
+        variance_flag:
+        variance_flag_emptyFootprint:
+        variance_value:
+        calib_astrometry_used:
+        calib_photometry_reserved:
+        calib_photometry_used:
+        calib_psf_candidate:
+        calib_psf_reserved:
+        calib_psf_used:
+        deblend_deblendedAsPsf:
+        deblend_hasStrayFlux:
+        deblend_masked:
+        deblend_nChild:
+        deblend_parentTooBig:
+        deblend_patchedTemplate:
+        deblend_rampedTemplate:
+        deblend_skipped:
+        deblend_tooManyPeaks:
+        hsmPsfMoments_flag:
+        hsmPsfMoments_flag_no_pixels:
+        hsmPsfMoments_flag_not_contained:
+        hsmPsfMoments_flag_parent_source:
+        iDebiasedPSF_flag:
+        iDebiasedPSF_flag_no_pixels:
+        iDebiasedPSF_flag_not_contained:
+        iDebiasedPSF_flag_parent_source:
+        iDebiasedPSF_flag_galsim:
+        iDebiasedPSF_flag_edge:
+        hsmShapeRegauss_flag:
+        hsmShapeRegauss_flag_galsim:
+        hsmShapeRegauss_flag_no_pixels:
+        hsmShapeRegauss_flag_not_contained:
+        hsmShapeRegauss_flag_parent_source:
+        sky_source:
+        visit:
+        detector:
+        band:
+        physical_filter:
+        sourceId:
   constraints:
   - name: fk_Source_Visit
     description: Link a Source to its associated Visit
@@ -5192,139 +1452,38 @@ tables:
     PSF photometry is performed, based on coordinates from a reference band chosen for each
     Object and reported in the Object.refBand column."
   tap:table_index: 30
-  columns:
-  - name: objectId
-    description: Unique Object ID. Primary Key of the Object Table
-    datatype: long
-    tap:principal: 1
-  - name: parentObjectId
-    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
-    datatype: long
-    tap:principal: 0
-  - name: coord_ra
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: coord_dec
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: visit
-    description: Id of the visit where this source was measured.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-    tap:principal: 1
-  - name: detector
-    description: Id of the detector where this source was measured.
-    datatype: short
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-    tap:principal: 1
-  - name: band
-    description: Abstract filter that is not associated with a particular instrument
-    datatype: char
-    length: 1
-    tap:principal: 1
-  - name: psfFlux
-    description: Flux derived from linear least-squares fit of psf model forced on
-      the calexp
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfFluxErr
-    description: Uncertainty on the flux derived from linear least-squares fit of
-      psf model forced on the calexp
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfFlux_flag
-    description: Failure to derive linear least-squares fit of psf model forced on
-      the calexp
-    datatype: boolean
-    tap:principal: 0
-  - name: psfDiffFlux
-    description: Flux derived from linear least-squares fit of psf model forced on
-      the image difference
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfDiffFluxErr
-    description: Uncertainty on the flux derived from linear least-squares fit of
-      psf model forced on the image difference
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfDiffFlux_flag
-    description: Failure to derive linear least-squares fit of psf model forced on
-      the image difference
-    datatype: boolean
-    tap:principal: 0
-  - name: diff_PixelFlags_nodataCenter
-    description: Source center is outside usable region on image difference (masked
-      NO_DATA)
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_bad
-    description: Bad pixel in the Source footprint
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_cr
-    description: Cosmic ray in the Source footprint
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_crCenter
-    description: Cosmic ray in the Source center
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_edge
-    description: Source is on the edge of an exposure region (masked EDGE)
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_interpolated
-    description: Interpolated pixel in the Source footprint
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_interpolatedCenter
-    description: Interpolated pixel in the Source center
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_nodata
-    description: Source is outside usable exposure region (masked NO_DATA)
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_saturated
-    description: Saturated pixel in the Source footprint
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_saturatedCenter
-    description: Saturated pixel in the Source center
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_suspect
-    description: Sources footprint includes suspect pixels
-    datatype: boolean
-    tap:principal: 0
-  - name: pixelFlags_suspectCenter
-    description: Sources center is close to suspect pixels
-    datatype: boolean
-    tap:principal: 0
-  - name: invalidPsfFlag
-    description: Source has an invalid PSF.
-    datatype: boolean
-    tap:principal: 0
-  - name: tract
-    description: Skymap tract ID
-    datatype: long
-    tap:principal: 0
-  - name: patch
-    description: Skymap patch ID
-    datatype: long
-    tap:principal: 0
+  columnRefs:
+    base:
+      ForcedSource:
+        objectId:
+        parentObjectId:
+        coord_ra:
+        coord_dec:
+        visit:
+        detector:
+        band:
+        psfFlux:
+        psfFluxErr:
+        psfFlux_flag:
+        psfDiffFlux:
+        psfDiffFluxErr:
+        psfDiffFlux_flag:
+        diff_PixelFlags_nodataCenter:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        invalidPsfFlag:
+        tract:
+        patch:
+
   constraints:
   - name: fk_ForcedSource_Object
     description: Link an Object to its associated ForcedSources
@@ -5348,439 +1507,101 @@ tables:
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
-  columns:
-  - name: diaSourceId
-    description: Unique identifier of this DiaSource.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-  - name: visit
-    description: Id of the visit where this diaSource was measured.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-  - name: detector
-    description: Id of the detector where this diaSource was measured.
-    datatype: short
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-  - name: diaObjectId
-    description: Id of the diaObject this source was associated with, if any. If not,
-      it is set to 0
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: ssObjectId
-    description: Id of the ssObject this source was associated with, if any. If not,
-      it is set to 0
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: parentDiaSourceId
-    description: Id of the parent diaSource this diaSource has been deblended from,
-      if any.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: midpointMjdTai
-    description: Effective mid-visit time for this diaSource, expressed as Modified
-      Julian Date, International Atomic Time.
-    datatype: double
-    nullable: false
-    ivoa:unit: d
-    ivoa:ucd: time.epoch
-  - name: coord_dec
-    description: Fiducial ICRS Declination of centroid used for database indexing.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.dec;meta.main
-  - name: coord_ra
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.ra;meta.main
-  - name: ra
-    description: Right ascension coordinate of the center of this diaSource.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: dec
-    description: Declination coordinate of the center of this diaSource.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: raErr
-    description: Error in right ascension.
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: stat.error;pos.eq.ra
-  - name: decErr
-    description: Error in declination.
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: stat.error;pos.eq.dec
-  - name: ra_dec_Cov
-    description: Covariance between right ascension and declination.
-    datatype: float
-    ivoa:unit: deg**2
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-  - name: x
-    description: Unweighted first moment centroid, overall centroid.
-    datatype: double
-    nullable: false
-    ivoa:unit: pixel
-    ivoa:ucd: pos.cartesian.x
-  - name: xErr
-    description: 1-sigma uncertainty on x position.
-    datatype: float
-    ivoa:unit: pixel
-    ivoa:ucd: stat.error;pos.cartesian.x
-  - name: y
-    description: Unweighted first moment centroid, overall centroid.
-    datatype: double
-    nullable: false
-    ivoa:unit: pixel
-    ivoa:ucd: pos.cartesian.y
-  - name: yErr
-    description: 1-sigma uncertainty on y position.
-    datatype: float
-    ivoa:unit: pixel
-    ivoa:ucd: stat.error;pos.cartesian.y
-  - name: centroid_flag
-    description: General centroid algorithm failure flag; set if anything went wrong
-      when fitting the centroid. Another centroid flag field should also be set to
-      provide more information.
-    datatype: boolean
-    nullable: false
-  - name: apFlux
-    description: Flux in a 12 pixel radius aperture on the difference image.
-    datatype: float
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: apFluxErr
-    description: Estimated uncertainty of apFlux.
-    datatype: float
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error;phot.count
-  - name: apFlux_flag
-    description: General aperture flux algorithm failure flag; set if anything went
-      wrong when measuring aperture fluxes. Another apFlux flag field should also
-      be set to provide more information.
-    datatype: boolean
-    nullable: false
-  - name: apFlux_flag_apertureTruncated
-    description: Aperture did not fit within measurement image.
-    datatype: boolean
-    nullable: false
-  - name: isNegative
-    description: Source was detected as significantly negative.
-    datatype: boolean
-    nullable: false
-  - name: snr
-    description: The signal-to-noise ratio at which this source was detected in the
-      difference image. Ratio of apFlux/apFluxErr.
-    datatype: double
-    ivoa:ucd: stat.snr
-  - name: psfFlux
-    description: Flux for Point Source model. Note this actually measures
-      the flux difference between the template and the visit image.
-    datatype: float
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: psfFluxErr
-    description: Uncertainty of psfFlux.
-    datatype: float
-    ivoa:unit: nJy
-  - name: psfChi2
-    description: Chi^2 statistic of the point source model fit.
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: psfNdata
-    description: The number of data points (pixels) used to fit the point source model.
-    datatype: int
-    nullable: false
-    ivoa:unit: pixel
-  - name: psfFlux_flag
-    description: Failure to derive linear least-squares fit of psf model. Another
-      psfFlux flag field should also be set to provide more information.
-    datatype: boolean
-    nullable: false
-  - name: psfFlux_flag_edge
-    description: Object was too close to the edge of the image to use the full PSF model.
-    datatype: boolean
-    nullable: false
-  - name: psfFlux_flag_noGoodPixels
-    description: Not enough non-rejected pixels in data to attempt the fit.
-    datatype: boolean
-    nullable: false
-  - name: trailFlux
-    description: Flux for a trailed source model. Note this actually measures
-      the flux difference between the template and the visit image.
-    datatype: float
-    ivoa:unit: nJy
-  - name: trailFluxErr
-    description: Uncertainty of trailFlux.
-    datatype: float
-    ivoa:unit: nJy
-  - name: trailRa
-    description: Right ascension coordinate of centroid for trailed source model.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.ra
-  - name: trailDec
-    description: Declination coordinate of centroid for trailed source model.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.dec
-  - name: trailLength
-    description: Maximum likelihood fit of trail length.
-    datatype: double
-    ivoa:unit: arcsec
-  - name: trailAngle
-    description: Maximum likelihood fit of the angle between the meridian through
-      the centroid and the trail direction (bearing).
-    datatype: double
-    ivoa:unit: deg
-  - name: trail_flag_edge
-    description: This flag is set if a trailed source extends onto or past edge pixels.
-    datatype: boolean
-    nullable: false
-  - name: dipoleMeanFlux
-    description: Maximum likelihood value for the mean absolute flux of the two lobes
-      for a dipole model.
-    datatype: double
-    ivoa:unit: nJy
-  - name: dipoleMeanFluxErr
-    description: Uncertainty of dipoleMeanFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: dipoleFluxDiff
-    description: Maximum likelihood value for the difference of absolute fluxes of
-      the two lobes for a dipole model.
-    datatype: double
-    ivoa:unit: nJy
-  - name: dipoleFluxDiffErr
-    description: Uncertainty of dipoleFluxDiff.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: dipoleLength
-    description: Maximum likelihood value for the lobe separation in dipole model.
-    datatype: double
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.angDistance
-  - name: dipoleAngle
-    description: Maximum likelihood fit of the angle between the meridian through
-      the centroid and the dipole direction (bearing, from negative to positive lobe).
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.posAng
-  - name: dipoleChi2
-    description: Chi^2 statistic of the model fit.
-    datatype: double
-    ivoa:ucd: stat.fit.chi2
-  - name: dipoleNdata
-    description: The number of data points (pixels) used to fit the model.
-    datatype: long
-    nullable: false
-  - name: scienceFlux
-    description: Forced photometry flux for a point source model measured on the visit image
-      centered at DiaSource position.
-    datatype: float
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: scienceFluxErr
-    description: Estimated uncertainty of scienceFlux.
-    datatype: float
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error;phot.count
-  - name: forced_PsfFlux_flag
-    description: Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.
-    datatype: boolean
-    nullable: false
-  - name: forced_PsfFlux_flag_edge
-    description: Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.
-    datatype: boolean
-    nullable: false
-  - name: forced_PsfFlux_flag_noGoodPixels
-    description: Forced PSF flux not enough non-rejected pixels in data to attempt the fit.
-    datatype: boolean
-    nullable: false
-  - name: templateFlux
-    description: Forced photometry flux for a point source model measured on the template image
-      centered at the DiaSource position.
-    datatype: float
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: templateFluxErr
-    description: Uncertainty of templateFlux.
-    datatype: float
-    ivoa:ucd: stat.error;phot.count
-    ivoa:unit: nJy
-  - name: ixx
-    description: Adaptive second moment of the source intensity.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: iyy
-    description: Adaptive second moment of the source intensity.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: ixy
-    description: Adaptive second moment of the source intensity.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: ixxPSF
-    description: Adaptive second moment for the PSF.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: iyyPSF
-    description: Adaptive second moment for the PSF.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: ixyPSF
-    description: Adaptive second moment for the PSF.
-    datatype: double
-    ivoa:unit: nJy.arcsec**2
-  - name: shape_flag
-    description: General source shape algorithm failure flag; set if anything went wrong
-      when measuring the shape. Another shape flag field should also be set
-      to provide more information.
-    datatype: boolean
-    nullable: false
-  - name: shape_flag_no_pixels
-    description: No pixels to measure shape.
-    datatype: boolean
-    nullable: false
-  - name: shape_flag_not_contained
-    description: Center not contained in footprint bounding box.
-    datatype: boolean
-    nullable: false
-  - name: shape_flag_parent_source
-    description: This source is a parent source; we should only be measuring on deblended children in difference imaging.
-    datatype: boolean
-    nullable: false
-  - name: extendedness
-    description: A measure of extendedness, computed by comparing an object's moment-based trace radius to
-      the PSF moments. extendedness = 1 implies a high degree of confidence
-      that the source is extended. extendedness = 0 implies a high degree of confidence
-      that the source is point-like.
-    datatype: double
-  - name: reliability
-    description: Probability (0-1) that the diaSource is astrophysical,
-       derived from a machine learning model.
-    datatype: float
-  - name: band
-    description: Filter band this source was observed with.
-    datatype: char
-    length: 1
-  - name: isDipole
-    description: Source well fit by a dipole.
-    datatype: boolean
-    nullable: false
-  - name: dipoleFitAttempted
-    description: Attempted to fit a dipole model to this source.
-    datatype: boolean
-    nullable: false
-  - name: timeProcessedMjdTai
-    description: Time when the image was processed and this DiaSource record was generated,
-      expressed as Modified Julian Date, International Atomic Time.
-    datatype: double
-    nullable: false
-    ivoa:ucd: time.epoch
-  - name: bboxSize
-    description: Size of the square bounding box that fully contains the detection footprint.
-    datatype: long
-    nullable: false
-    ivoa:unit: pixel
-  - name: pixelFlags
-    description: General pixel flags failure; set if anything went wrong when setting
-      pixels flags from this footprint's mask. This implies that some pixelFlags for
-      this source may be incorrectly set to False.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_bad
-    description: Bad pixel in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_cr
-    description: Cosmic ray in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_crCenter
-    description: Cosmic ray in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_edge
-    description: Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_nodata
-    description: NO_DATA pixel in the source footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_nodataCenter
-    description: NO_DATA pixel in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_interpolated
-    description: Interpolated pixel in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_interpolatedCenter
-    description: Interpolated pixel in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_offimage
-    description: DiaSource center is off image.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_saturated
-    description: Saturated pixel in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_saturatedCenter
-    description: Saturated pixel in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_suspect
-    description: DiaSource's footprint includes suspect pixels.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_suspectCenter
-    description: Suspect pixel in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_streak
-    description: Streak in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_streakCenter
-    description: Streak in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_injected
-    description: Injection in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_injectedCenter
-    description: Injection in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_injected_template
-    description: Template injection in the DiaSource footprint.
-    datatype: boolean
-    nullable: false
-  - name: pixelFlags_injected_templateCenter
-    description: Template injection in the 3x3 region around the centroid.
-    datatype: boolean
-    nullable: false
-  - name: glint_trail
-    description: This flag is set if the source is part of a glint trail.
-    datatype: boolean
-    nullable: false
+  columnRefs:
+    base:
+      DiaSource:
+        diaSourceId:
+        visit:
+        detector:
+        diaObjectId:
+        ssObjectId:
+        parentDiaSourceId:
+        midpointMjdTai:
+        coord_dec:
+        coord_ra:
+        ra:
+        dec:
+        raErr:
+        decErr:
+        ra_dec_Cov:
+        x:
+        xErr:
+        y:
+        yErr:
+        centroid_flag:
+        apFlux:
+        apFluxErr:
+        apFlux_flag:
+        apFlux_flag_apertureTruncated:
+        isNegative:
+        snr:
+        psfFlux:
+        psfFluxErr:
+        psfChi2:
+        psfNdata:
+        psfFlux_flag:
+        psfFlux_flag_edge:
+        psfFlux_flag_noGoodPixels:
+        trailFlux:
+        trailFluxErr:
+        trailRa:
+        trailDec:
+        trailLength:
+        trailAngle:
+        trail_flag_edge:
+        dipoleMeanFlux:
+        dipoleMeanFluxErr:
+        dipoleFluxDiff:
+        dipoleFluxDiffErr:
+        dipoleLength:
+        dipoleAngle:
+        dipoleChi2:
+        dipoleNdata:
+        scienceFlux:
+        scienceFluxErr:
+        forced_PsfFlux_flag:
+        forced_PsfFlux_flag_edge:
+        forced_PsfFlux_flag_noGoodPixels:
+        templateFlux:
+        templateFluxErr:
+        ixx:
+        iyy:
+        ixy:
+        ixxPSF:
+        iyyPSF:
+        ixyPSF:
+        shape_flag:
+        shape_flag_no_pixels:
+        shape_flag_not_contained:
+        shape_flag_parent_source:
+        extendedness:
+        reliability:
+        band:
+        isDipole:
+        dipoleFitAttempted:
+        timeProcessedMjdTai:
+        bboxSize:
+        pixelFlags:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_nodata:
+        pixelFlags_nodataCenter:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_offimage:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        pixelFlags_streak:
+        pixelFlags_streakCenter:
+        pixelFlags_injected:
+        pixelFlags_injectedCenter:
+        pixelFlags_injected_template:
+        pixelFlags_injected_templateCenter:
+        glint_trail:
   constraints:
   - name: uniq_diaSourceId
     description: Unique constraint on diaSourceId
@@ -5819,298 +1640,73 @@ tables:
     single-epoch difference images."
   tap:table_index: 40
   primaryKey: '#DiaObject.diaObjectId'
-  columns:
-  - name: diaObjectId
-    description: Unique identifier of this DiaObject.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: ra
-    description: Right Ascension coordinate of the position of the DiaObject.
-    datatype: double
-    nullable: false
-    ivoa:ucd: pos.eq.ra;meta.main
-    ivoa:unit: deg
-  - name: dec
-    description: Declination coordinate of the position of the DiaObject.
-    datatype: double
-    nullable: false
-    ivoa:ucd: pos.eq.dec;meta.main
-    ivoa:unit: deg
-  - name: u_psfFluxMean
-    description: Weighted mean point-source model magnitude for u filter.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: u_psfFluxMeanErr
-    description: Standard error of u_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: u_psfFluxSigma
-    description: Standard deviation of the distribution of u_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: u_psfFluxNdata
-    description: The number of u-band data points.
-    datatype: int
-    nullable: false
-  - name: g_psfFluxMean
-    description: Weighted mean point-source model magnitude for g filter.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: g_psfFluxMeanErr
-    description: Standard error of g_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: g_psfFluxSigma
-    description: Standard deviation of the distribution of g_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: g_psfFluxNdata
-    description: The number of g-band data points.
-    datatype: int
-    nullable: false
-  - name: r_psfFluxMean
-    description: Weighted mean point-source model magnitude for r filter.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: r_psfFluxMeanErr
-    description: Standard error of r_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: r_psfFluxSigma
-    description: Standard deviation of the distribution of r_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: r_psfFluxNdata
-    description: The number of r-band data points.
-    datatype: int
-    nullable: false
-  - name: i_psfFluxMean
-    description: Weighted mean point-source model magnitude for i filter.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: i_psfFluxMeanErr
-    description: Standard error of i_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: i_psfFluxSigma
-    description: Standard deviation of the distribution of i_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: i_psfFluxNdata
-    description: The number of i-band data points.
-    datatype: int
-    nullable: false
-  - name: z_psfFluxMean
-    description: Weighted mean point-source model magnitude for z filter.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: phot.count
-  - name: z_psfFluxMeanErr
-    description: Standard error of z_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: z_psfFluxSigma
-    description: Standard deviation of the distribution of z_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: z_psfFluxNdata
-    description: The number of z-band data points.
-    datatype: int
-    nullable: false
-  - name: y_psfFluxMean
-    datatype: double
-    ivoa:unit: nJy
-    description: Weighted mean point-source model magnitude for y filter.
-    ivoa:ucd: phot.count
-  - name: y_psfFluxMeanErr
-    description: Standard error of y_psfFluxMean.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.error
-  - name: y_psfFluxSigma
-    description: Standard deviation of the distribution of y_psfFlux.
-    datatype: double
-    ivoa:unit: nJy
-    ivoa:ucd: stat.stdev
-  - name: y_psfFluxNdata
-    description: The number of y-band data points.
-    datatype: int
-    nullable: false
-  - name: u_scienceFluxMean
-    description: Weighted mean forced photometry flux for u filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: u_scienceFluxMeanErr
-    description: Standard error of u_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: g_scienceFluxMean
-    description: Weighted mean forced photometry flux for g filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: g_scienceFluxMeanErr
-    description: Standard error of g_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: r_scienceFluxMean
-    description: Weighted mean forced photometry flux for r filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: r_scienceFluxMeanErr
-    description: Standard error of r_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: i_scienceFluxMean
-    description: Weighted mean forced photometry flux for i filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: i_scienceFluxMeanErr
-    description: Standard error of i_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: z_scienceFluxMean
-    description: Weighted mean forced photometry flux for z filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: z_scienceFluxMeanErr
-    description: Standard error of z_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: y_scienceFluxMean
-    description: Weighted mean forced photometry flux for y filter.
-    datatype: double
-    ivoa:ucd: phot.count
-    ivoa:unit: nJy
-  - name: y_scienceFluxMeanErr
-    description: Standard error of y_scienceFluxMean.
-    datatype: double
-    ivoa:ucd: stat.error
-    ivoa:unit: nJy
-  - name: u_psfFluxMin
-    description: Minimum observed u band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: u_psfFluxMax
-    description: Maximum observed u band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: u_psfFluxMaxSlope
-    description: Maximum slope between u band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: u_psfFluxErrMean
-    description: Mean of the u band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_psfFluxMin
-    description: Minimum observed g band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: g_psfFluxMax
-    description: Maximum observed g band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: g_psfFluxMaxSlope
-    description: Maximum slope between g band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: g_psfFluxErrMean
-    description: Mean of the g band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_psfFluxMin
-    description: Minimum observed r band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: r_psfFluxMax
-    description: Maximum observed r band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: r_psfFluxMaxSlope
-    description: Maximum slope between r band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: r_psfFluxErrMean
-    description: Mean of the r band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_psfFluxMin
-    description: Minimum observed i band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: i_psfFluxMax
-    description: Maximum observed i band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: i_psfFluxMaxSlope
-    description: Maximum slope between i band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: i_psfFluxErrMean
-    description: Mean of the i band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_psfFluxMin
-    description: Minimum observed z band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: z_psfFluxMax
-    description: Maximum observed z band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: z_psfFluxMaxSlope
-    description: Maximum slope between z band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: z_psfFluxErrMean
-    description: Mean of the z band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: y_psfFluxMin
-    description: Minimum observed y band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: y_psfFluxMax
-    description: Maximum observed y band fluxes.
-    datatype: double
-    ivoa:unit: nJy
-  - name: y_psfFluxMaxSlope
-    description: Maximum slope between y band flux obsevations max(delta_flux/delta_time).
-    datatype: double
-    ivoa:unit: nJy/d
-  - name: y_psfFluxErrMean
-    description: Mean of the y band flux errors.
-    datatype: float
-    ivoa:unit: nJy
-  - name: nDiaSources
-    description: Total number of DiaSources associated with this DiaObject.
-    nullable: false
-    datatype: long
+  columnRefs:
+    base:
+      DiaObject:
+        diaObjectId:
+        ra:
+        dec:
+        u_psfFluxMean:
+        u_psfFluxMeanErr:
+        u_psfFluxSigma:
+        u_psfFluxNdata:
+        g_psfFluxMean:
+        g_psfFluxMeanErr:
+        g_psfFluxSigma:
+        g_psfFluxNdata:
+        r_psfFluxMean:
+        r_psfFluxMeanErr:
+        r_psfFluxSigma:
+        r_psfFluxNdata:
+        i_psfFluxMean:
+        i_psfFluxMeanErr:
+        i_psfFluxSigma:
+        i_psfFluxNdata:
+        z_psfFluxMean:
+        z_psfFluxMeanErr:
+        z_psfFluxSigma:
+        z_psfFluxNdata:
+        y_psfFluxMean:
+        y_psfFluxMeanErr:
+        y_psfFluxSigma:
+        y_psfFluxNdata:
+        u_scienceFluxMean:
+        u_scienceFluxMeanErr:
+        g_scienceFluxMean:
+        g_scienceFluxMeanErr:
+        r_scienceFluxMean:
+        r_scienceFluxMeanErr:
+        i_scienceFluxMean:
+        i_scienceFluxMeanErr:
+        z_scienceFluxMean:
+        z_scienceFluxMeanErr:
+        y_scienceFluxMean:
+        y_scienceFluxMeanErr:
+        u_psfFluxMin:
+        u_psfFluxMax:
+        u_psfFluxMaxSlope:
+        u_psfFluxErrMean:
+        g_psfFluxMin:
+        g_psfFluxMax:
+        g_psfFluxMaxSlope:
+        g_psfFluxErrMean:
+        r_psfFluxMin:
+        r_psfFluxMax:
+        r_psfFluxMaxSlope:
+        r_psfFluxErrMean:
+        i_psfFluxMin:
+        i_psfFluxMax:
+        i_psfFluxMaxSlope:
+        i_psfFluxErrMean:
+        z_psfFluxMin:
+        z_psfFluxMax:
+        z_psfFluxMaxSlope:
+        z_psfFluxErrMean:
+        y_psfFluxMin:
+        y_psfFluxMax:
+        y_psfFluxMaxSlope:
+        y_psfFluxErrMean:
+        nDiaSources:
   indexes:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column
@@ -6121,154 +1717,38 @@ tables:
     visit images and difference images, based on and linked to the entries in the
     DiaObject table."
   tap:table_index: 60
-  columns:
-  - name: diaObjectId
-    description: Id of the DiaObject that this DiaForcedSource was associated with.
-    datatype: long
-    tap:principal: 1
-  - name: parentObjectId
-    description: Unique ObjectId of the parent of the ObjectId in context of the deblender.
-    datatype: long
-    tap:principal: 0
-  - name: coord_ra
-    description: Fiducial ICRS Right Ascension of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: coord_dec
-    description: Fiducial ICRS Declination of centroid used for database indexing
-    datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: visit
-    description: Id of the visit where this forced source was measured.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-    tap:principal: 1
-  - name: detector
-    description: Id of the detector where this forced source was measured.
-    datatype: short
-    nullable: false
-    ivoa:ucd: meta.id;obs.image
-    tap:principal: 1
-  - name: band
-    description: Abstract filter that is not associated with a particular instrument
-    datatype: char
-    length: 1
-    tap:principal: 1
-  - name: psfFlux
-    description: Flux derived from linear least-squares fit of psf model forced on
-      the calexp
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfFluxErr
-    description: Uncertainty on the flux derived from linear least-squares fit of
-      psf model forced on the calexp
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfFlux_flag
-    description: Failure to derive linear least-squares fit of psf model forced on
-      the calexp
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: psfDiffFlux
-    description: Flux derived from linear least-squares fit of psf model forced on
-      the image difference
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfDiffFluxErr
-    description: Uncertainty on the flux derived from linear least-squares fit of
-      psf model forced on the image difference
-    datatype: float
-    ivoa:unit: nJy
-    tap:principal: 1
-  - name: psfDiffFlux_flag
-    description: Failure to derive linear least-squares fit of psf model forced on
-      the image difference
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: diff_PixelFlags_nodataCenter
-    description: Source center is outside usable region on image difference (masked
-      NO_DATA)
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_bad
-    description: Bad pixel in the Source footprint
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_cr
-    description: Cosmic ray in the Source footprint
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_crCenter
-    description: Cosmic ray in the Source center
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_edge
-    description: Source is on the edge of an exposure region (masked EDGE)
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_interpolated
-    description: Interpolated pixel in the Source footprint
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_interpolatedCenter
-    description: Interpolated pixel in the Source center
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_nodata
-    description: Source is outside usable exposure region (masked NO_DATA)
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_saturated
-    description: Saturated pixel in the Source footprint
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_saturatedCenter
-    description: Saturated pixel in the Source center
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_suspect
-    description: Sources footprint includes suspect pixels
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: pixelFlags_suspectCenter
-    description: Sources center is close to suspect pixels
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: invalidPsfFlag
-    description: Forced source has an invalid PSF.
-    datatype: boolean
-    nullable: false
-    tap:principal: 0
-  - name: tract
-    description: Skymap tract ID
-    datatype: long
-    tap:principal: 0
-  - name: patch
-    description: Skymap patch ID
-    datatype: long
-    tap:principal: 0
+  columnRefs:
+    base:
+      ForcedSourceOnDiaObject:
+        diaObjectId:
+        parentObjectId:
+        coord_ra:
+        coord_dec:
+        visit:
+        detector:
+        band:
+        psfFlux:
+        psfFluxErr:
+        psfFlux_flag:
+        psfDiffFlux:
+        psfDiffFluxErr:
+        psfDiffFlux_flag:
+        diff_PixelFlags_nodataCenter:
+        pixelFlags_bad:
+        pixelFlags_cr:
+        pixelFlags_crCenter:
+        pixelFlags_edge:
+        pixelFlags_interpolated:
+        pixelFlags_interpolatedCenter:
+        pixelFlags_nodata:
+        pixelFlags_saturated:
+        pixelFlags_saturatedCenter:
+        pixelFlags_suspect:
+        pixelFlags_suspectCenter:
+        invalidPsfFlag:
+        tract:
+        patch:
+
   constraints:
   - name: fk_ForcedSourceOnDiaobject_DiaObject
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects
@@ -6293,56 +1773,14 @@ tables:
   description: "Static information about the subset of tracts and patches from the standard
     LSST skymap that apply to coadds in these catalogs"
   tap:table_index: 70
-  columns:
-  - name: lsst_tract
-    description: "ID number of the top level, 'tract', within the standard LSST skymap"
-    nullable: false
-    ivoa:ucd: meta.id;obs.field
-    tap:std: 0
-    tap:principal: 1
-    ivoa:unit:
-    datatype: long
-    tap:column_index: 1
-  - name: lsst_patch
-    description: "ID number of the second level, 'patch', within the standard LSST skymap"
-    nullable: false
-    ivoa:ucd: meta.id.part;obs.field
-    tap:std: 0
-    tap:principal: 1
-    ivoa:unit:
-    datatype: long
-    tap:column_index: 2
-  - name: s_ra
-    description: "Central Spatial Position in ICRS; Right ascension"
-    nullable: false
-    ivoa:ucd: pos.eq.ra
-    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit: deg
-    datatype: double
-    tap:column_index: 3
-  - name: s_dec
-    description: "Central Spatial Position in ICRS; Declination"
-    nullable: false
-    ivoa:ucd: pos.eq.dec
-    votable:utype: Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit: deg
-    datatype: double
-    tap:column_index: 4
-  - name: s_region
-    description: "Sky region covered by the coadd (expressed in ICRS frame)"
-    nullable: false
-    ivoa:ucd: pos.outline;obs.field
-    votable:utype: Char.SpatialAxis.Coverage.Support.Area
-    tap:std: 1
-    tap:principal: 1
-    ivoa:unit:
-    datatype: string
-    length: 512
-    tap:column_index: 5
+  columnRefs:
+    base:
+      CoaddPatches:
+        lsst_tract:
+        lsst_patch:
+        s_ra:
+        s_dec:
+        s_region:
   indexes:
   - name: idx_CoaddPatches_lsst_patch
     description: Non-unique index on the lsst_patch column
@@ -6354,99 +1792,27 @@ tables:
     - "#CoaddPatches.lsst_tract"
 - name: Visit
   description: "Metadata about the pointings of the telescope,
-    largely associated with the boresight of the LSSTComCam focal plane as a whole."
+    largely associated with the boresight of the LSSTCam focal plane as a whole."
   tap:table_index: 80
   primaryKey: '#Visit.visit'
-  columns:
-  - name: visit
-    description: Unique identifier.
-    datatype: long
-    ivoa:ucd: meta.id;obs.image
-    tap:principal: 1
-  - name: physical_filter
-    description: ID of physical filter, the filter associated with a particular instrument.
-    datatype: char
-    length: 32
-    votable:arraysize: '*'
-    tap:principal: 0
-  - name: band
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    datatype: char
-    length: 1
-    votable:arraysize: '*'
-    tap:principal: 1
-  - name: ra
-    description: Right Ascension of focal plane center.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: dec
-    description: Declination of focal plane center
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: skyRotation
-    description: Sky rotation angle.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: azimuth
-    description: Azimuth of focal plane center at the middle of the visit.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: altitude
-    description: Altitude of focal plane center at the middle of the visit.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: zenithDistance
-    description: Zenith distance at the middle of the visit.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: airmass
-    description: Airmass of the observed line of sight.
-    datatype: double
-    tap:principal: 1
-  - name: expTime
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    datatype: double
-    ivoa:unit: s
-    tap:principal: 1
-  - name: expMidpt
-    description: Midpoint time for exposure at the fiducial center of the focal plane
-      array. TAI, accurate to 10ms.
-    datatype: timestamp
-    precision: 6
-    tap:column_index: 6
-    tap:principal: 0
-    votable:arraysize: '*'
-    votable:xtype: timestamp
-  - name: expMidptMJD
-    description: Midpoint time for exposure at the fiducial center of the focal plane
-      array in MJD. TAI, accurate to 10ms.
-    datatype: double
-    ivoa:ucd: time.epoch;obs.exposure
-    ivoa:unit: d
-    tap:column_index: 5
-    tap:principal: 1
-  - name: obsStart
-    description: Start time of the visit at the fiducial center of the focal plane
-      array, TAI, accurate to 10ms.
-    datatype: timestamp
-    precision: 6
-    votable:arraysize: '*'
-    votable:xtype: timestamp
-    tap:principal: 0
-  - name: obsStartMJD
-    description: Start of the exposure in MJD, TAI, accurate to 10ms.
-    datatype: double
-    ivoa:ucd: time.start;obs.exposure
-    ivoa:unit: d
-    tap:column_index: 7
-    tap:principal: 0
+  columnRefs:
+    base:
+      Visit:
+        visit:
+        physical_filter:
+        band:
+        ra:
+        dec:
+        skyRotation:
+        azimuth:
+        altitude:
+        zenithDistance:
+        airmass:
+        expTime:
+        expMidpt:
+        expMidptMJD:
+        obsStart:
+        obsStartMJD:
   indexes:
   - name: idx_Visit_visit
     description: Unique index on the visit column
@@ -6458,398 +1824,81 @@ tables:
   - "#VisitDetector.detector"
   description: "Per-detector metadata and metrics associated with each visit"
   tap:table_index: 90
-  columns:
-  - name: visitId
-    description: Reference to the corresponding entry in the Visit table.
-    datatype: long
-    ivoa:ucd: meta.id.parent;obs
-    tap:column_index: 2
-    tap:principal: 1
-  - name: detector
-    description: Detector ID. A detector associated with a particular instrument (not
-      an observation of that detector).
-    datatype: long
-    tap:principal: 1
-  - name: physical_filter
-    description: ID of physical filter, the filter associated with a particular instrument.
-    datatype: char
-    length: 32
-    votable:arraysize: '*'
-    tap:principal: 0
-  - name: band
-    description: Name of the band used to take the visit where this source was measured.
-      Abstract filter that is not associated with a particular instrument.
-    datatype: char
-    length: 1
-    votable:arraysize: '*'
-    tap:principal: 1
-  - name: ra
-    description: Right Ascension of Ccd center.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: dec
-    description: Declination of Ccd center.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: pixelScale
-    description: Measured detector pixel scale.
-    datatype: float
-    ivoa:unit: arcsec/pixel
-    tap:principal: 0
-  - name: zenithDistance
-    description: Zenith distance at observation mid-point.
-    datatype: float
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: expTime
-    description: Spatially-averaged duration of visit, accurate to 10ms.
-    datatype: double
-    ivoa:unit: s
-    tap:principal: 1
-  - name: zeroPoint
-    description: Zero-point for the Ccd, estimated at Ccd center.
-    datatype: float
-    ivoa:unit: mag
-    tap:principal: 0
-  - name: psfSigma
-    description: PSF model second-moments determinant radius (center of chip)
-    datatype: float
-    ivoa:unit: pixel
-    tap:principal: 1
-  - name: skyBg
-    description: Average sky background.
-    datatype: float
-    ivoa:unit: adu
-    tap:principal: 0
-  - name: skyNoise
-    description: RMS noise of the sky background.
-    datatype: float
-    ivoa:unit: adu
-    tap:principal: 0
-  - name: psfAdaptiveThresholdValue
-    description: Threshold value used in the adaptive threshold detection pass for PSF modelling.
-    datatype: double
-    tap:principal: 0
-  - name: psfAdaptiveIncludeThresholdMultiplier
-    description: Threshold multiplier used in the adaptive threshold detection pass for PSF modelling.
-    datatype: double
-    tap:principal: 0
-  - name: nShapeletsStar
-    description: Number of sources used in the shapelet decomposition.
-    datatype: int
-    tap:principal: 0
-  - name: shapeletsOnlyIqScore
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power only from the non-atmospheric decomposition coefficients. The
-      score spans the range [0.0, 1.0] with lower values indicating better image quality.
-    datatype: double
-    tap:principal: 0
-  - name: shapeletsIqScore
-    description: The dimensionless image quality score as determined from the shapelets decomposition
-      that includes power from the median centroid offset between those used in the decomposition
-      and those of the centroid slot in addition to non-atmospheric decomposition coefficients.
-      The score spans the range [0.0, 1.0] with lower values indicating better image quality.
-    datatype: double
-    tap:principal: 0
-  - name: centroidDiffShapeletsVsSlotMedian
-    description: Median centroid difference (sqrt((slot_x - shapelet_x)**2 + (slot_y - shapelet_y)**2))
-      for sources used in the shapelet decomposition.
-    datatype: double
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: shapeletsStarEMedian
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the sources used in the
-      shapelet decomposition.
-    datatype: double
-    tap:principal: 0
-  - name: shapeletsStarUnNormalizedEMedian
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
-      of the sources used in the shapelet decomposition.
-    datatype: double
-    ivoa:unit: pixel**2
-  - name: refCatSourceDensity
-    description: Source density for the detector region as computed from the loaded reference catalog
-      (number per degrees**2)
-    datatype: float
-    ivoa:unit: count/deg**2
-    tap:principal: 0
-  - name: astromOffsetMean
-    description: Mean offset of astrometric calibration matches (arcsec)
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: astromOffsetStd
-    description: Standard deviation of offsets of astrometric calibration matches
-      (arcsec)
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: starComa1Median
-    description: Coma-like higher-order moment combination (median M30 + M12 of the stars used in
-      the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starComa2Median
-    description: Coma-like higher-order moment combination (median M21 + M03 of the stars used in
-      the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starTrefoil1Median
-    description: Trefoil-like higher-order moment combination (median M30 - 3*M12 of the stars used in
-      the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starTrefoil2Median
-    description: Trefoil-like higher-order moment combination (median 3*M21 - M03 of the stars used in
-      the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starKurtosisMedian
-    description: Kurtosis-like higher-order moment combination (median M40 + 2*M22 + M04 of the stars
-      used in the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starE41Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median M40 - M04
-      of the stars used in the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: starE42Median
-    description: Fourth-order ellipticity-like higher-order moment combination (median 2*(M31 + M13)
-      of the stars used in the PSF model)
-    datatype: double
-    tap:principal: 0
-  - name: nPsfStar
-    description: Number of stars used for PSF model
-    datatype: int
-    tap:principal: 0
-  - name: psfStarDeltaE1Median
-    description: Median E1 residual (starE1 - psfE1) for psf stars
-    datatype: double
-    tap:principal: 0
-  - name: psfStarDeltaE2Median
-    description: Median E2 residual (starE2 - psfE2) for psf stars
-    datatype: double
-    tap:principal: 0
-  - name: psfStarDeltaE1Scatter
-    description: Scatter (via MAD) of E1 residual (starE1 - psfE1) for psf stars
-    datatype: double
-    tap:principal: 0
-  - name: psfStarDeltaE2Scatter
-    description: Scatter (via MAD) of E2 residual (starE2 - psfE2) for psf stars
-    datatype: double
-    tap:principal: 0
-  - name: psfStarDeltaSizeMedian
-    description: Median size residual (starSize - psfSize) for psf stars (pixel)
-    datatype: double
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: psfStarDeltaSizeScatter
-    description: Scatter (via MAD) of size residual (starSize - psfSize) for stars
-      (pixel)
-    datatype: double
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: psfStarScaledDeltaSizeScatter
-    description: Scatter (via MAD) of size residual scaled by median size squared
-    datatype: double
-    tap:principal: 0
-  - name: psfTraceRadiusDelta
-    description: Delta (max - min) of model psf trace radius values evaluated on a
-      grid of unmasked pixels (pixel)
-    datatype: double
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: psfApFluxDelta
-    description: Delta (max - min) of model psf aperture flux (with aperture radius
-      of max(2, 3*psfSigma)) values evaluated on a grid of unmasked pixels
-    datatype: double
-    tap:principal: 0
-  - name: psfApCorrSigmaScaledDelta
-    description: Delta (max - min) of psf flux aperture correction factors scaled
-      (divided) by the psfSigma evaluated on a grid of unmasked pixels
-    datatype: double
-    tap:principal: 0
-  - name: maxDistToNearestPsf
-    description: Maximum distance of an unmasked pixel to its nearest model psf star
-      (pixel)
-    datatype: double
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: starEMedian
-    description: Median ellipticity (sqrt(starE1**2.0 + starE2**2.0)) of the stars
-      used in the PSF model.
-    datatype: double
-    tap:principal: 0
-  - name: starUnNormalizedEMedian
-    description: Median un-normalized ellipticity (sqrt((starXX - starYY)**2.0 + (2.0*starXY)**2.0))
-      of the stars used in the PSF model.
-    datatype: double
-    ivoa:unit: pixel**2
-    tap:principal: 0
-  - name: seeing
-    description: Mean measured FWHM of the PSF.
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 1
-  - name: skyRotation
-    description: Sky rotation angle.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: expMidpt
-    description: Midpoint time for exposure at the fiducial center of the focal plane
-      array. TAI, accurate to 10ms.
-    datatype: timestamp
-    precision: 6
-    tap:column_index: 6
-    votable:arraysize: '*'
-    votable:xtype: timestamp
-    tap:principal: 0
-  - name: expMidptMJD
-    description: Midpoint time for exposure at the fiducial center of the focal plane
-      array in MJD. TAI, accurate to 10ms.
-    datatype: double
-    ivoa:ucd: time.epoch;obs.exposure
-    ivoa:unit: d
-    tap:column_index: 5
-    tap:principal: 1
-  - name: obsStart
-    description: Start of the visit, TAI, accurate to 10ms.
-    datatype: timestamp
-    precision: 6
-    votable:arraysize: '*'
-    votable:xtype: timestamp
-    tap:principal: 0
-  - name: obsStartMJD
-    description: Start of the exposure in MJD, TAI, accurate to 10ms.
-    datatype: double
-    ivoa:ucd: time.start;obs.exposure
-    ivoa:unit: d
-    tap:column_index: 7
-    tap:principal: 0
-  - name: darkTime
-    description: Average dark current accumulation time, accurate to 10ms.
-    datatype: double
-    ivoa:unit: s
-    tap:principal: 0
-  - name: xSize
-    description: Number of columns in the image.
-    datatype: long
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: ySize
-    description: Number of rows in the image.
-    datatype: long
-    ivoa:unit: pixel
-    tap:principal: 0
-  - name: llcra
-    description: Right Ascension of lower left corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: llcdec
-    description: Declination of lower left corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: ulcra
-    description: Right Ascension of upper left corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: ulcdec
-    description: Declination of upper left corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: urcra
-    description: Right Ascension of upper right corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: urcdec
-    description: Declination of upper right corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: lrcra
-    description: Right Ascension of lower right corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: lrcdec
-    description: Declination of lower right corner.
-    datatype: double
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: effTime
-    description: Effective time metric
-    datatype: double
-    ivoa:unit: s
-    tap:principal: 0
-  - name: effTimePsfSigmaScale
-    description: Effective time metric -- PSF size component
-    datatype: double
-    tap:principal: 0
-  - name: effTimeSkyBgScale
-    description: Effective time metric -- Sky background component
-    datatype: double
-    tap:principal: 0
-  - name: effTimeZeroPointScale
-    description: Effective time metric -- Throughput component
-    datatype: double
-    tap:principal: 0
-  - name: magLim
-    description: 5-sigma limiting magnitude
-    datatype: double
-    ivoa:unit: mag
-    tap:principal: 1
-  - name: wcsCornerMaxOffset
-    description: >
-      Maximum distance between the preliminary and final WCS at the corners of the detector.
-      The WCS is set to null if this exceeds 0.5".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the final WCS position and
-      the position predicted by camera geometry, after re-pointing using the final WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryDetectorPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the prelimnary WCS
-      for this detector only.  The detector is rejected from the pointing fit if this
-      exceeds 10".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
-  - name: wcsPreliminaryVisitPointingResidual
-    description: >
-      Maximum difference (on the pointing-fit grid) between the preliminary WCS position and
-      the position predicted by camera geometry, after re-pointing using the preliminary WCS
-      of all non-rejected detectors in the visit.
-      The WCS is set to null if this exceeds 60".
-    datatype: double
-    ivoa:unit: arcsec
-    tap:principal: 0
+  columnRefs:
+    base:
+      VisitDetector:
+        visitId:
+        detector:
+        physical_filter:
+        band:
+        ra:
+        dec:
+        pixelScale:
+        zenithDistance:
+        expTime:
+        zeroPoint:
+        psfSigma:
+        skyBg:
+        skyNoise:
+        astromOffsetMean:
+        astromOffsetStd:
+        starComa1Median:
+        starComa2Median:
+        starTrefoil1Median:
+        starTrefoil2Median:
+        starKurtosisMedian:
+        starE41Median:
+        starE42Median:
+        nPsfStar:
+        psfStarDeltaE1Median:
+        psfStarDeltaE2Median:
+        psfStarDeltaE1Scatter:
+        psfStarDeltaE2Scatter:
+        psfStarDeltaSizeMedian:
+        psfStarDeltaSizeScatter:
+        psfStarScaledDeltaSizeScatter:
+        psfTraceRadiusDelta:
+        psfApFluxDelta:
+        psfApCorrSigmaScaledDelta:
+        maxDistToNearestPsf:
+        starEMedian:
+        starUnNormalizedEMedian:
+        seeing:
+        skyRotation:
+        expMidpt:
+        expMidptMJD:
+        obsStart:
+        obsStartMJD:
+        darkTime:
+        xSize:
+        ySize:
+        llcra:
+        llcdec:
+        ulcra:
+        ulcdec:
+        urcra:
+        urcdec:
+        lrcra:
+        lrcdec:
+        effTime:
+        effTimePsfSigmaScale:
+        effTimeSkyBgScale:
+        effTimeZeroPointScale:
+        magLim:
+        wcsCornerMaxOffset:
+        wcsDetectorPointingResidual:
+        wcsVisitPointingResidual:
+        wcsPreliminaryDetectorPointingResidual:
+        wcsPreliminaryVisitPointingResidual:
+        shapeletsIqScore:
+        centroidDiffShapeletsVsSlotMedian:
+        shapeletsStarEMedian:
+        refCatSourceDensity:
+        psfAdaptiveIncludeThresholdMultiplier:
+        shapeletsStarUnNormalizedEMedian:
+        psfAdaptiveThresholdValue:
+        shapeletsOnlyIqScore:
+        nShapeletsStar:
   constraints:
   - name: fk_VisitDetector_Visit
     description: Link a Visit to the CCD-level images it contains
@@ -6868,390 +1917,93 @@ tables:
     columns:
     - "#VisitDetector.visitId"
     - "#VisitDetector.detector"
-
 - name: SSObject
   description: LSST-computed per-object quantities.
   tap:table_index: 110
   primaryKey: '#SSObject.ssObjectId'
-  columns:
-  - name: ssObjectId
-    description: Unique identifier.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: designation
-    description: The unpacked primary provisional designation for this object.
-    datatype: char
-    length: 16
-    ivoa:ucd: meta.id;src
-  - name: nObs
-    description: Total number of LSST observations of this object.
-    datatype: int
-    nullable: false
-    ivoa:ucd: meta.number;obs
-  - name: arc
-    description: 'Timespan ("arc") of all LSST observations, t_{last} - t_{first}'
-    datatype: float
-    nullable: false
-    ivoa:unit: d
-    ivoa:ucd: time.duration;obs
-  - name: firstObservationMjdTai
-    description: The time of the first LSST observation of this object (could be precovered), TAI.
-    datatype: double
-    ivoa:unit: d
-    ivoa:ucd: time.epoch;obs
-    # DP2 DISABLED: we will not deliver this for DP2.  The list of Rubin
-    # discoveries will be in flux early in the survey.  Due to the long lead
-    # time between freezing the input data and the release, what we write into
-    # here may change significantly by the time DP2 is released.  Users
-    # interested in this can easily pull it from the MPC (or the PPDB) at the
-    # time of DP2 release.
-    #
-    #  - name: discoverySubmissionDate
-    #    description: The date the LSST first submitted the discovery observations to the MPC. NULL if not an LSST discovery. TAI.
-    #    datatype: double
-    #    ivoa:unit: d
-    #    ivoa:ucd: time.epoch
-
-  - name: MOIDEarth
-    description: Minimum orbit intersection distance to Earth.
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.distance;src.orbital
-  - name: MOIDEarthDeltaV
-    description: DeltaV at the MOID point.
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc.orbital
-  - name: MOIDEarthEclipticLongitude
-    description: "Ecliptic longitude of the MOID point (Earth's orbit)."
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.ecliptic.lon
-  - name: MOIDEarthTrueAnomaly
-    description: "True anomaly of the MOID point on Earth's orbit."
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng
-  - name: MOIDEarthTrueAnomalyObject
-    description: "True anomaly of the MOID point on the object's orbit."
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;src.orbital
-
-  - name: tisserand_J
-    description: Tisserand parameter with respect to Jupiter (T_J).
-    datatype: float
-    ivoa:ucd: src.orbital.TissJ
-
-  - name: extendednessMax
-    description: Maximum `extendedness` value from the DiaSource.
-    datatype: float
-  - name: extendednessMedian
-    description: Median `extendedness` value from the DiaSource.
-    datatype: float
-  - name: extendednessMin
-    description: Minimum `extendedness` value from the DiaSource.
-    datatype: float
-
-  - name: u_nObs
-    description: Total number of data points (u band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: u_H
-    description: Best fit absolute magnitude (u band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: u_HErr
-    description: Error in the estimate of H (u band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: u_G12
-    description: Best fit G12 slope parameter (u band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: u_G12Err
-    description: Error in the estimate of G12 (u band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: u_H_u_G12_Cov
-    description: H–G12 covariance (u band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: u_nObsUsed
-    description: The number of data points used to fit the phase curve (u band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: u_Chi2
-    description: Chi^2 statistic of the phase curve fit (u band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: u_phaseAngleMin
-    description: Minimum phase angle observed (u band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: u_phaseAngleMax
-    description: Maximum phase angle observed (u band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: u_slope_fit_failed
-    description: G12 fit failed in u band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
-
-
-  - name: g_nObs
-    description: Total number of data points (g band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: g_H
-    description: Best fit absolute magnitude (g band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: g_HErr
-    description: Error in the estimate of H (g band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: g_G12
-    description: Best fit G12 slope parameter (g band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: g_G12Err
-    description: Error in the estimate of G12 (g band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: g_H_g_G12_Cov
-    description: H–G12 covariance (g band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: g_nObsUsed
-    description: The number of data points used to fit the phase curve (g band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: g_Chi2
-    description: Chi^2 statistic of the phase curve fit (g band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: g_phaseAngleMin
-    description: Minimum phase angle observed (g band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: g_phaseAngleMax
-    description: Maximum phase angle observed (g band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: g_slope_fit_failed
-    description: G12 fit failed in g band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
-
-
-  - name: r_nObs
-    description: Total number of data points (r band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: r_H
-    description: Best fit absolute magnitude (r band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: r_HErr
-    description: Error in the estimate of H (r band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: r_G12
-    description: Best fit G12 slope parameter (r band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: r_G12Err
-    description: Error in the estimate of G12 (r band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: r_H_r_G12_Cov
-    description: H–G12 covariance (r band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: r_nObsUsed
-    description: The number of data points used to fit the phase curve (r band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: r_Chi2
-    description: Chi^2 statistic of the phase curve fit (r band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: r_phaseAngleMin
-    description: Minimum phase angle observed (r band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: r_phaseAngleMax
-    description: Maximum phase angle observed (r band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: r_slope_fit_failed
-    description: G12 fit failed in r band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
-
-
-  - name: i_nObs
-    description: Total number of data points (i band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: i_H
-    description: Best fit absolute magnitude (i band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: i_HErr
-    description: Error in the estimate of H (i band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: i_G12
-    description: Best fit G12 slope parameter (i band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: i_G12Err
-    description: Error in the estimate of G12 (i band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: i_H_i_G12_Cov
-    description: H–G12 covariance (i band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: i_nObsUsed
-    description: The number of data points used to fit the phase curve (i band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: i_Chi2
-    description: Chi^2 statistic of the phase curve fit (i band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: i_phaseAngleMin
-    description: Minimum phase angle observed (i band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: i_phaseAngleMax
-    description: Maximum phase angle observed (i band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: i_slope_fit_failed
-    description: G12 fit failed in i band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
-
-
-  - name: z_nObs
-    description: Total number of data points (z band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: z_H
-    description: Best fit absolute magnitude (z band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: z_HErr
-    description: Error in the estimate of H (z band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: z_G12
-    description: Best fit G12 slope parameter (z band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: z_G12Err
-    description: Error in the estimate of G12 (z band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: z_H_z_G12_Cov
-    description: H–G12 covariance (z band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: z_nObsUsed
-    description: The number of data points used to fit the phase curve (z band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: z_Chi2
-    description: Chi^2 statistic of the phase curve fit (z band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: z_phaseAngleMin
-    description: Minimum phase angle observed (z band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: z_phaseAngleMax
-    description: Maximum phase angle observed (z band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: z_slope_fit_failed
-    description: G12 fit failed in z band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
-
-
-  - name: y_nObs
-    description: Total number of data points (y band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: y_H
-    description: Best fit absolute magnitude (y band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag
-  - name: y_HErr
-    description: Error in the estimate of H (y band).
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: stat.error;phot.mag
-  - name: y_G12
-    description: Best fit G12 slope parameter (y band).
-    datatype: float
-    ivoa:ucd: stat.fit.param
-  - name: y_G12Err
-    description: Error in the estimate of G12 (y band).
-    datatype: float
-    ivoa:ucd: stat.error;stat.fit.param
-  - name: y_H_y_G12_Cov
-    description: H–G12 covariance (y band).
-    datatype: float
-    ivoa:unit: mag**2
-    ivoa:ucd: stat.covariance;phot.mag;stat.fit.param
-  - name: y_nObsUsed
-    description: The number of data points used to fit the phase curve (y band).
-    datatype: int
-    ivoa:ucd: meta.number;obs
-  - name: y_Chi2
-    description: Chi^2 statistic of the phase curve fit (y band).
-    datatype: float
-    ivoa:ucd: stat.fit.chi2
-  - name: y_phaseAngleMin
-    description: Minimum phase angle observed (y band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.min
-  - name: y_phaseAngleMax
-    description: Maximum phase angle observed (y band).
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng;stat.max
-  - name: y_slope_fit_failed
-    description: G12 fit failed in y band. G12 contains a fiducial value used to fit H.
-    datatype: boolean
+  columnRefs:
+    base:
+      SSObject:
+        ssObjectId:
+        designation:
+        nObs:
+        arc:
+        firstObservationMjdTai:
+        MOIDEarth:
+        MOIDEarthDeltaV:
+        MOIDEarthEclipticLongitude:
+        MOIDEarthTrueAnomaly:
+        MOIDEarthTrueAnomalyObject:
+        tisserand_J:
+        extendednessMax:
+        extendednessMedian:
+        extendednessMin:
+        u_nObs:
+        u_H:
+        u_HErr:
+        u_G12:
+        u_G12Err:
+        u_H_u_G12_Cov:
+        u_nObsUsed:
+        u_Chi2:
+        u_phaseAngleMin:
+        u_phaseAngleMax:
+        u_slope_fit_failed:
+        g_nObs:
+        g_H:
+        g_HErr:
+        g_G12:
+        g_G12Err:
+        g_H_g_G12_Cov:
+        g_nObsUsed:
+        g_Chi2:
+        g_phaseAngleMin:
+        g_phaseAngleMax:
+        g_slope_fit_failed:
+        r_nObs:
+        r_H:
+        r_HErr:
+        r_G12:
+        r_G12Err:
+        r_H_r_G12_Cov:
+        r_nObsUsed:
+        r_Chi2:
+        r_phaseAngleMin:
+        r_phaseAngleMax:
+        r_slope_fit_failed:
+        i_nObs:
+        i_H:
+        i_HErr:
+        i_G12:
+        i_G12Err:
+        i_H_i_G12_Cov:
+        i_nObsUsed:
+        i_Chi2:
+        i_phaseAngleMin:
+        i_phaseAngleMax:
+        i_slope_fit_failed:
+        z_nObs:
+        z_H:
+        z_HErr:
+        z_G12:
+        z_G12Err:
+        z_H_z_G12_Cov:
+        z_nObsUsed:
+        z_Chi2:
+        z_phaseAngleMin:
+        z_phaseAngleMax:
+        z_slope_fit_failed:
+        y_nObs:
+        y_H:
+        y_HErr:
+        y_G12:
+        y_G12Err:
+        y_H_y_G12_Cov:
+        y_nObsUsed:
+        y_Chi2:
+        y_phaseAngleMin:
+        y_phaseAngleMax:
+        y_slope_fit_failed:
   constraints:
   - name: fk_SSObject_mpc_orbits
     description: Link an SSObject to its associated mpc_orbits
@@ -7270,231 +2022,52 @@ tables:
     description: Index on the MOIDEarth column
     columns:
     - "#SSObject.MOIDEarth"
-
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
   tap:table_index: 120
   primaryKey: '#SSSource.diaSourceId'
-
-  columns:
-  - name: diaSourceId
-    description: Unique identifier of the observation (matching DiaSource.diaSourceId).
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: ssObjectId
-    description: Unique LSST identifier of the Solar System object.
-    datatype: long
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: designation
-    description: The unpacked primary provisional designation for this object.
-    datatype: char
-    length: 16
-    ivoa:ucd: meta.id;src
-
-
-  - name: eclLambda
-    description: Ecliptic longitude, converted from the observed coordinates.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.ecliptic.lon
-  - name: eclBeta
-    description: Ecliptic latitude, converted from the observed coordinates.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.ecliptic.lat
-
-  - name: galLon
-    description: Galactic longitude, converted from the observed coordinates.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.galactic.lon
-  - name: galLat
-    description: Galactic latitude, converted from the observed coordinates.
-    datatype: double
-    nullable: false
-    ivoa:unit: deg
-    ivoa:ucd: pos.galactic.lat
-
-  - name: elongation
-    description: Solar elongation of the object at the time of observation.
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng
-  - name: phaseAngle
-    description: Phase angle between the Sun, object, and observer.
-    datatype: float
-    ivoa:unit: deg
-    ivoa:ucd: pos.phaseAng
-
-  - name: topoRange
-    description: Topocentric distance (delta) at light-emission time.
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.distance
-  - name: topoRangeRate
-    description: Topocentric radial (line-of-sight) velocity (deldot); positive values indicate motion away from the observer.
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc
-
-  - name: helioRange
-    description: Heliocentric distance (r) at light-emission time.
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.distance;pos.heliocentric
-  - name: helioRangeRate
-    description: Heliocentric radial velocity (rdot); positive values indicate motion away from the Sun.
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.heliocentric
-
-  - name: ephRa
-    description: Predicted ICRS right ascension from the orbit in mpc_orbits.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.ra;meta.modelled;pos.ephem
-  - name: ephDec
-    description: Predicted ICRS declination from the orbit in mpc_orbits.
-    datatype: double
-    ivoa:unit: deg
-    ivoa:ucd: pos.eq.dec;meta.modelled;pos.ephem
-  - name: ephVmag
-    description: >
-      Predicted magnitude in V band, computed from mpc_orbits data including
-      the mpc_orbits-provided (H, G) estimates
-    datatype: float
-    ivoa:unit: mag
-    ivoa:ucd: phot.mag;em.opt.V
-
-  - name: ephRate
-    description: Total predicted on-sky angular rate of motion.
-    datatype: float
-    ivoa:unit: deg/d
-    ivoa:ucd: pos.pm;pos.ephem
-  - name: ephRateRa
-    description: Predicted on-sky angular rate in the R.A. direction (includes the cos(dec) factor).
-    datatype: float
-    ivoa:unit: deg/d
-    ivoa:ucd: pos.pm;pos.eq.ra;pos.ephem
-  - name: ephRateDec
-    description: Predicted on-sky angular rate in the declination direction.
-    datatype: float
-    ivoa:unit: deg/d
-    ivoa:ucd: pos.pm;pos.eq.dec;pos.ephem
-
-  - name: ephOffset
-    description: Total observed versus predicted angular separation on the sky.
-    datatype: float
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.angDistance;stat.fit.omc
-  - name: ephOffsetRa
-    description: Offset between observed and predicted position in the R.A. direction (includes cos(dec) term).
-    datatype: double
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.eq.ra;stat.fit.omc
-  - name: ephOffsetDec
-    description: Offset between observed and predicted position in declination.
-    datatype: double
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.eq.dec;stat.fit.omc
-  - name: ephOffsetAlongTrack
-    description: Offset between observed and predicted position in the along-track direction on the sky.
-    datatype: float
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.angDistance;stat.fit.omc
-  - name: ephOffsetCrossTrack
-    description: Offset between observed and predicted position in the cross-track direction on the sky.
-    datatype: float
-    ivoa:unit: arcsec
-    ivoa:ucd: pos.angDistance;stat.fit.omc
-
-
-  - name: helio_x
-    description: Cartesian heliocentric X coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.x;pos.heliocentric
-  - name: helio_y
-    description: Cartesian heliocentric Y coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.y;pos.heliocentric
-  - name: helio_z
-    description: Cartesian heliocentric Z coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.z;pos.heliocentric
-  - name: helio_vx
-    description: Cartesian heliocentric X velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.x
-  - name: helio_vy
-    description: Cartesian heliocentric Y velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.y
-  - name: helio_vz
-    description: Cartesian heliocentric Z velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.z
-  - name: helio_vtot
-    description: "The magnitude of the heliocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz)."
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.heliocentric
-
-  - name: topo_x
-    description: Cartesian topocentric X coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.x
-  - name: topo_y
-    description: Cartesian topocentric Y coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.y
-  - name: topo_z
-    description: Cartesian topocentric Z coordinate at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: AU
-    ivoa:ucd: pos.cartesian.z
-  - name: topo_vx
-    description: Cartesian topocentric X velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.x
-  - name: topo_vy
-    description: Cartesian topocentric Y velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.y
-  - name: topo_vz
-    description: Cartesian topocentric Z velocity at light-emission time (ICRS).
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc;pos.cartesian.z
-  - name: topo_vtot
-    description: "The magnitude of the topocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz)."
-    datatype: float
-    ivoa:unit: km/s
-    ivoa:ucd: phys.veloc
-
-  - name: diaDistanceRank
-    description: >-
-      The rank of the diaSourceId-identified source in terms of its
-      closeness to the predicted SSO position.  If diaSourceId is the
-      nearest DiaSource to this SSO prediction, diaSourceDistanceRank=1
-      would be set. If it is the second nearest, it would be 2, etc.
-    datatype: short
-
-
+  columnRefs:
+    base:
+      SSSource:
+        diaSourceId:
+        ssObjectId:
+        designation:
+        eclLambda:
+        eclBeta:
+        galLon:
+        galLat:
+        elongation:
+        phaseAngle:
+        topoRange:
+        topoRangeRate:
+        helioRange:
+        helioRangeRate:
+        ephRa:
+        ephDec:
+        ephVmag:
+        ephRate:
+        ephRateRa:
+        ephRateDec:
+        ephOffset:
+        ephOffsetRa:
+        ephOffsetDec:
+        ephOffsetAlongTrack:
+        ephOffsetCrossTrack:
+        helio_x:
+        helio_y:
+        helio_z:
+        helio_vx:
+        helio_vy:
+        helio_vz:
+        helio_vtot:
+        topo_x:
+        topo_y:
+        topo_z:
+        topo_vx:
+        topo_vy:
+        topo_vz:
+        topo_vtot:
+        diaDistanceRank:
   constraints:
   - name: fk_SSSource_DiaSource
     description: Link an SSSource to its associated DiaSource
@@ -7503,7 +2076,6 @@ tables:
     - '#SSSource.diaSourceId'
     referencedColumns:
     - '#DiaSource.diaSourceId'
-
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
@@ -7511,7 +2083,6 @@ tables:
     - '#SSSource.ssObjectId'
     referencedColumns:
     - '#SSObject.ssObjectId'
-
   - name: fk_SSSource_mpc_orbits
     description: Link an SSSource to its associated mpc_orbits
     '@type': ForeignKey
@@ -7519,7 +2090,6 @@ tables:
     - '#SSSource.designation'
     referencedColumns:
     - '#mpc_orbits.designation'
-
   indexes:
   - name: idx_SSSource_ssObjectId
     description: >
@@ -7533,7 +2103,6 @@ tables:
       single-epoch data for SSObjects.
     columns:
     - "#SSSource.designation"
-
 - name: mpc_orbits
   description: Table of orbital elements and related information of known (sun-orbiting and unbound) Solar
     System objects. Replicated from the Minor Planet Center (Postgres) database. This schema will
@@ -7541,241 +2110,62 @@ tables:
     developed elsewhere on the RSP.
   tap:table_index: 130
   primaryKey: '#mpc_orbits.id'
-  columns:
-  - name: id
-    description: Internal ID (generally not seen/used by the user)
-    datatype: int
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: designation
-    # Note: the 'designation' column is a Rubin-provided copy of the
-    # unpacked_primary_provisional_designation column to work around UX issues.
-    description: The primary provisional designation in unpacked form (e.g. 2008 AB).
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: packed_primary_provisional_designation
-    description: The primary provisional designation in packed form (e.g. K08A00B)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: unpacked_primary_provisional_designation
-    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: mpc_orb_jsonb
-    description: Details of the orbit solution in JSON form
-    datatype: text
-  - name: created_at
-    description: When this row was created
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.creation;meta.dataset
-  - name: updated_at
-    description: When this row was updated
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.processing;meta.dataset
-  - name: orbit_type_int
-    description: Orbit Type (Integer)
-    datatype: int
-  - name: u_param
-    description: U parameter
-    datatype: int
-  - name: nopp
-    description: number of oppositions
-    datatype: int
-  - name: arc_length_total
-    description: "Arc length over total observations [days]"
-    datatype: double
-    ivoa:unit: d
-  - name: arc_length_sel
-    description: "Arc length over total observations *selected* [days]"
-    datatype: double
-    ivoa:unit: d
-  - name: nobs_total
-    description: Total number of all observations (optical + radar) available
-    datatype: int
-  - name: nobs_total_sel
-    description: Total number of all observations (optical + radar) selected for use in orbit fitting
-    datatype: int
-  - name: a
-    description: "Semi Major Axis [au]"
-    datatype: double
-    ivoa:ucd: pos.distance;src.orbital
-    ivoa:unit: AU
-  - name: q
-    description: "Pericenter Distance [au]"
-    datatype: double
-    ivoa:ucd: pos.distance;src.orbital
-    ivoa:unit: AU
-  - name: e
-    description: "Eccentricity"
-    datatype: double
-    ivoa:ucd: src.orbital.eccentricity
-  - name: i
-    description: "Inclination [degrees]"
-    datatype: double
-    ivoa:ucd: src.orbital.inclination
-    ivoa:unit: deg
-  - name: node
-    description: "Longitude of Ascending Node [degrees]"
-    datatype: double
-    ivoa:ucd: src.orbital.node
-    ivoa:unit: deg
-  - name: argperi
-    description: "Argument of Pericenter [degrees]"
-    datatype: double
-    ivoa:ucd: src.orbital.periastron
-    ivoa:unit: deg
-  - name: peri_time
-    description: "Time from Pericenter Passage [days]"
-    datatype: double
-    ivoa:unit: d
-  - name: yarkovsky
-    description: "Yarkovsky Component [10^(-10)*au/day^2]"
-    datatype: double
-    ivoa:unit: 1e-10.au.d-2
-  - name: srp
-    description: "Solar-Radiation Pressure Component [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a1
-    description: "A1 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a2
-    description: "A2 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a3
-    description: "A3 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: dt
-    description: DT non-grav component
-    datatype: double
-  - name: mean_anomaly
-    description: "Mean Anomaly [degrees]"
-    datatype: double
-    ivoa:ucd: src.orbital.meanAnomaly
-    ivoa:unit: deg
-  - name: period
-    description: "Orbital Period [days]"
-    datatype: double
-    ivoa:ucd: time.period.revolution;src.orbital
-    ivoa:unit: d
-  - name: mean_motion
-    description: "Orbital Mean Motion [degrees per day]"
-    datatype: double
-    ivoa:ucd: src.orbital.meanMotion
-    ivoa:unit: deg.d-1
-  - name: a_unc
-    description: "Uncertainty on Semi Major Axis [au]"
-    datatype: double
-    ivoa:ucd: stat.error;pos.distance;src.orbital
-    ivoa:unit: AU
-  - name: q_unc
-    description: "Uncertainty on Pericenter Distance [au]"
-    datatype: double
-    ivoa:ucd: stat.error;pos.distance;src.orbital
-    ivoa:unit: AU
-  - name: e_unc
-    description: "Uncertainty on Eccentricity"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.eccentricity
-  - name: i_unc
-    description: "Uncertainty on Inclination [degrees]"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.inclination
-    ivoa:unit: deg
-  - name: node_unc
-    description: "Uncertainty on Longitude of Ascending Node [degrees]"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.node
-    ivoa:unit: deg
-  - name: argperi_unc
-    description: "Uncertainty on Argument of Pericenter [degrees]"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.periastron
-    ivoa:unit: deg
-  - name: peri_time_unc
-    description: "Uncertainty on Time from Pericenter Passage [days]"
-    datatype: double
-    ivoa:unit: d
-  - name: yarkovsky_unc
-    description: "Uncertainty on Yarkovsky Component [10^(-10)*au/day^2]"
-    datatype: double
-    ivoa:unit: 1e-10.au.d-2
-  - name: srp_unc
-    description: "Uncertainty on Solar-Radiation Pressure Component [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a1_unc
-    description: "Uncertainty on A1 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a2_unc
-    description: "Uncertainty on A2 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: a3_unc
-    description: "Uncertainty on A3 non-grav components [m^2/ton]"
-    datatype: double
-    ivoa:unit: m2.t-1
-  - name: dt_unc
-    description: Uncertainty on DT non-grav component
-    datatype: double
-  - name: mean_anomaly_unc
-    description: "Uncertainty on Mean Anomaly [degrees]"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.meanAnomaly
-    ivoa:unit: deg
-  - name: period_unc
-    description: "Uncertainty on Orbital Period [days]"
-    datatype: double
-    ivoa:ucd: stat.error;time.period.revolution;src.orbital
-    ivoa:unit: d
-  - name: mean_motion_unc
-    description: "Uncertainty on Orbital Mean Motion [degrees per day]"
-    datatype: double
-    ivoa:ucd: stat.error;src.orbital.meanMotion
-    ivoa:unit: deg.d-1
-  - name: epoch_mjd
-    description: Epoch of the Orbfit-Solution in MJD
-    datatype: double
-    ivoa:ucd: time.epoch;src.orbital
-    ivoa:unit: d
-  - name: h
-    description: H-Magnitude
-    datatype: double
-    ivoa:ucd: phys.magAbs
-    ivoa:unit: mag
-  - name: g
-    description: G-Slope Parameter
-    datatype: double
-  - name: not_normalized_rms
-    description: "unnormalized rms of the fit [arcsec]"
-    datatype: double
-    ivoa:ucd: stat.rms;stat.fit
-    ivoa:unit: arcsec
-  - name: normalized_rms
-    description: "rms of the fit [unitless]"
-    datatype: double
-    ivoa:ucd: stat.rms;stat.fit
-  - name: earth_moid
-    description: "Minimum Orbit Intersection Distance [au] with respect to the Earths Orbit"
-    datatype: double
-    ivoa:ucd: pos.distance;src.orbital
-    ivoa:unit: AU
-  - name: fitting_datetime
-    description: Date of the last orbit fit
-    datatype: timestamp
-    precision: 6
+  columnRefs:
+    base:
+      mpc_orbits:
+        id:
+        designation:
+        packed_primary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        mpc_orb_jsonb:
+        created_at:
+        updated_at:
+        orbit_type_int:
+        u_param:
+        nopp:
+        arc_length_total:
+        arc_length_sel:
+        nobs_total:
+        nobs_total_sel:
+        a:
+        q:
+        e:
+        i:
+        node:
+        argperi:
+        peri_time:
+        yarkovsky:
+        srp:
+        a1:
+        a2:
+        a3:
+        dt:
+        mean_anomaly:
+        period:
+        mean_motion:
+        a_unc:
+        q_unc:
+        e_unc:
+        i_unc:
+        node_unc:
+        argperi_unc:
+        peri_time_unc:
+        yarkovsky_unc:
+        srp_unc:
+        a1_unc:
+        a2_unc:
+        a3_unc:
+        dt_unc:
+        mean_anomaly_unc:
+        period_unc:
+        mean_motion_unc:
+        epoch_mjd:
+        h:
+        g:
+        not_normalized_rms:
+        normalized_rms:
+        earth_moid:
+        fitting_datetime:
   constraints:
   - name: unique_mpc_orbits_unpacked_primary_provisional_designation
     description: Uniqueness of unpacked_primary_provisional_designation
@@ -7792,7 +2182,6 @@ tables:
     '@type': Unique
     columns:
     - '#mpc_orbits.packed_primary_provisional_designation'
-
 - name: current_identifications
   description: All single-designations, and all identifications between designations. Always uses primary
     provisional designation (even for numbered objects). Includes all comets and satellites.
@@ -7801,64 +2190,20 @@ tables:
     elsewhere on the RSP.
   tap:table_index: 140
   primaryKey: '#current_identifications.id'
-  columns:
-  - name: id
-    description: Internal ID (generally not seen/used by the user)
-    datatype: int
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: packed_primary_provisional_designation
-    description: The primary provisional designation in packed form (e.g. K08A00B)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: packed_secondary_provisional_designation
-    description: The secondary provisional designation in packed form (e.g. K08A00B). May be the same-as (A=A)
-      or different-to (A=B) the primary provisional designation
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: unpacked_primary_provisional_designation
-    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: unpacked_secondary_provisional_designation
-    description: The secondary provisional designation in unpacked form (e.g. 2008 AB). May be the same-as
-      (A=A) or different-to (A=B) the primary provisional designation
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: published
-    description: Has this been published yet? i.e. has it been released to the public?
-    datatype: boolean
-    ivoa:ucd: meta.code.status;meta.dataset
-  - name: identifier_ids
-    description: This is a set of unique identifier_ids in an array that points to the identification_metadata
-      table.
-    datatype: text
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: object_type
-    description: Integer to indicate the object type. To be linked (foreign key) to object_type lookup table
-    datatype: int
-  - name: numbered
-    description: Has the object been numbered and hence does it appear in the numbered_objects table?
-    datatype: boolean
-  - name: created_at
-    description: When this row was created
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.creation;meta.dataset
-  - name: updated_at
-    description: When this row was updated
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.processing;meta.dataset
+  columnRefs:
+    base:
+      current_identifications:
+        id:
+        packed_primary_provisional_designation:
+        packed_secondary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        unpacked_secondary_provisional_designation:
+        published:
+        identifier_ids:
+        object_type:
+        numbered:
+        created_at:
+        updated_at:
   constraints:
   - name: unique_current_identifications_packed_primary_provisional_desig
     "@type": Unique
@@ -7870,7 +2215,6 @@ tables:
     description: Unique index on the packed_secondary_provisional_designation column
     columns:
     - '#current_identifications.packed_secondary_provisional_designation'
-
 - name: numbered_identifications
   description: The numbered identification table contains all the numbered objects (minor planets, comets and
     natural satellites) with their primary provisional designations. The table is continously
@@ -7879,60 +2223,20 @@ tables:
     end-users to rerun queries developed elsewhere on the RSP.
   tap:table_index: 150
   primaryKey: '#numbered_identifications.id'
-  columns:
-  - name: id
-    description: Internal ID (generally not seen/used by the user)
-    datatype: int
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: packed_primary_provisional_designation
-    description: The primary provisional designation in packed form (e.g. K08A00B)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: unpacked_primary_provisional_designation
-    description: The primary provisional designation in unpacked form (e.g. 2008 AB)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: permid
-    description: Permanent designation (number)
-    datatype: char
-    length: 16
-    nullable: false
-    ivoa:ucd: meta.id;src
-  - name: iau_designation
-    description: IAU-approved designation (not filled at the moment)
-    datatype: text
-    ivoa:ucd: meta.id;src
-  - name: iau_name
-    description: IAU-approved name (not filled at the moment)
-    datatype: char
-    length: 32
-    ivoa:ucd: meta.id;src
-  - name: numbered_publication_references
-    description: MPEC where this object was numbered
-    datatype: text
-    ivoa:ucd: meta.bib.bibcode
-  - name: named_publication_references
-    description: MPEC where this object was named
-    datatype: text
-    ivoa:ucd: meta.bib.bibcode
-  - name: naming_credit
-    description: Credit for suggesting the name
-    datatype: text
-  - name: created_at
-    description: When this row was created
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.creation;meta.dataset
-  - name: updated_at
-    description: When this row was updated
-    datatype: timestamp
-    precision: 6
-    ivoa:ucd: time.processing;meta.dataset
+  columnRefs:
+    base:
+      numbered_identifications:
+        id:
+        packed_primary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        permid:
+        iau_designation:
+        iau_name:
+        numbered_publication_references:
+        named_publication_references:
+        naming_credit:
+        created_at:
+        updated_at:
   constraints:
   - name: unique_numbered_identifications_iau_name
     "@type": Unique
@@ -7954,469 +2258,132 @@ tables:
     description: Unique index on the unpacked_primary_provisional_designation column
     columns:
     - '#numbered_identifications.unpacked_primary_provisional_designation'
-
 - name: Parent
   description: "Descriptions of the parent objects in the deblending hierarchy."
   tap:table_index: 160
   primaryKey: '#Parent.objectId'
-  columns:
-  - name: objectId
-    description: Unique id. Unique ObjectID
-    datatype: long
-    ivoa:ucd: meta.id;src
-    tap:principal: 1
-  - name: parentObjectId
-    description: Unique ID of parent source. Reference band.
-    datatype: long
-    tap:principal: 1
-  - name: merge_peak_sky
-    description: True when the parent object is a sky object
-    datatype: boolean
-  - name: deblend_nChild
-    description: Number of children this object has (defaults to 0)
-    datatype: int
-  - name: deblend_nPeaks
-    description: Number of peaks this parent footprint has (even if the deblender
-      failed or skipped this blend)
-    datatype: int
-  - name: deblend_failed
-    description: Deblender failed to deblend this source
-    datatype: boolean
-  - name: deblend_skipped
-    description: Deblender skipped this source
-    datatype: boolean
-  - name: deblend_skipped_isolatedParent
-    description: Deblender skipped this footprint because there was only a single
-      peak
-    datatype: boolean
-  - name: deblend_skipped_parentTooBig
-    description: Deblender skipped this source because the parent footprint was too
-      large.
-    datatype: boolean
-  - name: deblend_skipped_tooManyPeaks
-    description: Deblender skipped this source because there were too many peaks in
-      the Footprint.
-    datatype: boolean
-  - name: deblend_skipped_masked
-    description: Deblender skipped this source because there were too many masked
-      pixels.
-    datatype: boolean
-  - name: deblend_skipped_isPseudo
-    description: Deblender skipped this source because it was marked as a pseudo
-      source like a sky object.
-    datatype: boolean
-  - name: deblend_incompleteData
-    description: One or more bands were not deblended due to an inability to model
-      the PSF.
-    datatype: boolean
-  - name: deblend_iterations
-    description: Number of iterations during deblending
-    datatype: int
-  - name: deblend_chi2
-    description: Chi^2 of the source after deblending.
-    datatype: float
-  indexes:
-  - name: idx_Parent_objectId
-    description: Unique index on objectId column
-    columns:
-    - "#Parent.objectId"
-
+  columnRefs:
+    base:
+      Parent:
+        objectId:
+        parentObjectId:
+        merge_peak_sky:
+        deblend_nChild:
+        deblend_nPeaks:
+        deblend_failed:
+        deblend_skipped:
+        deblend_skipped_isolatedParent:
+        deblend_skipped_parentTooBig:
+        deblend_skipped_tooManyPeaks:
+        deblend_skipped_masked:
+        deblend_skipped_isPseudo:
+        deblend_incompleteData:
+        deblend_iterations:
+        deblend_chi2:
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."
   tap:table_index: 170
   primaryKey: '#ShearObject.shearObjectId'
-  columns:
-  - name: shearObjectId
-    description: Unique identifier for a ShearObject, specific to a single metacalibration counterfactual image.
-    datatype: long
-    ivoa:ucd: meta.id;src
-    tap:principal: 1
-  - name: tract
-    description: Skymap tract ID
-    datatype: long
-    tap:principal: 1
-  - name: patch
-    description: Skymap patch ID
-    datatype: long
-    tap:principal: 1
-  - name: cell_x
-    description: Column of the cell within the patch on which this measurement was made.
-    datatype: int
-  - name: cell_y
-    description: Row of the cell within the patch on which this measurement was made.
-    datatype: int
-  - name: metaStep
-    description: Type of artificial shear applied to image. One of 'ns', '1p', '1m', '2p', '2m'.
-    datatype: char
-    length: 2
-  - name: image_flags
-    description: Flags for the image on which this measurement was made.
-    datatype: int
-  - name: x
-    description: Centroid (tract, x-axis) of the detected ShearObject.
-    datatype: float
-  - name: y
-    description: Centroid (tract, y-axis) of the detected ShearObject.
-    datatype: float
-  - name: ra
-    description: Detected Right Ascension of the ShearObject.
-    datatype: double
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-  - name: dec
-    description: Detected Declination of the ShearObject.
-    datatype: double
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-  - name: psfOriginal_flags
-    description: Flags for the original PSF measurement.
-    datatype: int
-  - name: psfOriginal_e1
-    description: Distortion-style e1 of the original PSF from adaptive moments.
-    datatype: float
-  - name: psfOriginal_e2
-    description: Distortion-style e2 of the original PSF from adaptive moments.
-    datatype: float
-  - name: psfOriginal_T
-    description: Trace (<x^2> + <y^2>) measurement of the original PSF from adaptive moments.
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: bmask_flags
-    description: bmask flags for the ShearObject.
-    datatype: int
-  - name: ormask_flags
-    description: ored mask flags for the ShearObject.
-    datatype: int
-  - name: mfrac
-    description: Gaussian-weighted masked fraction for the ShearObject.
-    datatype: float
-  - name: gauss_psfReconvolved_flags
-    description: Flags for reconvolved PSF (measured with gauss algorithm).
-    datatype: int
-  - name: gauss_psfReconvolved_g1
-    description: Reduced-shear g1 of the reconvolved PSF (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_psfReconvolved_g2
-    description: Reduced-shear g2 of the reconvolved PSF (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_psfReconvolved_T
-    description: Trace (<x^2> + <y^2>) of the reconvolved PSF (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: gauss_g1
-    description: Reduced-shear g1 measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_g2
-    description: Reduced-shear g2 measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_g1_g1_Cov
-    description: Auto-covariance of g1 measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_g1_g2_Cov
-    description: Cross-covariance of g1 and g2 measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_g2_g2_Cov
-    description: Auto-covariance of g2 measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_snr
-    description: Signal-to-noise ratio measure of the ShearObject (measured with gauss algorithm).
-    datatype: float
-  - name: gauss_T
-    description: Trace (<x^2> + <y^2>) measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: gauss_TErr
-    description: Uncertainty in the trace measurement of the ShearObject (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: gauss_shape_flags
-    description: Flags for the second moments measurement of the ShearObject (measured with gauss algorithm).
-    datatype: int
-  - name: gauss_object_flags
-    description: Flags for the ShearObject measurement (measured with gauss algorithm).
-    datatype: int
-  - name: gauss_flags
-    description: Overall flags for gauss measurement algorithm.
-    datatype: int
-  - name: pgauss_snr
-    description: Signal-to-noise ratio measure of the ShearObject (measured with pgauss algorithm).
-    datatype: float
-  - name: pgauss_T
-    description: Trace (<x^2> + <y^2>) measurement of the ShearObject (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: pgauss_TErr
-    description: Uncertainty in the trace measurement of the ShearObject (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: arcsec**2
-  - name: pgauss_shape_flags
-    description: Flags for the second moments measurement of the ShearObject (measured with pgauss algorithm).
-    datatype: int
-  - name: pgauss_object_flags
-    description: Flags for the ShearObject measurement (measured with pgauss algorithm).
-    datatype: int
-  - name: pgauss_flags
-    description: Overall flags for pgauss measurement algorithm.
-    datatype: int
-  - name: g_gaussFlux_flags
-    description: Flags set for flux in g band measured with gauss algorithm.
-    datatype: int
-  - name: g_gaussFlux
-    description: Flux in g band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_gaussFluxErr
-    description: Flux uncertainty in g band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaussFlux_flags
-    description: Flags set for flux in r band measured with gauss algorithm.
-    datatype: int
-  - name: r_gaussFlux
-    description: Flux in r band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_gaussFluxErr
-    description: Flux uncertainty in r band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaussFlux_flags
-    description: Flags set for flux in i band measured with gauss algorithm.
-    datatype: int
-  - name: i_gaussFlux
-    description: Flux in i band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_gaussFluxErr
-    description: Flux uncertainty in i band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaussFlux_flags
-    description: Flags set for flux in z band measured with gauss algorithm.
-    datatype: int
-  - name: z_gaussFlux
-    description: Flux in z band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_gaussFluxErr
-    description: Flux uncertainty in z band (measured with gauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_pgaussFlux_flags
-    description: Flags set for flux in g band measured with pgauss algorithm.
-    datatype: int
-  - name: g_pgaussFlux
-    description: Flux in g band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: g_pgaussFluxErr
-    description: Flux uncertainty in g band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_pgaussFlux_flags
-    description: Flags set for flux in r band measured with pgauss algorithm.
-    datatype: int
-  - name: r_pgaussFlux
-    description: Flux in r band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: r_pgaussFluxErr
-    description: Flux uncertainty in r band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_pgaussFlux_flags
-    description: Flags set for flux in i band measured with pgauss algorithm.
-    datatype: int
-  - name: i_pgaussFlux
-    description: Flux in i band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: i_pgaussFluxErr
-    description: Flux uncertainty in i band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_pgaussFlux_flags
-    description: Flags set for flux in z band measured with pgauss algorithm.
-    datatype: int
-  - name: z_pgaussFlux
-    description: Flux in z band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
-  - name: z_pgaussFluxErr
-    description: Flux uncertainty in z band (measured with pgauss algorithm).
-    datatype: float
-    ivoa:unit: nJy
+  columnRefs:
+    base:
+      ShearObject:
+        shearObjectId:
+        tract:
+        patch:
+        cell_x:
+        cell_y:
+        metaStep:
+        image_flags:
+        x:
+        y:
+        ra:
+        dec:
+        psfOriginal_flags:
+        psfOriginal_e1:
+        psfOriginal_e2:
+        psfOriginal_T:
+        bmask_flags:
+        ormask_flags:
+        mfrac:
+        gauss_psfReconvolved_flags:
+        gauss_psfReconvolved_g1:
+        gauss_psfReconvolved_g2:
+        gauss_psfReconvolved_T:
+        gauss_g1:
+        gauss_g2:
+        gauss_g1_g1_Cov:
+        gauss_g1_g2_Cov:
+        gauss_g2_g2_Cov:
+        gauss_snr:
+        gauss_T:
+        gauss_TErr:
+        gauss_shape_flags:
+        gauss_object_flags:
+        gauss_flags:
+        pgauss_snr:
+        pgauss_T:
+        pgauss_TErr:
+        pgauss_shape_flags:
+        pgauss_object_flags:
+        pgauss_flags:
+        g_gaussFlux_flags:
+        g_gaussFlux:
+        g_gaussFluxErr:
+        r_gaussFlux_flags:
+        r_gaussFlux:
+        r_gaussFluxErr:
+        i_gaussFlux_flags:
+        i_gaussFlux:
+        i_gaussFluxErr:
+        z_gaussFlux_flags:
+        z_gaussFlux:
+        z_gaussFluxErr:
+        g_pgaussFlux_flags:
+        g_pgaussFlux:
+        g_pgaussFluxErr:
+        r_pgaussFlux_flags:
+        r_pgaussFlux:
+        r_pgaussFluxErr:
+        i_pgaussFlux_flags:
+        i_pgaussFlux:
+        i_pgaussFluxErr:
+        z_pgaussFlux_flags:
+        z_pgaussFlux:
+        z_pgaussFluxErr:
 - name: IsolatedStarStellarMotions
   description: Position, proper motion, and parallax for isolated stars, fit using
     associated source measurements, with positions for associated reference objects
     if available.
   tap:table_index: 180
   primaryKey: '#IsolatedStarStellarMotions.isolated_star_id'
-  columns:
-  - name: isolated_star_id
-    description: Unique id of isolated star
-    datatype: int
-    ivoa:ucd: meta.id;meta.main
-    tap:principal: 1
-  - name: ra
-    description: Position in right ascension at the reference epoch.
-    datatype: float
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: dec
-    description: Position in declination at the reference epoch.
-    datatype: float
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: raPM
-    description: Proper motion in right ascension.
-    datatype: float
-    ivoa:ucd: pos.pm;pos.eq.ra
-    ivoa:unit: mas/yr
-    tap:principal: 1
-  - name: decPM
-    description: Proper motion in declination.
-    datatype: float
-    ivoa:ucd: pos.pm;pos.eq.dec
-    ivoa:unit: mas/yr
-    tap:principal: 1
-  - name: parallax
-    description: Parallax
-    datatype: float
-    ivoa:ucd: pos.parallax
-    ivoa:unit: mas
-    tap:principal: 1
-  - name: epoch
-    description: Epoch in MJD to which the position corresponds.
-    datatype: float
-    ivoa:ucd: time.epoch
-    ivoa:unit: d
-    tap:principal: 1
-  - name: raErr
-    description: Error in right ascension at the reference epoch.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.ra
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: decErr
-    description: Error in declination at the reference epoch.
-    datatype: float
-    ivoa:ucd: stat.error;pos.eq.dec
-    ivoa:unit: deg
-    tap:principal: 1
-  - name: raPMErr
-    description: Error in proper motion in right ascension.
-    datatype: float
-    ivoa:ucd: stat.error;pos.pm;pos.eq.ra
-    ivoa:unit: mas/yr
-    tap:principal: 1
-  - name: decPMErr
-    description: Error in proper motion in declination.
-    datatype: float
-    ivoa:ucd: stat.error;pos.pm;pos.eq.dec
-    ivoa:unit: mas/yr
-    tap:principal: 1
-  - name: parallaxErr
-    description: Error in parallax.
-    datatype: float
-    ivoa:ucd: stat.error;pos.parallax
-    ivoa:unit: mas
-    tap:principal: 1
-  - name: ra_dec_Cov
-    description: Covariance between right ascension and declination.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
-    ivoa:unit: deg**2
-    tap:principal: 1
-  - name: ra_raPM_Cov
-    description: Covariance between right ascension and proper motion in right ascension.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.ra
-    ivoa:unit: deg*mas/yr
-    tap:principal: 1
-  - name: ra_decPM_Cov
-    description: Covariance between right ascension and proper motion in declination.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.dec
-    ivoa:unit: deg*mas/yr
-    tap:principal: 1
-  - name: ra_parallax_Cov
-    description: Covariance between right ascension and parallax.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.ra;pos.parallax
-    ivoa:unit: deg*mas
-    tap:principal: 1
-  - name: dec_raPM_Cov
-    description: Covariance between declination and proper motion in right ascension.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.ra
-    ivoa:unit: deg*mas/yr
-    tap:principal: 1
-  - name: dec_decPM_Cov
-    description: Covariance between declination and proper motion in declination.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.dec
-    ivoa:unit: deg*mas/yr
-    tap:principal: 1
-  - name: dec_parallax_Cov
-    description: Covariance between declination and parallax.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.eq.dec;pos.parallax
-    ivoa:unit: deg*mas
-    tap:principal: 1
-  - name: raPM_decPM_Cov
-    description: Covariance between proper motion in right ascension and proper motion in declination.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.pm;pos.eq.dec
-    ivoa:unit: mas**2/yr**2
-    tap:principal: 1
-  - name: raPM_parallax_Cov
-    description: Covariance between proper motion in right ascension and parallax.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.parallax
-    ivoa:unit: mas**2/yr
-    tap:principal: 1
-  - name: decPM_parallax_Cov
-    description: Covariance between proper motion in declination and parallax.
-    datatype: float
-    ivoa:ucd: stat.covariance;pos.pm;pos.eq.dec;pos.parallax
-    ivoa:unit: mas**2/yr
-    tap:principal: 1
-  - name: referenceId
-    description: Id of the reference object if available.
-    datatype: float
-    tap:principal: 1
-  - name: ref_ra
-    description: Position of the reference object in right ascension at the reference
-      epoch.
-    datatype: float
-    ivoa:ucd: pos.eq.ra
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: ref_dec
-    description: Position of the reference object in declination at the reference
-      epoch.
-    datatype: float
-    ivoa:ucd: pos.eq.dec
-    ivoa:unit: deg
-    tap:principal: 0
-  - name: ref_raPM
-    description: Proper motion of the reference object in right ascension.
-    datatype: float
-    ivoa:ucd: pos.pm;pos.eq.ra
-    ivoa:unit: mas/yr
-    tap:principal: 0
-  - name: ref_decPM
-    description: Proper motion of the reference object in declination.
-    datatype: float
-    ivoa:ucd: pos.pm;pos.eq.dec
-    ivoa:unit: mas/yr
-    tap:principal: 0
-  - name: ref_parallax
-    description: Parallax of the reference object
-    datatype: float
-    ivoa:ucd: pos.parallax
-    ivoa:unit: mas
-    tap:principal: 0
+  columnRefs:
+    base:
+      IsolatedStarStellarMotions:
+        isolated_star_id:
+        ra:
+        dec:
+        raPM:
+        decPM:
+        parallax:
+        epoch:
+        raErr:
+        decErr:
+        raPMErr:
+        decPMErr:
+        parallaxErr:
+        ra_dec_Cov:
+        ra_raPM_Cov:
+        ra_decPM_Cov:
+        ra_parallax_Cov:
+        dec_raPM_Cov:
+        dec_decPM_Cov:
+        dec_parallax_Cov:
+        raPM_decPM_Cov:
+        raPM_parallax_Cov:
+        decPM_parallax_Cov:
+        referenceId:
+        ref_ra:
+        ref_dec:
+        ref_raPM:
+        ref_decPM:
+        ref_parallax:


### PR DESCRIPTION
This PR converts `lsstcam.yaml`, `imsim.yaml`, and `hsc.yaml` to use shared column references from a new schema `drp_base.yaml`, which functions as a column dictionary. The new schema was created from the current contents of `lsstcam.yaml`, plus some detection flags present in `imsim.yaml` and `hsc.yaml`.

The columns in `drp_base.yaml` were sorted alphabetically using `felis dump --sort-columns`. The `drp_base.yaml` contains only the table and column definitions without any constraints, primary keys, etc.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [x] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
