### PR TITLE
SP-3219: collect and implement schema description updates

### DIFF
--- a/docs/changes/SP-3219.sci.md
+++ b/docs/changes/SP-3219.sci.md
@@ -1,0 +1,1 @@
+Updated schema descriptions for aperture fluxes, sky values, extendedness columns, and kron radii.

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -204,111 +204,111 @@ tables:
     datatype: int
     ivoa:unit: pixel
   - name: g_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on g-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on g-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on g-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on g-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on g-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on g-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on g-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on g-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on g-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on g-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on g-band.
     datatype: float
     ivoa:unit: nJy
   - name: g_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on g-band.
     datatype: boolean
   - name: g_apFlux_flag
@@ -468,8 +468,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: g_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on g-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on g-band; values are either 0 or 1.
     datatype: float
   - name: g_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -740,6 +740,7 @@ tables:
   - name: g_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on g-band.
     datatype: float
+    ivoa:unit: pixel
   - name: g_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
@@ -974,111 +975,111 @@ tables:
       (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
     datatype: float
   - name: i_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on i-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on i-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on i-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on i-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on i-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on i-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on i-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on i-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on i-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on i-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on i-band.
     datatype: float
     ivoa:unit: nJy
   - name: i_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on i-band.
     datatype: boolean
   - name: i_apFlux_flag
@@ -1238,8 +1239,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: i_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on i-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on i-band; values are either 0 or 1.
     datatype: float
   - name: i_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -1510,6 +1511,7 @@ tables:
   - name: i_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on i-band.
     datatype: float
+    ivoa:unit: pixel
   - name: i_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
@@ -1756,111 +1758,111 @@ tables:
     datatype: long
     tap:principal: 1
   - name: r_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on r-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on r-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on r-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on r-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on r-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on r-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on r-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on r-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on r-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on r-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on r-band.
     datatype: float
     ivoa:unit: nJy
   - name: r_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on r-band.
     datatype: boolean
   - name: r_apFlux_flag
@@ -2020,8 +2022,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: r_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on r-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on r-band; values are either 0 or 1.
     datatype: float
   - name: r_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -2292,6 +2294,7 @@ tables:
   - name: r_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on r-band.
     datatype: float
+    ivoa:unit: pixel
   - name: r_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
@@ -2663,111 +2666,111 @@ tables:
     datatype: long
     tap:principal: 1
   - name: u_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on u-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on u-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on u-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on u-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on u-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on u-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on u-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on u-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on u-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on u-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on u-band.
     datatype: float
     ivoa:unit: nJy
   - name: u_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on u-band.
     datatype: boolean
   - name: u_apFlux_flag
@@ -2927,8 +2930,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: u_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on u-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on u-band; values are either 0 or 1.
     datatype: float
   - name: u_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -3199,6 +3202,7 @@ tables:
   - name: u_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on u-band.
     datatype: float
+    ivoa:unit: pixel
   - name: u_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes.
@@ -3429,111 +3433,111 @@ tables:
       on u-band.
     datatype: boolean
   - name: y_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on y-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on y-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on y-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on y-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on y-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on y-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on y-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on y-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on y-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on y-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on y-band.
     datatype: float
     ivoa:unit: nJy
   - name: y_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on y-band.
     datatype: boolean
   - name: y_apFlux_flag
@@ -3693,8 +3697,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: y_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on y-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on y-band; values are either 0 or 1.
     datatype: float
   - name: y_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -3965,6 +3969,7 @@ tables:
   - name: y_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on y-band.
     datatype: float
+    ivoa:unit: pixel
   - name: y_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
@@ -4195,111 +4200,111 @@ tables:
       on y-band.
     datatype: boolean
   - name: z_ap03Flux
-    description: Flux within 3.0-pixel aperture. Forced on z-band.
+    description: Flux within 3.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 3.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap03Flux_flag
-    description: Flag set for any failure with the 3.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 3.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap06Flux
-    description: Flux within 6.0-pixel aperture. Forced on z-band.
+    description: Flux within 6.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 6.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap06Flux_flag
-    description: Flag set for any failure with the 6.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 6.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap09Flux
-    description: Flux within 9.0-pixel aperture. Forced on z-band.
+    description: Flux within 9.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 9.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap09Flux_flag
-    description: Flag set for any failure with the 9.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 9.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap12Flux
-    description: Flux within 12.0-pixel aperture. Forced on z-band.
+    description: Flux within 12.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 12.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap12Flux_flag
-    description: Flag set for any failure with the 12.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 12.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap17Flux
-    description: Flux within 17.0-pixel aperture. Forced on z-band.
+    description: Flux within 17.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 17.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap17Flux_flag
-    description: Flag set for any failure with the 17.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 17.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap25Flux
-    description: Flux within 25.0-pixel aperture. Forced on z-band.
+    description: Flux within 25.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 25.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap25Flux_flag
-    description: Flag set for any failure with the 25.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 25.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap35Flux
-    description: Flux within 35.0-pixel aperture. Forced on z-band.
+    description: Flux within 35.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 35.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap35Flux_flag
-    description: Flag set for any failure with the 35.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 35.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap50Flux
-    description: Flux within 50.0-pixel aperture. Forced on z-band.
+    description: Flux within 50.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 50.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap50Flux_flag
-    description: Flag set for any failure with the 50.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 50.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_ap70Flux
-    description: Flux within 70.0-pixel aperture. Forced on z-band.
+    description: Flux within 70.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture. Forced on z-band.
+    description: Flux uncertainty within 70.0-pixel radius aperture. Forced on z-band.
     datatype: float
     ivoa:unit: nJy
   - name: z_ap70Flux_flag
-    description: Flag set for any failure with the 70.0-pixel aperture flux. Forced
+    description: Flag set for any failure with the 70.0-pixel radius aperture flux. Forced
       on z-band.
     datatype: boolean
   - name: z_apFlux_flag
@@ -4459,8 +4464,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: z_extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1). Measured on z-band.
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1). Measured on z-band; values are either 0 or 1.
     datatype: float
   - name: z_extendedness_flag
     description: Flag set for any failure in the flux-ratio extendedness. Measured
@@ -4731,6 +4736,7 @@ tables:
   - name: z_kronRad
     description: Kron radius (sqrt(a*b)).  Measured on z-band.
     datatype: float
+    ivoa:unit: pixel
   - name: z_model_extendedness
     description: Model flux- and size-based estimate of whether the object is extended
       (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
@@ -4965,99 +4971,99 @@ tables:
     independently of the Object detections on coadded images.
   columns:
   - name: ap03Flux
-    description: Flux within 3.0-pixel aperture
+    description: Flux within 3.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap03FluxErr
-    description: Flux uncertainty within 3.0-pixel aperture
+    description: Flux uncertainty within 3.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap03Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap06Flux
-    description: Flux within 6.0-pixel aperture
+    description: Flux within 6.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap06FluxErr
-    description: Flux uncertainty within 6.0-pixel aperture
+    description: Flux uncertainty within 6.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap06Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap09Flux
-    description: Flux within 9.0-pixel aperture
+    description: Flux within 9.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap09FluxErr
-    description: Flux uncertainty within 9.0-pixel aperture
+    description: Flux uncertainty within 9.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap09Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap12Flux
-    description: Flux within 12.0-pixel aperture
+    description: Flux within 12.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap12FluxErr
-    description: Flux uncertainty within 12.0-pixel aperture
+    description: Flux uncertainty within 12.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap12Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap17Flux
-    description: Flux within 17.0-pixel aperture
+    description: Flux within 17.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap17FluxErr
-    description: Flux uncertainty within 17.0-pixel aperture
+    description: Flux uncertainty within 17.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap17Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap25Flux
-    description: Flux within 25.0-pixel aperture
+    description: Flux within 25.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap25FluxErr
-    description: Flux uncertainty within 25.0-pixel aperture
+    description: Flux uncertainty within 25.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap25Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap35Flux
-    description: Flux within 35.0-pixel aperture
+    description: Flux within 35.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap35FluxErr
-    description: Flux uncertainty within 35.0-pixel aperture
+    description: Flux uncertainty within 35.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap35Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap50Flux
-    description: Flux within 50.0-pixel aperture
+    description: Flux within 50.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap50FluxErr
-    description: Flux uncertainty within 50.0-pixel aperture
+    description: Flux uncertainty within 50.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap50Flux_flag
     description: General Failure Flag
     datatype: boolean
   - name: ap70Flux
-    description: Flux within 70.0-pixel aperture
+    description: Flux within 70.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap70FluxErr
-    description: Flux uncertainty within 70.0-pixel aperture
+    description: Flux uncertainty within 70.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: ap70Flux_flag
@@ -5073,7 +5079,7 @@ tables:
     description: Full sinc coefficient image did not fit within measurement image
     datatype: boolean
   - name: apFlux_12_0_instFlux
-    description: Flux within 12.0-pixel aperture
+    description: Flux within 12.0-pixel radius aperture
     datatype: double
     ivoa:unit: count
   - name: apFlux_12_0_instFluxErr
@@ -5084,7 +5090,7 @@ tables:
     description: General Failure Flag
     datatype: boolean
   - name: apFlux_17_0_instFlux
-    description: Flux within 17.0-pixel aperture
+    description: Flux within 17.0-pixel radius aperture
     datatype: double
     ivoa:unit: count
   - name: apFlux_17_0_instFluxErr
@@ -5095,7 +5101,7 @@ tables:
     description: General Failure Flag
     datatype: boolean
   - name: apFlux_35_0_instFlux
-    description: Flux within 35.0-pixel aperture
+    description: Flux within 35.0-pixel radius aperture
     datatype: double
     ivoa:unit: count
   - name: apFlux_35_0_instFluxErr
@@ -5106,7 +5112,7 @@ tables:
     description: General Failure Flag
     datatype: boolean
   - name: apFlux_50_0_instFlux
-    description: Flux within 50.0-pixel aperture
+    description: Flux within 50.0-pixel radius aperture
     datatype: double
     ivoa:unit: count
   - name: apFlux_50_0_instFluxErr
@@ -5133,11 +5139,11 @@ tables:
     description: Object has no shape
     datatype: boolean
   - name: calibFlux
-    description: Flux within 12.0-pixel aperture
+    description: Flux within 12.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: calibFluxErr
-    description: Flux uncertainty within 12.0-pixel aperture
+    description: Flux uncertainty within 12.0-pixel radius aperture
     datatype: double
     ivoa:unit: nJy
   - name: calib_astrometry_used
@@ -5239,8 +5245,8 @@ tables:
     nullable: false
     ivoa:ucd: meta.id;obs.image
   - name: extendedness
-    description: Flux-ratio measure of whether an object is point-like (0) or extended
-      (1).
+    description: PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended
+      (1); values are either 0 or 1.
     datatype: double
   - name: extendedness_flag
     description: Set to 1 for any fatal failure.
@@ -5487,7 +5493,7 @@ tables:
     datatype: double
     ivoa:unit: nJy
   - name: sky_source
-    description: Sky objects.
+    description: Sky objects quasi-randomly placed with no detection footprints or bad pixels within an 8-pixel radius. Used for measurement of background and noise properties.
     datatype: boolean
   - name: sourceId
     description: Unique id. Unique Source ID. Primary Key.

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -5485,11 +5485,11 @@ tables:
     description: Set to 1 for any fatal failure.
     datatype: boolean
   - name: sky
-    description: Background in annulus around source
+    description: Background in annulus of radius 7-15 times the PSF sigma around source
     datatype: double
     ivoa:unit: nJy
   - name: skyErr
-    description: Background in annulus around source
+    description: Error in background in annulus around source
     datatype: double
     ivoa:unit: nJy
   - name: sky_source

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -742,8 +742,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: g_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes; values range from 0 to 1.
     datatype: float
   - name: g_moments_flag
     description: Failure flag for moments (g-band)
@@ -963,16 +963,16 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: g_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on g-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on g-band; values range from 0 to 1.
     datatype: float
   - name: g_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured
       on g-band.
     datatype: boolean
   - name: griz_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses g-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses griz-band fluxes; values range from 0 to 1.
     datatype: float
   - name: i_ap03Flux
     description: Flux within 3.0-pixel radius aperture. Forced on i-band.
@@ -1513,8 +1513,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: i_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses i-band fluxes; values range from 0 to 1.
     datatype: float
   - name: i_moments_flag
     description: Failure flag for moments (i-band)
@@ -1734,8 +1734,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: i_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on i-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on i-band; values range from 0 to 1.
     datatype: float
   - name: i_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured
@@ -2296,8 +2296,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: r_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses r-band fluxes; values range from 0 to 1.
     datatype: float
   - name: r_moments_flag
     description: Failure flag for moments (r-band)
@@ -2517,8 +2517,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: r_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on r-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on r-band; values range from 0 to 1.
     datatype: float
   - name: r_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured
@@ -2536,8 +2536,8 @@ tables:
     datatype: float
     tap:principal: 1
   - name: refSizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Reference band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured in the reference band; values range from 0 to 1.
     datatype: float
     tap:principal: 1
   - name: sersic_chi2_reduced
@@ -3204,8 +3204,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: u_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses u-band fluxes; values range from 0 to 1.
     datatype: float
   - name: u_moments_flag
     description: Failure flag for moments (u-band)
@@ -3425,8 +3425,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: u_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on u-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on u-band; values range from 0 to 1.
     datatype: float
   - name: u_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured
@@ -3971,8 +3971,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: y_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses y-band fluxes; values range from 0 to 1.
     datatype: float
   - name: y_moments_flag
     description: Failure flag for moments (y-band)
@@ -4192,8 +4192,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: y_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on y-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on y-band; values range from 0 to 1.
     datatype: float
   - name: y_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured
@@ -4738,8 +4738,8 @@ tables:
     datatype: float
     ivoa:unit: pixel
   - name: z_model_extendedness
-    description: Model flux- and size-based estimate of whether the object is extended
-      (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes.
+    description: Sersic model flux- and size-based estimate of whether the object is extended
+      (resolved) or not, from 0 (compact) to 1 (extended). Uses z-band fluxes; values range from 0 to 1.
     datatype: float
   - name: z_moments_flag
     description: Failure flag for moments (z-band)
@@ -4959,8 +4959,8 @@ tables:
     datatype: float
     ivoa:unit: nJy
   - name: z_sizeExtendedness
-    description: Moments-based measure of whether an object is point-like (0) or extended
-      (1). Measured on z-band.
+    description: Moments-based comparison of source size to the local PSF to estimate whether an object
+      is point-like (0) or extended (1). Measured on z-band; values range from 0 to 1.
     datatype: float
   - name: z_sizeExtendedness_flag
     description: Flag set for any failure in the moments-based extendedness. Measured


### PR DESCRIPTION
- added “radius” to aperture fluxes in drp_base.yaml
- sky_source description (in Source) added
- added units of “pixel” to {band}_kronRad columns
- extendedness descriptions updated to read “PSF to cModel flux-ratio measure of whether an object is point-like (0) or extended (1). Measured on g-band; values are either 0 or 1.”
- Updated size- and model- based extendedness descriptions
- sky and skyErr come from “LocalBackgroundAlgorithm” in meas_base – updated to say “Background in annulus of radius 7-15 times the PSF sigma around source”. Would like to know if the “PSF sigma” corresponds to something in the Source table.

Jenkins run kicked off at https://ci.lsst.cloud/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/9288/pipeline

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [x] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
