### PR TITLE
DM-51789: Convert column references to use names instead of IDs

### DIFF
--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -414,7 +414,7 @@ tables:
   indexes:
   - name: IDX_DiaObject_validityStart
     columns:
-    - "#DiaObject.validityStartMjdTai"
+    - "validityStartMjdTai"
 - name: DiaSource
   description: Table to store 'difference image sources'; - sources detected at
     SNR >=5 on difference images.
@@ -896,14 +896,14 @@ tables:
   indexes:
   - name: IDX_DiaSource_visitDetector
     columns:
-    - "#DiaSource.visit"
-    - "#DiaSource.detector"
+    - "visit"
+    - "detector"
   - name: IDX_DiaSource_diaObjectId
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
 - name: DiaForcedSource
   description: Forced-photometry source measurement on an individual difference Exposure
     for all objects in the DiaObject table.
@@ -990,8 +990,8 @@ tables:
   indexes:
   - name: IDX_DiaForcedSource_visitDetector
     columns:
-    - "#DiaForcedSource.visit"
-    - "#DiaForcedSource.detector"
+    - "visit"
+    - "detector"
 - name: DiaObject_To_Object_Match
   description: The table stores mapping of diaObjects to the nearby objects.
   columns:
@@ -1016,10 +1016,10 @@ tables:
   indexes:
   - name: IDX_DiaObjectToObjectMatch_diaObjectId
     columns:
-    - "#DiaObject_To_Object_Match.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaObjectToObjectMatch_objectId
     columns:
-    - "#DiaObject_To_Object_Match.objectId"
+    - "objectId"
 - name: DiaObjectLast
   description: Table with a subset of DiaObject columns used to store only the
     latest version of each object.
@@ -1741,19 +1741,21 @@ tables:
     description: Link an SSObject to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSObject.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
   - name: unique_SSObject_designation
     description: Unique index on the designation column
     '@type': Unique
     columns:
-    - "#SSObject.designation"
+    - "designation"
   indexes:
   - name: idx_SSObject_MOIDEarth
     description: Index on the MOIDEarth column
     columns:
-    - "#SSObject.MOIDEarth"
+    - "MOIDEarth"
 
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
@@ -1984,25 +1986,31 @@ tables:
     description: Link an SSSource to its associated DiaSource
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
 
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
 
   - name: fk_SSSource_mpc_orbits
     description: Link an SSSource to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSSource.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
 
   indexes:
   - name: idx_SSSource_ssObjectId
@@ -2010,14 +2018,14 @@ tables:
       Non-unique index on the ssObjectId column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 
   - name: idx_SSSource_designation
     description: >
       Non-unique index on the designation column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.designation"
+    - "designation"
 
 - name: mpc_orbits
   description: Table of orbital elements and related information of known (sun-orbiting and unbound) Solar
@@ -2266,17 +2274,17 @@ tables:
     description: Uniqueness of unpacked_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'
   - name: unique_mpc_orbits_designation
     description: Uniqueness of designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.designation'
+    - 'designation'
   - name: unique_mpc_orbits_packed_primary_provisional_designation
     description: Uniqueness of packed_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
 
 - name: current_identifications
   description: All single-designations, and all identifications between designations. Always uses primary
@@ -2349,12 +2357,12 @@ tables:
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#current_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: uniq_current_identifications_packed_secondary_provisional_desig
     "@type": Unique
     description: Unique index on the packed_secondary_provisional_designation column
     columns:
-    - '#current_identifications.packed_secondary_provisional_designation'
+    - 'packed_secondary_provisional_designation'
 
 - name: numbered_identifications
   description: The numbered identification table contains all the numbered objects (minor planets, comets and
@@ -2423,19 +2431,19 @@ tables:
     "@type": Unique
     description: Unique index on the iau_name column
     columns:
-    - '#numbered_identifications.iau_name'
+    - 'iau_name'
   - name: unique_numbered_identifications_packed_primary_prov_desig
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: unique_numbered_identifications_permid
     "@type": Unique
     description: Unique index on the permid column
     columns:
-    - '#numbered_identifications.permid'
+    - 'permid'
   - name: uniq_numbered_identifications_unpacked_primary_prov_desig
     "@type": Unique
     description: Unique index on the unpacked_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'

--- a/python/lsst/sdm/schemas/cdb_latiss.yaml
+++ b/python/lsst/sdm/schemas/cdb_latiss.yaml
@@ -21,22 +21,22 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   - name: un_exposure_exposure_id
     "@id": "#exposure.un_exposure_exposure_id"
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure.exposure_id"
+    - "exposure_id"
   - name: un_exposure_exposure_id_ds
     "@id": "#exposure.un_exposure_exposure_id_ds"
     "@type": Unique
     description: Ensure exposure_id plus day_obs plus seq_num is unique.
     columns:
-    - "#exposure.exposure_id"
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "exposure_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -348,41 +348,49 @@ tables:
     "@id": "#exposure_flexdata.fk_exposure_flexdata_ds"
     "@type": ForeignKey
     description: Flex data day_obs must be an Exposure day_obs
-    columns: ["#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_obs_id_ds
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id_ds"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_flexdata.obs_id", "#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["obs_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_exposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   - name: un_exposure_flexdata_ds_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_ds_key"
     "@type": Unique
     description: Day obs + seq num + key must be unique.
     columns:
-    - "#exposure_flexdata.day_obs"
-    - "#exposure_flexdata.seq_num"
-    - "#exposure_flexdata.key"
+    - "day_obs"
+    - "seq_num"
+    - "key"
   - name: un_exposure_flexdata_obs_id_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_obs_id_key"
     "@type": Unique
     description: obs_id plus key must be unique.
     columns:
-    - "#exposure_flexdata.obs_id"
-    - "#exposure_flexdata.key"
+    - "obs_id"
+    - "key"
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -461,41 +469,47 @@ tables:
     "@type": Unique
     description: Ensure ccdexposure_id is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
+    - "ccdexposure_id"
   - name: un_ccdexposure_exposure_id_detector
     "@id": "#ccdexposure.un_ccdexposure_exposure_id_detector"
     "@type": Unique
     description: Ensure exposure_id plus detector is unique.
     columns:
-    - "#ccdexposure.exposure_id"
-    - "#ccdexposure.detector"
+    - "exposure_id"
+    - "detector"
   - name: un_ccdexposure_ccdexposure_id_dsd
     "@id": "#ccdexposure.un_ccdexposure_ccdexposure_id_dsd"
     "@type": Unique
     description: Ensure ccdexposure_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: fk_ccdexposure_ds
     "@id": "#ccdexposure.fk_ccdexposure_ds"
     "@type": ForeignKey
     description: day_obs must be in the Exposure table.
-    columns: ["#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_ccdexposure_exposure_id
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_ccdexposure_exposure_id_ds
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id_ds"
     "@type": ForeignKey
     description: exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#ccdexposure.exposure_id", "#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: ccdexposure_id
     "@id": "#ccdexposure.ccdexposure_id"
@@ -546,34 +560,40 @@ tables:
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure_camera.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_camera_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_camera_ccdexposure_id_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id_dsd"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_camera.ccdexposure_id"
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_camera.day_obs"
@@ -623,40 +643,48 @@ tables:
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_flexdata.obs_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_flexdata_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_dsd"
     "@type": ForeignKey
     description: Flex data day_obs/seq_num/detector must be a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_obs_id_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id_dsd"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.obs_id"
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "obs_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#ccdexposure_flexdata.key"]
-    referencedColumns: ["#ccdexposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "ccdexposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: day_obs
     "@id": "#ccdexposure_flexdata.day_obs"
@@ -741,15 +769,15 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1.visit_id"
+    - "visit_id"
   - name: un_visit1_visit_id_ds
     "@id": "#visit1.un_visit1_visit_id_ds"
     "@type": Unique
     description: Ensure visit_id plus day_obs plus seq_num is unique.
     columns:
-    - "#visit1.visit_id"
-    - "#visit1.day_obs"
-    - "#visit1.seq_num"
+    - "visit_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: visit_id
     "@id": "#visit1.visit_id"
@@ -1056,20 +1084,26 @@ tables:
     "@id": "#visit1_quicklook.fk_visit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
-    columns: ["#visit1_quicklook.visit_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_visit1_quicklook_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_visit1_quicklook_visit_id_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_visit_id_ds"
     "@type": ForeignKey
     description: Quicklook visit_id/day_obs/seq_num must match an Exposure.
-    columns: ["#visit1_quicklook.visit_id", "#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["visit_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: visit_id
     "@id": "#visit1_quicklook.visit_id"
@@ -1270,20 +1304,26 @@ tables:
     "@id": "#exposure_quicklook.fk_exposure_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_quicklook_obs_id
     "@id": "#exposure_quicklook.fk_exposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_quicklook_exposure_id_ds
     "@id": "#exposure_quicklook.fk_exposure_quicklook_exposure_id_ds"
     "@type": ForeignKey
     description: Quicklook exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_quicklook.exposure_id", "#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"
@@ -1358,35 +1398,39 @@ tables:
     "@type": Unique
     description: Ensure ccdvisit_id is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
+    - "ccdvisit_id"
   - name: un_ccdvisit1_ccdvisit_id_dsd
     "@id": "#ccdvisit1.un_ccdvisit1_ccdvisit_id_dsd"
     "@type": Unique
     description: Ensure ccdvisit_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
-    - "#ccdvisit1.day_obs"
-    - "#ccdvisit1.seq_num"
-    - "#ccdvisit1.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: un_ccdvisit1_visit_id_detector
     "@id": "#ccdvisit1.un_ccdvisit1_visit_id_detector"
     "@type": Unique
     description: Ensure visit_id plus detector is unique.
     columns:
-    - "#ccdvisit1.visit_id"
-    - "#ccdvisit1.detector"
+    - "visit_id"
+    - "detector"
   - name: fk_ccdvisit1_visit_id
     "@id": "#ccdvisit1.fk_ccdvisit1_visit_id"
     "@type": ForeignKey
     description: visit_id must be in the Visit1 table.
-    columns: ["#ccdvisit1.visit_id"]
-    referencedColumns: ["#visit1.visit_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "visit1"
+      columns: ["visit_id"]
   - name: fk_ccdvisit1_ds
     "@id": "#ccdvisit1.fk_ccdvisit1_ds"
     "@type": ForeignKey
     description: day_obs/seq_num must be in the Visit1 table.
-    columns: ["#ccdvisit1.day_obs", "#ccdvisit1.seq_num"]
-    referencedColumns: ["#visit1.day_obs", "#visit1.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "visit1"
+      columns: ["day_obs", "seq_num"]
   columns:
   - name: day_obs
     "@id": "#ccdvisit1.day_obs"
@@ -1439,34 +1483,40 @@ tables:
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdvisit1_quicklook.ccdvisit_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdvisit_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdvisit1_quicklook_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdvisit1_quicklook_ccdvisit_id_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_ccdvisit_id_dsd"
     "@type": ForeignKey
     description: ccdvisit_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdvisit1_quicklook.ccdvisit_id"
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdvisit1_quicklook.day_obs"
@@ -1655,34 +1705,40 @@ tables:
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdexposure_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_quicklook.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_quicklook_dsd
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_qk_id_day_seq_det
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_qk_id_day_seq_det"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_quicklook.ccdexposure_id"
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_quicklook.day_obs"

--- a/python/lsst/sdm/schemas/cdb_lsstcam.yaml
+++ b/python/lsst/sdm/schemas/cdb_lsstcam.yaml
@@ -21,22 +21,22 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   - name: un_exposure_exposure_id
     "@id": "#exposure.un_exposure_exposure_id"
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure.exposure_id"
+    - "exposure_id"
   - name: un_exposure_exposure_id_ds
     "@id": "#exposure.un_exposure_exposure_id_ds"
     "@type": Unique
     description: Ensure exposure_id plus day_obs plus seq_num is unique.
     columns:
-    - "#exposure.exposure_id"
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "exposure_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -336,41 +336,49 @@ tables:
     "@id": "#exposure_flexdata.fk_exposure_flexdata_ds"
     "@type": ForeignKey
     description: Flex data day_obs must be an Exposure day_obs
-    columns: ["#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_obs_id_ds
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id_ds"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_flexdata.obs_id", "#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["obs_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_exposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   - name: un_exposure_flexdata_ds_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_ds_key"
     "@type": Unique
     description: Day obs + seq num + key must be unique.
     columns:
-    - "#exposure_flexdata.day_obs"
-    - "#exposure_flexdata.seq_num"
-    - "#exposure_flexdata.key"
+    - "day_obs"
+    - "seq_num"
+    - "key"
   - name: un_exposure_flexdata_obs_id_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_obs_id_key"
     "@type": Unique
     description: obs_id plus key must be unique.
     columns:
-    - "#exposure_flexdata.obs_id"
-    - "#exposure_flexdata.key"
+    - "obs_id"
+    - "key"
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -449,41 +457,47 @@ tables:
     "@type": Unique
     description: Ensure ccdexposure_id is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
+    - "ccdexposure_id"
   - name: un_ccdexposure_exposure_id_detector
     "@id": "#ccdexposure.un_ccdexposure_exposure_id_detector"
     "@type": Unique
     description: Ensure exposure_id plus detector is unique.
     columns:
-    - "#ccdexposure.exposure_id"
-    - "#ccdexposure.detector"
+    - "exposure_id"
+    - "detector"
   - name: un_ccdexposure_ccdexposure_id_dsd
     "@id": "#ccdexposure.un_ccdexposure_ccdexposure_id_dsd"
     "@type": Unique
     description: Ensure ccdexposure_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: fk_ccdexposure_ds
     "@id": "#ccdexposure.fk_ccdexposure_ds"
     "@type": ForeignKey
     description: day_obs must be in the Exposure table.
-    columns: ["#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_ccdexposure_exposure_id
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_ccdexposure_exposure_id_ds
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id_ds"
     "@type": ForeignKey
     description: exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#ccdexposure.exposure_id", "#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: ccdexposure_id
     "@id": "#ccdexposure.ccdexposure_id"
@@ -534,34 +548,40 @@ tables:
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure_camera.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_camera_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_camera_ccdexposure_id_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id_dsd"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_camera.ccdexposure_id"
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_camera.day_obs"
@@ -611,40 +631,48 @@ tables:
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_flexdata.obs_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_flexdata_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_dsd"
     "@type": ForeignKey
     description: Flex data day_obs/seq_num/detector must be a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_obs_id_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id_dsd"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.obs_id"
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "obs_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#ccdexposure_flexdata.key"]
-    referencedColumns: ["#ccdexposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "ccdexposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: day_obs
     "@id": "#ccdexposure_flexdata.day_obs"
@@ -729,15 +757,15 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1.visit_id"
+    - "visit_id"
   - name: un_visit1_visit_id_ds
     "@id": "#visit1.un_visit1_visit_id_ds"
     "@type": Unique
     description: Ensure visit_id plus day_obs plus seq_num is unique.
     columns:
-    - "#visit1.visit_id"
-    - "#visit1.day_obs"
-    - "#visit1.seq_num"
+    - "visit_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: visit_id
     "@id": "#visit1.visit_id"
@@ -1036,20 +1064,26 @@ tables:
     "@id": "#visit1_quicklook.fk_visit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
-    columns: ["#visit1_quicklook.visit_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_visit1_quicklook_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_visit1_quicklook_visit_id_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_visit_id_ds"
     "@type": ForeignKey
     description: Quicklook visit_id/day_obs/seq_num must match an Exposure.
-    columns: ["#visit1_quicklook.visit_id", "#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["visit_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: visit_id
     "@id": "#visit1_quicklook.visit_id"
@@ -1888,20 +1922,26 @@ tables:
     "@id": "#exposure_quicklook.fk_exposure_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_quicklook_obs_id
     "@id": "#exposure_quicklook.fk_exposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_quicklook_exposure_id_ds
     "@id": "#exposure_quicklook.fk_exposure_quicklook_exposure_id_ds"
     "@type": ForeignKey
     description: Quicklook exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_quicklook.exposure_id", "#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"
@@ -2004,35 +2044,39 @@ tables:
     "@type": Unique
     description: Ensure ccdvisit_id is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
+    - "ccdvisit_id"
   - name: un_ccdvisit1_ccdvisit_id_dsd
     "@id": "#ccdvisit1.un_ccdvisit1_ccdvisit_id_dsd"
     "@type": Unique
     description: Ensure ccdvisit_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
-    - "#ccdvisit1.day_obs"
-    - "#ccdvisit1.seq_num"
-    - "#ccdvisit1.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: un_ccdvisit1_visit_id_detector
     "@id": "#ccdvisit1.un_ccdvisit1_visit_id_detector"
     "@type": Unique
     description: Ensure visit_id plus detector is unique.
     columns:
-    - "#ccdvisit1.visit_id"
-    - "#ccdvisit1.detector"
+    - "visit_id"
+    - "detector"
   - name: fk_ccdvisit1_visit_id
     "@id": "#ccdvisit1.fk_ccdvisit1_visit_id"
     "@type": ForeignKey
     description: visit_id must be in the Visit1 table.
-    columns: ["#ccdvisit1.visit_id"]
-    referencedColumns: ["#visit1.visit_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "visit1"
+      columns: ["visit_id"]
   - name: fk_ccdvisit1_ds
     "@id": "#ccdvisit1.fk_ccdvisit1_ds"
     "@type": ForeignKey
     description: day_obs/seq_num must be in the Visit1 table.
-    columns: ["#ccdvisit1.day_obs", "#ccdvisit1.seq_num"]
-    referencedColumns: ["#visit1.day_obs", "#visit1.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "visit1"
+      columns: ["day_obs", "seq_num"]
   columns:
   - name: day_obs
     "@id": "#ccdvisit1.day_obs"
@@ -2085,34 +2129,40 @@ tables:
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdvisit1_quicklook.ccdvisit_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdvisit_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdvisit1_quicklook_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdvisit1_quicklook_ccdvisit_id_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_ccdvisit_id_dsd"
     "@type": ForeignKey
     description: ccdvisit_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdvisit1_quicklook.ccdvisit_id"
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdvisit1_quicklook.day_obs"
@@ -2461,34 +2511,40 @@ tables:
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdexposure_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_quicklook.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_quicklook_dsd
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_qk_id_day_seq_det
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_qk_id_day_seq_det"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_quicklook.ccdexposure_id"
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_quicklook.day_obs"

--- a/python/lsst/sdm/schemas/cdb_lsstcomcam.yaml
+++ b/python/lsst/sdm/schemas/cdb_lsstcomcam.yaml
@@ -21,22 +21,22 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   - name: un_exposure_exposure_id
     "@id": "#exposure.un_exposure_exposure_id"
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure.exposure_id"
+    - "exposure_id"
   - name: un_exposure_exposure_id_ds
     "@id": "#exposure.un_exposure_exposure_id_ds"
     "@type": Unique
     description: Ensure exposure_id plus day_obs plus seq_num is unique.
     columns:
-    - "#exposure.exposure_id"
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "exposure_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -336,41 +336,49 @@ tables:
     "@id": "#exposure_flexdata.fk_exposure_flexdata_ds"
     "@type": ForeignKey
     description: Flex data day_obs must be an Exposure day_obs
-    columns: ["#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_obs_id_ds
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id_ds"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_flexdata.obs_id", "#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["obs_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_exposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   - name: un_exposure_flexdata_ds_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_ds_key"
     "@type": Unique
     description: Day obs + seq num + key must be unique.
     columns:
-    - "#exposure_flexdata.day_obs"
-    - "#exposure_flexdata.seq_num"
-    - "#exposure_flexdata.key"
+    - "day_obs"
+    - "seq_num"
+    - "key"
   - name: un_exposure_flexdata_obs_id_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_obs_id_key"
     "@type": Unique
     description: obs_id plus key must be unique.
     columns:
-    - "#exposure_flexdata.obs_id"
-    - "#exposure_flexdata.key"
+    - "obs_id"
+    - "key"
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -449,41 +457,47 @@ tables:
     "@type": Unique
     description: Ensure ccdexposure_id is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
+    - "ccdexposure_id"
   - name: un_ccdexposure_exposure_id_detector
     "@id": "#ccdexposure.un_ccdexposure_exposure_id_detector"
     "@type": Unique
     description: Ensure exposure_id plus detector is unique.
     columns:
-    - "#ccdexposure.exposure_id"
-    - "#ccdexposure.detector"
+    - "exposure_id"
+    - "detector"
   - name: un_ccdexposure_ccdexposure_id_dsd
     "@id": "#ccdexposure.un_ccdexposure_ccdexposure_id_dsd"
     "@type": Unique
     description: Ensure ccdexposure_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: fk_ccdexposure_ds
     "@id": "#ccdexposure.fk_ccdexposure_ds"
     "@type": ForeignKey
     description: day_obs must be in the Exposure table.
-    columns: ["#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_ccdexposure_exposure_id
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_ccdexposure_exposure_id_ds
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id_ds"
     "@type": ForeignKey
     description: exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#ccdexposure.exposure_id", "#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: ccdexposure_id
     "@id": "#ccdexposure.ccdexposure_id"
@@ -534,34 +548,40 @@ tables:
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure_camera.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_camera_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_camera_ccdexposure_id_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id_dsd"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_camera.ccdexposure_id"
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_camera.day_obs"
@@ -611,40 +631,48 @@ tables:
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_flexdata.obs_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_flexdata_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_dsd"
     "@type": ForeignKey
     description: Flex data day_obs/seq_num/detector must be a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_obs_id_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id_dsd"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.obs_id"
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "obs_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#ccdexposure_flexdata.key"]
-    referencedColumns: ["#ccdexposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "ccdexposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: day_obs
     "@id": "#ccdexposure_flexdata.day_obs"
@@ -729,15 +757,15 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1.visit_id"
+    - "visit_id"
   - name: un_visit1_visit_id_ds
     "@id": "#visit1.un_visit1_visit_id_ds"
     "@type": Unique
     description: Ensure visit_id plus day_obs plus seq_num is unique.
     columns:
-    - "#visit1.visit_id"
-    - "#visit1.day_obs"
-    - "#visit1.seq_num"
+    - "visit_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: visit_id
     "@id": "#visit1.visit_id"
@@ -1036,20 +1064,26 @@ tables:
     "@id": "#visit1_quicklook.fk_visit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
-    columns: ["#visit1_quicklook.visit_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_visit1_quicklook_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_visit1_quicklook_visit_id_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_visit_id_ds"
     "@type": ForeignKey
     description: Quicklook visit_id/day_obs/seq_num must match an Exposure.
-    columns: ["#visit1_quicklook.visit_id", "#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["visit_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: visit_id
     "@id": "#visit1_quicklook.visit_id"
@@ -1557,20 +1591,26 @@ tables:
     "@id": "#exposure_quicklook.fk_exposure_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_quicklook_obs_id
     "@id": "#exposure_quicklook.fk_exposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_quicklook_exposure_id_ds
     "@id": "#exposure_quicklook.fk_exposure_quicklook_exposure_id_ds"
     "@type": ForeignKey
     description: Quicklook exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_quicklook.exposure_id", "#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"
@@ -1658,35 +1698,39 @@ tables:
     "@type": Unique
     description: Ensure ccdvisit_id is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
+    - "ccdvisit_id"
   - name: un_ccdvisit1_ccdvisit_id_dsd
     "@id": "#ccdvisit1.un_ccdvisit1_ccdvisit_id_dsd"
     "@type": Unique
     description: Ensure ccdvisit_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
-    - "#ccdvisit1.day_obs"
-    - "#ccdvisit1.seq_num"
-    - "#ccdvisit1.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: un_ccdvisit1_visit_id_detector
     "@id": "#ccdvisit1.un_ccdvisit1_visit_id_detector"
     "@type": Unique
     description: Ensure visit_id plus detector is unique.
     columns:
-    - "#ccdvisit1.visit_id"
-    - "#ccdvisit1.detector"
+    - "visit_id"
+    - "detector"
   - name: fk_ccdvisit1_visit_id
     "@id": "#ccdvisit1.fk_ccdvisit1_visit_id"
     "@type": ForeignKey
     description: visit_id must be in the Visit1 table.
-    columns: ["#ccdvisit1.visit_id"]
-    referencedColumns: ["#visit1.visit_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "visit1"
+      columns: ["visit_id"]
   - name: fk_ccdvisit1_ds
     "@id": "#ccdvisit1.fk_ccdvisit1_ds"
     "@type": ForeignKey
     description: day_obs/seq_num must be in the Visit1 table.
-    columns: ["#ccdvisit1.day_obs", "#ccdvisit1.seq_num"]
-    referencedColumns: ["#visit1.day_obs", "#visit1.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "visit1"
+      columns: ["day_obs", "seq_num"]
   columns:
   - name: day_obs
     "@id": "#ccdvisit1.day_obs"
@@ -1739,34 +1783,40 @@ tables:
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdvisit1_quicklook.ccdvisit_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdvisit_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdvisit1_quicklook_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdvisit1_quicklook_ccdvisit_id_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_ccdvisit_id_dsd"
     "@type": ForeignKey
     description: ccdvisit_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdvisit1_quicklook.ccdvisit_id"
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdvisit1_quicklook.day_obs"
@@ -1960,34 +2010,40 @@ tables:
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdexposure_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_quicklook.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_quicklook_dsd
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_qk_id_day_seq_det
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_qk_id_day_seq_det"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_quicklook.ccdexposure_id"
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_quicklook.day_obs"

--- a/python/lsst/sdm/schemas/cdb_lsstcomcamsim.yaml
+++ b/python/lsst/sdm/schemas/cdb_lsstcomcamsim.yaml
@@ -22,22 +22,22 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   - name: un_exposure_exposure_id
     "@id": "#exposure.un_exposure_exposure_id"
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure.exposure_id"
+    - "exposure_id"
   - name: un_exposure_exposure_id_ds
     "@id": "#exposure.un_exposure_exposure_id_ds"
     "@type": Unique
     description: Ensure exposure_id plus day_obs plus seq_num is unique.
     columns:
-    - "#exposure.exposure_id"
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "exposure_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -337,41 +337,49 @@ tables:
     "@id": "#exposure_flexdata.fk_exposure_flexdata_ds"
     "@type": ForeignKey
     description: Flex data day_obs must be an Exposure day_obs
-    columns: ["#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_flexdata_obs_id
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_obs_id_ds
     "@id": "#exposure_flexdata.fk_exposure_flexdata_obs_id_ds"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_flexdata.obs_id", "#exposure_flexdata.day_obs", "#exposure_flexdata.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["obs_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_exposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   - name: un_exposure_flexdata_ds_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_ds_key"
     "@type": Unique
     description: Day obs + seq num + key must be unique.
     columns:
-    - "#exposure_flexdata.day_obs"
-    - "#exposure_flexdata.seq_num"
-    - "#exposure_flexdata.key"
+    - "day_obs"
+    - "seq_num"
+    - "key"
   - name: un_exposure_flexdata_obs_id_key
     "@id": "#exposure_flexdata.un_exposure_flexdata_obs_id_key"
     "@type": Unique
     description: obs_id plus key must be unique.
     columns:
-    - "#exposure_flexdata.obs_id"
-    - "#exposure_flexdata.key"
+    - "obs_id"
+    - "key"
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -450,41 +458,47 @@ tables:
     "@type": Unique
     description: Ensure ccdexposure_id is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
+    - "ccdexposure_id"
   - name: un_ccdexposure_exposure_id_detector
     "@id": "#ccdexposure.un_ccdexposure_exposure_id_detector"
     "@type": Unique
     description: Ensure exposure_id plus detector is unique.
     columns:
-    - "#ccdexposure.exposure_id"
-    - "#ccdexposure.detector"
+    - "exposure_id"
+    - "detector"
   - name: un_ccdexposure_ccdexposure_id_dsd
     "@id": "#ccdexposure.un_ccdexposure_ccdexposure_id_dsd"
     "@type": Unique
     description: Ensure ccdexposure_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: fk_ccdexposure_ds
     "@id": "#ccdexposure.fk_ccdexposure_ds"
     "@type": ForeignKey
     description: day_obs must be in the Exposure table.
-    columns: ["#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_ccdexposure_exposure_id
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_ccdexposure_exposure_id_ds
     "@id": "#ccdexposure.fk_ccdexposure_exposure_id_ds"
     "@type": ForeignKey
     description: exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#ccdexposure.exposure_id", "#ccdexposure.day_obs", "#ccdexposure.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: ccdexposure_id
     "@id": "#ccdexposure.ccdexposure_id"
@@ -535,34 +549,40 @@ tables:
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id"
     "@type": ForeignKey
     description: exposure_id must be in the Exposure table.
-    columns: ["#ccdexposure_camera.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_camera_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_camera_ccdexposure_id_dsd
     "@id": "#ccdexposure_camera.fk_ccdexposure_camera_ccdexposure_id_dsd"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_camera.ccdexposure_id"
-    - "#ccdexposure_camera.day_obs"
-    - "#ccdexposure_camera.seq_num"
-    - "#ccdexposure_camera.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_camera.day_obs"
@@ -612,40 +632,48 @@ tables:
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_flexdata.obs_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_flexdata_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_dsd"
     "@type": ForeignKey
     description: Flex data day_obs/seq_num/detector must be a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_obs_id_dsd
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_obs_id_dsd"
     "@type": ForeignKey
     description: Flex data obs_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_flexdata.obs_id"
-    - "#ccdexposure_flexdata.day_obs"
-    - "#ccdexposure_flexdata.seq_num"
-    - "#ccdexposure_flexdata.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "obs_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_flexdata_key
     "@id": "#ccdexposure_flexdata.fk_ccdexposure_flexdata_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#ccdexposure_flexdata.key"]
-    referencedColumns: ["#ccdexposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "ccdexposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: day_obs
     "@id": "#ccdexposure_flexdata.day_obs"
@@ -730,15 +758,15 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1.visit_id"
+    - "visit_id"
   - name: un_visit1_visit_id_ds
     "@id": "#visit1.un_visit1_visit_id_ds"
     "@type": Unique
     description: Ensure visit_id plus day_obs plus seq_num is unique.
     columns:
-    - "#visit1.visit_id"
-    - "#visit1.day_obs"
-    - "#visit1.seq_num"
+    - "visit_id"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: visit_id
     "@id": "#visit1.visit_id"
@@ -1037,20 +1065,26 @@ tables:
     "@id": "#visit1_quicklook.fk_visit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook visit_id must be an Exposure exposure_id.
-    columns: ["#visit1_quicklook.visit_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_visit1_quicklook_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_visit1_quicklook_visit_id_ds
     "@id": "#visit1_quicklook.fk_visit1_quicklook_visit_id_ds"
     "@type": ForeignKey
     description: Quicklook visit_id/day_obs/seq_num must match an Exposure.
-    columns: ["#visit1_quicklook.visit_id", "#visit1_quicklook.day_obs", "#visit1_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["visit_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: visit_id
     "@id": "#visit1_quicklook.visit_id"
@@ -1520,20 +1554,26 @@ tables:
     "@id": "#exposure_quicklook.fk_exposure_quicklook_ds"
     "@type": ForeignKey
     description: Quicklook day_obs must be an Exposure day_obs.
-    columns: ["#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["day_obs", "seq_num"]
   - name: fk_exposure_quicklook_obs_id
     "@id": "#exposure_quicklook.fk_exposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_quicklook_exposure_id_ds
     "@id": "#exposure_quicklook.fk_exposure_quicklook_exposure_id_ds"
     "@type": ForeignKey
     description: Quicklook exposure_id/day_obs/seq_num must match an Exposure.
-    columns: ["#exposure_quicklook.exposure_id", "#exposure_quicklook.day_obs", "#exposure_quicklook.seq_num"]
-    referencedColumns: ["#exposure.exposure_id", "#exposure.day_obs", "#exposure.seq_num"]
+    columns: ["exposure_id", "day_obs", "seq_num"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id", "day_obs", "seq_num"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"
@@ -1637,35 +1677,39 @@ tables:
     "@type": Unique
     description: Ensure ccdvisit_id is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
+    - "ccdvisit_id"
   - name: un_ccdvisit1_ccdvisit_id_dsd
     "@id": "#ccdvisit1.un_ccdvisit1_ccdvisit_id_dsd"
     "@type": Unique
     description: Ensure ccdvisit_id plus day_obs plus seq_num plus detector is unique.
     columns:
-    - "#ccdvisit1.ccdvisit_id"
-    - "#ccdvisit1.day_obs"
-    - "#ccdvisit1.seq_num"
-    - "#ccdvisit1.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
   - name: un_ccdvisit1_visit_id_detector
     "@id": "#ccdvisit1.un_ccdvisit1_visit_id_detector"
     "@type": Unique
     description: Ensure visit_id plus detector is unique.
     columns:
-    - "#ccdvisit1.visit_id"
-    - "#ccdvisit1.detector"
+    - "visit_id"
+    - "detector"
   - name: fk_ccdvisit1_visit_id
     "@id": "#ccdvisit1.fk_ccdvisit1_visit_id"
     "@type": ForeignKey
     description: visit_id must be in the Visit1 table.
-    columns: ["#ccdvisit1.visit_id"]
-    referencedColumns: ["#visit1.visit_id"]
+    columns: ["visit_id"]
+    reference:
+      table: "visit1"
+      columns: ["visit_id"]
   - name: fk_ccdvisit1_ds
     "@id": "#ccdvisit1.fk_ccdvisit1_ds"
     "@type": ForeignKey
     description: day_obs/seq_num must be in the Visit1 table.
-    columns: ["#ccdvisit1.day_obs", "#ccdvisit1.seq_num"]
-    referencedColumns: ["#visit1.day_obs", "#visit1.seq_num"]
+    columns: ["day_obs", "seq_num"]
+    reference:
+      table: "visit1"
+      columns: ["day_obs", "seq_num"]
   columns:
   - name: day_obs
     "@id": "#ccdvisit1.day_obs"
@@ -1718,34 +1762,40 @@ tables:
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdvisit_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdvisit1_quicklook.ccdvisit_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdvisit_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdvisit1_quicklook_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdvisit1_quicklook_ccdvisit_id_dsd
     "@id": "#ccdvisit1_quicklook.fk_ccdvisit1_quicklook_ccdvisit_id_dsd"
     "@type": ForeignKey
     description: ccdvisit_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdvisit1_quicklook.ccdvisit_id"
-    - "#ccdvisit1_quicklook.day_obs"
-    - "#ccdvisit1_quicklook.seq_num"
-    - "#ccdvisit1_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdvisit_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdvisit1_quicklook.day_obs"
@@ -1939,34 +1989,40 @@ tables:
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_obs_id"
     "@type": ForeignKey
     description: Quicklook ccdexposure_id must be a CcdExposure ccdexposure_id.
-    columns: ["#ccdexposure_quicklook.ccdexposure_id"]
-    referencedColumns: ["#ccdexposure.ccdexposure_id"]
+    columns: ["ccdexposure_id"]
+    reference:
+      table: "ccdexposure"
+      columns: ["ccdexposure_id"]
   - name: fk_ccdexposure_quicklook_dsd
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_quicklook_dsd"
     "@type": ForeignKey
     description: day_obs/seq_num/detector must be in the CcdExposure table.
     columns:
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   - name: fk_ccdexposure_qk_id_day_seq_det
     "@id": "#ccdexposure_quicklook.fk_ccdexposure_qk_id_day_seq_det"
     "@type": ForeignKey
     description: ccdexposure_id/day_obs/seq_num/detector must match a CcdExposure.
     columns:
-    - "#ccdexposure_quicklook.ccdexposure_id"
-    - "#ccdexposure_quicklook.day_obs"
-    - "#ccdexposure_quicklook.seq_num"
-    - "#ccdexposure_quicklook.detector"
-    referencedColumns:
-    - "#ccdexposure.ccdexposure_id"
-    - "#ccdexposure.day_obs"
-    - "#ccdexposure.seq_num"
-    - "#ccdexposure.detector"
+    - "ccdexposure_id"
+    - "day_obs"
+    - "seq_num"
+    - "detector"
+    reference:
+      table: "ccdexposure"
+      columns:
+      - "ccdexposure_id"
+      - "day_obs"
+      - "seq_num"
+      - "detector"
   columns:
   - name: day_obs
     "@id": "#ccdexposure_quicklook.day_obs"

--- a/python/lsst/sdm/schemas/cdb_startrackerfast.yaml
+++ b/python/lsst/sdm/schemas/cdb_startrackerfast.yaml
@@ -20,8 +20,8 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -232,14 +232,18 @@ tables:
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -303,8 +307,10 @@ tables:
     "@id": "#exposure_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure exposure_id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"

--- a/python/lsst/sdm/schemas/cdb_startrackernarrow.yaml
+++ b/python/lsst/sdm/schemas/cdb_startrackernarrow.yaml
@@ -20,8 +20,8 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -232,14 +232,18 @@ tables:
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -303,8 +307,10 @@ tables:
     "@id": "#exposure_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure exposure_id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"

--- a/python/lsst/sdm/schemas/cdb_startrackerwide.yaml
+++ b/python/lsst/sdm/schemas/cdb_startrackerwide.yaml
@@ -20,8 +20,8 @@ tables:
     "@type": Unique
     description: Ensure day_obs plus seq_num is unique.
     columns:
-    - "#exposure.day_obs"
-    - "#exposure.seq_num"
+    - "day_obs"
+    - "seq_num"
   columns:
   - name: exposure_id
     "@id": "#exposure.exposure_id"
@@ -232,14 +232,18 @@ tables:
     "@id": "#exposure_flexdata.fk_obs_id"
     "@type": ForeignKey
     description: Flex data obs_id must be an Exposure exposure_id.
-    columns: ["#exposure_flexdata.obs_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["obs_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   - name: fk_exposure_flexdata_key
     "@id": "#exposure_flexdata.fk_key"
     "@type": ForeignKey
     description: Flex data key must be listed in the schema.
-    columns: ["#exposure_flexdata.key"]
-    referencedColumns: ["#exposure_flexdata_schema.key"]
+    columns: ["key"]
+    reference:
+      table: "exposure_flexdata_schema"
+      columns: ["key"]
   columns:
   - name: obs_id
     "@id": "#exposure_flexdata.obs_id"
@@ -303,8 +307,10 @@ tables:
     "@id": "#exposure_quicklook.fk_obs_id"
     "@type": ForeignKey
     description: Quicklook exposure_id must be an Exposure exposure_id.
-    columns: ["#exposure_quicklook.exposure_id"]
-    referencedColumns: ["#exposure.exposure_id"]
+    columns: ["exposure_id"]
+    reference:
+      table: "exposure"
+      columns: ["exposure_id"]
   columns:
   - name: exposure_id
     "@id": "#exposure_quicklook.exposure_id"

--- a/python/lsst/sdm/schemas/dp02_dc2.yaml
+++ b/python/lsst/sdm/schemas/dp02_dc2.yaml
@@ -5731,9 +5731,11 @@ tables:
     "@id": "#FK_Source_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated Sources
     columns:
-    - "#Source.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: ForcedSource
   "@id": "#ForcedSource"
   description: "Forced-photometry measurements on individual single-epoch visit images and
@@ -6063,17 +6065,21 @@ tables:
     "@id": "#FK_ForcedSource_objectId_Object_objectId"
     description: Link Objects to associated ForcedSources
     columns:
-    - "#ForcedSource.objectId"
-    referencedColumns:
-    - "#Object.objectId"
+    - "objectId"
+    reference:
+      table: "Object"
+      columns:
+      - "objectId"
   - name: CcdV_FS
     "@type": "ForeignKey"
     "@id": "#FK_ForcedSource_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated ForcedSources
     columns:
-    - "#ForcedSource.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: DiaObject
   "@id": "#DiaObject"
   description: "Properties of time-varying astronomical objects based on association
@@ -6995,17 +7001,21 @@ tables:
     "@id": "#FK_DiaSource_diaObjectId_DiaObject_diaObjectId"
     description: Link DiaObjects to associated DiaSources
     columns:
-    - "#DiaSource.diaObjectId"
-    referencedColumns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
+    reference:
+      table: "DiaObject"
+      columns:
+      - "diaObjectId"
   - name: CcdV_DiaS
     "@type": "ForeignKey"
     "@id": "#FK_DiaSource_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated DiaSources
     columns:
-    - "#DiaSource.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
   description: "Point-source forced-photometry measurements on individual single-epoch
@@ -7310,9 +7320,11 @@ tables:
     "@id": "#FK_ForcedSourceOnDiaObject_diaObjectId_DiaObject_diaObjectId"
     description: Link DiaObject to associated ForcedSourceOnDiaObjects
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
-    referencedColumns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
+    reference:
+      table: "DiaObject"
+      columns:
+      - "diaObjectId"
 - name: Visit
   '@id': '#Visit'
   description: "Metadata about the pointings of the DC2 simulated survey,
@@ -7701,9 +7713,11 @@ tables:
     "@id": "#FK_CcdVisit_visitId_Visit_visitId"
     description: Link Visits to the CcdVisits they contain
     columns:
-    - "#CcdVisit.visitId"
-    referencedColumns:
-    - "#Visit.visit"
+    - "visitId"
+    reference:
+      table: "Visit"
+      columns:
+      - "visit"
 - name: CoaddPatches
   "@id": "#coaddpatches"
   description: "Static information about the subset of tracts and patches from the standard
@@ -7840,17 +7854,21 @@ tables:
     "@id": "#FK_MatchesTruth_match_objectId_Object_objectId"
     description: Link Object to potential matches to Truth entries
     columns:
-    - "#MatchesTruth.match_objectId"
-    referencedColumns:
-    - "#Object.objectId"
+    - "match_objectId"
+    reference:
+      table: "Object"
+      columns:
+      - "objectId"
   - name: Tru_MatTru
     "@type": "ForeignKey"
     "@id": "#FK_MatchesTruth_id_truth_type_TruthSummary_id_truth_type"
     description: Link Truth entries to potential matches to Objects
     columns:
-    - "#MatchesTruth.id_truth_type"
-    referencedColumns:
-    - "#TruthSummary.id_truth_type"
+    - "id_truth_type"
+    reference:
+      table: "TruthSummary"
+      columns:
+      - "id_truth_type"
 # - name: MatchesObject
 #   '@id': '#MatchesObject'
 #   description: Match information for objectTable_tract sources

--- a/python/lsst/sdm/schemas/dp03_10yr.yaml
+++ b/python/lsst/sdm/schemas/dp03_10yr.yaml
@@ -417,24 +417,26 @@ tables:
   - name: IDX_DiaSource_ccdVisitId
     "@id": "#IDX_DiaSource_ccdVisitId"
     columns:
-    - "#DiaSource.ccdVisitId"
+    - "ccdVisitId"
   - name: IDX_DiaSource_diaObjectId
     "@id": "#IDX_DiaSource_diaObjectId"
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     "@id": "#IDX_DiaSource_ssObjectId"
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
   constraints:
   - name: SSO_DS_10yr
     "@type": "ForeignKey"
     "@id": "#FK_DiaSource_ssObjectId_SSObject_ssObjectId_10yr"
     description: Link SSObjects to associated DiaSources
     columns:
-    - "#DiaSource.ssObjectId"
-    referencedColumns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
+    reference:
+      table: "SSObject"
+      columns:
+      - "ssObjectId"
   mysql:engine: MyISAM
   mysql:charset: latin1
 - name: SSSource
@@ -596,9 +598,11 @@ tables:
     "@id": "#FK_SSSource_ssObjectId_SSObject_ssObjectId_10yr"
     description: Link SSObjects to associated SSSources
     columns:
-    - "#SSSource.ssObjectId"
-    referencedColumns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
+    reference:
+      table: "SSObject"
+      columns:
+      - "ssObjectId"
 - name: MPCORB
   "@id": "#MPCORB"
   description: The orbit catalog produced by the Minor Planet Center. Ingested daily.

--- a/python/lsst/sdm/schemas/dp03_1yr.yaml
+++ b/python/lsst/sdm/schemas/dp03_1yr.yaml
@@ -417,15 +417,15 @@ tables:
   - name: IDX_DiaSource_ccdVisitId
     "@id": "#IDX_DiaSource_ccdVisitId"
     columns:
-    - "#DiaSource.ccdVisitId"
+    - "ccdVisitId"
   - name: IDX_DiaSource_diaObjectId
     "@id": "#IDX_DiaSource_diaObjectId"
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     "@id": "#IDX_DiaSource_ssObjectId"
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
   mysql:engine: MyISAM
   mysql:charset: latin1
 - name: SSSource

--- a/python/lsst/sdm/schemas/dp1.yaml
+++ b/python/lsst/sdm/schemas/dp1.yaml
@@ -4879,7 +4879,7 @@ tables:
   - name: idx_Object_objectId
     description: Unique index on objectId column
     columns:
-    - "#Object.objectId"
+    - "objectId"
 - name: Source
   description: "Properties of detections on the single-epoch visit images, performed
     independently of the Object detections on coadded images."
@@ -5445,14 +5445,16 @@ tables:
     description: Link a Source to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#Source.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_Source_sourceId
     description: Unique index on sourceId column
     columns:
-    - "#Source.sourceId"
+    - "sourceId"
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit images and
     difference images, based on and linked to the entries in the Object table. Point-source
@@ -5597,21 +5599,25 @@ tables:
     description: Link an Object to its associated ForcedSources
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.objectId'
-    referencedColumns:
-    - '#Object.objectId'
+    - 'objectId'
+    reference:
+      table: 'Object'
+      columns:
+      - 'objectId'
   - name: fk_ForcedSource_Visit
     description: Link a ForcedSource to its associated visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSource_objectId
     description: Non-unique index on the objectId column; accelerates retrieval of light curves for Objects
     columns:
-    - '#ForcedSource.objectId'
+    - 'objectId'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -5957,33 +5963,39 @@ tables:
     description: Unique constraint on diaSourceId
     '@type': Unique
     columns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
   - name: fk_DiaSource_Visit
     description: Link a DiaSource to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#DiaSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   - name: fk_DiaSource_DiaObject
     description: Link a DiaObject to its associated DiaSources
     '@type': ForeignKey
     columns:
-    - '#DiaSource.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_DiaSource_SSObject
     description: Link a DiaSource to its associated SSObject, if any
     '@type': ForeignKey
     columns:
-    - '#DiaSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_DiaSource_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -6564,7 +6576,7 @@ tables:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column
     columns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
 - name: ForcedSourceOnDiaObject
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
@@ -6708,21 +6720,25 @@ tables:
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_ForcedSourceOnDiaObject_Visit
     description: Link a ForcedSourceOnDiaObject to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSourceOnDiaObject_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
+    - "diaObjectId"
 - name: CoaddPatches
   description: "Static information about the subset of tracts and patches from the standard
     LSST skymap that apply to coadds in these catalogs"
@@ -6781,11 +6797,11 @@ tables:
   - name: idx_CoaddPatches_lsst_patch
     description: Non-unique index on the lsst_patch column
     columns:
-    - "#CoaddPatches.lsst_patch"
+    - "lsst_patch"
   - name: idx_CoaddPatches_lsst_tract
     description: Non-unique index on the lsst_tract column
     columns:
-    - "#CoaddPatches.lsst_tract"
+    - "lsst_tract"
 - name: Visit
   description: "Metadata about the pointings of the telescope,
     largely associated with the boresight of the LSSTComCam focal plane as a whole."
@@ -6885,7 +6901,7 @@ tables:
   - name: idx_Visit_visit
     description: Unique index on the visit column
     columns:
-    - "#Visit.visit"
+    - "visit"
 - name: CcdVisit
   primaryKey:
   - "#CcdVisit.visitId"
@@ -7158,19 +7174,21 @@ tables:
     description: Link a Visit to the CCD-level images it contains
     '@type': ForeignKey
     columns:
-    - '#CcdVisit.visitId'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visitId'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_CcdVisit_visitId
     description: Non-unique index on visitId column; accelerates retrieval of data for all detectors for a visit
     columns:
-    - "#CcdVisit.visitId"
+    - "visitId"
   - name: idx_CcdVisit_visitId_detector
     description: Unique index on visit and detector columns in CcdVisit table
     columns:
-    - "#CcdVisit.visitId"
-    - "#CcdVisit.detector"
+    - "visitId"
+    - "detector"
 - name: SSObject
   description: LSST-computed per-object quantities. 1:1 relationship with MPCORB.
   tap:table_index: 110
@@ -7194,7 +7212,7 @@ tables:
   - name: idx_SSObject_ssObjectId
     description: Unique index on the ssObjectId column
     columns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
 - name: SSSource
   description: LSST-computed per-source quantities. 1:1 relationship with DiaSource.
   tap:table_index: 120
@@ -7297,25 +7315,29 @@ tables:
     description: Link an SSSource to its associated DiaSource
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_SSSource_diaSourceId
     description: Unique index on the diaSourceId column; accelerates joins between DiaSource and SSSource
     columns:
-    - "#SSSource.diaSourceId"
+    - "diaSourceId"
   - name: idx_SSSource_ssObjectId
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 - name: MPCORB
   description: Orbit catalog produced by the Minor Planet Center based on submissions from DP1 processing.
     The columns are described at https://minorplanetcenter.net//iau/info/MPOrbitFormat.html .
@@ -7368,15 +7390,17 @@ tables:
     description: Link an MPCORB record to its associated SSObject
     '@type': ForeignKey
     columns:
-    - '#MPCORB.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_MPCORB_mpcDesignation
     description: Non-unique index on the mpcDesignation column
     columns:
-    - "#MPCORB.mpcDesignation"
+    - "mpcDesignation"
   - name: idx_MPCORB_ssObjectId
     description: Unique index on the ssObjectId column
     columns:
-    - "#MPCORB.ssObjectId"
+    - "ssObjectId"

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1267,7 +1267,7 @@ tables:
   - name: idx_Object_objectId
     description: Unique index on objectId column.
     columns:
-    - "#Object.objectId"
+    - "objectId"
 - name: Source
   description: "Properties of detections on the single-epoch visit images,
     performed independently of the Object detections on coadded images."
@@ -1437,14 +1437,16 @@ tables:
     description: Link a Source to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#Source.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_Source_sourceId
     description: Unique index on sourceId column.
     columns:
-    - "#Source.sourceId"
+    - "sourceId"
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit
     images and difference images, based on and linked to the entries in the
@@ -1488,21 +1490,25 @@ tables:
     description: Link an Object to its associated ForcedSources.
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.objectId'
-    referencedColumns:
-    - '#Object.objectId'
+    - 'objectId'
+    reference:
+      table: 'Object'
+      columns:
+      - 'objectId'
   - name: fk_ForcedSource_Visit
     description: Link a ForcedSource to its associated visit.
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSource_objectId
     description: Non-unique index on the objectId column; accelerates retrieval of light curves for Objects.
     columns:
-    - '#ForcedSource.objectId'
+    - 'objectId'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -1606,33 +1612,39 @@ tables:
     description: Unique constraint on diaSourceId.
     '@type': Unique
     columns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
   - name: fk_DiaSource_Visit
     description: Link a DiaSource to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   - name: fk_DiaSource_DiaObject
     description: Link a DiaObject to its associated DiaSources.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_DiaSource_SSObject
     description: Link a DiaSource to its associated SSObject, if any.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_DiaSource_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects.
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -1710,7 +1722,7 @@ tables:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column.
     columns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
 - name: ForcedSourceOnDiaObject
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
@@ -1752,21 +1764,25 @@ tables:
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects.
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_ForcedSourceOnDiaObject_Visit
     description: Link a ForcedSourceOnDiaObject to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSourceOnDiaObject_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects.
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
+    - "diaObjectId"
 
 # - name: CoaddPatches
 #   description: "Static information about the subset of tracts and patches from the standard
@@ -1808,7 +1824,7 @@ tables:
   - name: idx_Visit_visit
     description: Unique index on the visit column.
     columns:
-    - "#Visit.visit"
+    - "visit"
 - name: VisitDetector
   primaryKey:
   - "#VisitDetector.visitId"
@@ -1879,19 +1895,21 @@ tables:
     description: Link a Visit to the CCD-level images it contains.
     '@type': ForeignKey
     columns:
-    - '#VisitDetector.visitId'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visitId'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_VisitDetector_visitId
     description: Non-unique index on visitId column; accelerates retrieval of data for all detectors for a visit.
     columns:
-    - "#VisitDetector.visitId"
+    - "visitId"
   - name: idx_VisitDetector_visitId_detector
     description: Unique index on visit and detector columns in VisitDetector table.
     columns:
-    - "#VisitDetector.visitId"
-    - "#VisitDetector.detector"
+    - "visitId"
+    - "detector"
 - name: SSObject
   description: LSST-computed per-object quantities.
   tap:table_index: 110
@@ -1983,7 +2001,7 @@ tables:
   - name: idx_SSObject_ssObjectId
     description: Unique index on the ssObjectId column.
     columns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
   tap:table_index: 120
@@ -2035,25 +2053,29 @@ tables:
     description: Link an SSSource to its associated DiaSource.
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources.
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_SSSource_diaSourceId
     description: Unique index on the diaSourceId column; accelerates joins between DiaSource and SSSource.
     columns:
-    - "#SSSource.diaSourceId"
+    - "diaSourceId"
   - name: idx_SSSource_ssObjectId
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects.
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 # - name: mpc_orbits
 #   description: Table of orbital elements and related information of known
 #     (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
@@ -2246,7 +2268,7 @@ tables:
   - name: idx_ShearObject_shearObjectId
     description: Unique index on the shearObjectId column.
     columns:
-    - "#ShearObject.shearObjectId"
+    - "shearObjectId"
 - name: IsolatedStarStellarMotions
   description: Position, proper motion, and parallax for isolated stars, fit using
     associated source measurements, with positions for associated reference objects
@@ -2288,8 +2310,8 @@ tables:
   - name: idx_IsolatedStarStellarMotions_isolated_star_id
     description: Unique index on the isolated_star_id column.
     columns:
-    - "#IsolatedStarStellarMotions.isolated_star_id"
+    - "isolated_star_id"
   - name: idx_IsolatedStarStellarMotions_referenceId
     description: Non-unique index on the referenceId column; accelerates retrieval of stellar motions for reference objects.
     columns:
-    - "#IsolatedStarStellarMotions.referenceId"
+    - "referenceId"

--- a/python/lsst/sdm/schemas/efd_latiss.yaml
+++ b/python/lsst/sdm/schemas/efd_latiss.yaml
@@ -17,7 +17,7 @@ tables:
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure_efd.exposure_id"
+    - "exposure_id"
   columns:
   - name: day_obs
     "@id": "#exposure_efd.day_obs"
@@ -1709,7 +1709,7 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1_efd.visit_id"
+    - "visit_id"
   columns:
   - name: day_obs
     "@id": "#visit1_efd.day_obs"

--- a/python/lsst/sdm/schemas/efd_lsstcam.yaml
+++ b/python/lsst/sdm/schemas/efd_lsstcam.yaml
@@ -17,7 +17,7 @@ tables:
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure_efd.exposure_id"
+    - "exposure_id"
   columns:
   - name: day_obs
     "@id": "#exposure_efd.day_obs"
@@ -2931,7 +2931,7 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1_efd.visit_id"
+    - "visit_id"
   columns:
   - name: day_obs
     "@id": "#visit1_efd.day_obs"

--- a/python/lsst/sdm/schemas/efd_lsstcomcam.yaml
+++ b/python/lsst/sdm/schemas/efd_lsstcomcam.yaml
@@ -17,7 +17,7 @@ tables:
     "@type": Unique
     description: Ensure exposure_id is unique.
     columns:
-    - "#exposure_efd.exposure_id"
+    - "exposure_id"
   columns:
   - name: day_obs
     "@id": "#exposure_efd.day_obs"
@@ -2919,7 +2919,7 @@ tables:
     "@type": Unique
     description: Ensure visit_id is unique.
     columns:
-    - "#visit1_efd.visit_id"
+    - "visit_id"
   columns:
   - name: day_obs
     "@id": "#visit1_efd.day_obs"

--- a/python/lsst/sdm/schemas/hsc.yaml
+++ b/python/lsst/sdm/schemas/hsc.yaml
@@ -1404,4 +1404,4 @@ tables:
   - name: idx_Parent_objectId
     description: Unique index on objectId column
     columns:
-    - "#Parent.objectId"
+    - "objectId"

--- a/python/lsst/sdm/schemas/imsim.yaml
+++ b/python/lsst/sdm/schemas/imsim.yaml
@@ -1872,4 +1872,4 @@ tables:
   - name: idx_Parent_objectId
     description: Unique index on objectId column
     columns:
-    - "#Parent.objectId"
+    - "objectId"

--- a/python/lsst/sdm/schemas/lsstcam.yaml
+++ b/python/lsst/sdm/schemas/lsstcam.yaml
@@ -1268,7 +1268,7 @@ tables:
   - name: idx_Object_objectId
     description: Unique index on objectId column
     columns:
-    - "#Object.objectId"
+    - "objectId"
 - name: Source
   description: "Properties of detections on the single-epoch visit images, performed
     independently of the Object detections on coadded images."
@@ -1438,14 +1438,16 @@ tables:
     description: Link a Source to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#Source.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_Source_sourceId
     description: Unique index on sourceId column
     columns:
-    - "#Source.sourceId"
+    - "sourceId"
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit images and
     difference images, based on and linked to the entries in the Object table. Point-source
@@ -1489,21 +1491,25 @@ tables:
     description: Link an Object to its associated ForcedSources
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.objectId'
-    referencedColumns:
-    - '#Object.objectId'
+    - 'objectId'
+    reference:
+      table: 'Object'
+      columns:
+      - 'objectId'
   - name: fk_ForcedSource_Visit
     description: Link a ForcedSource to its associated visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSource_objectId
     description: Non-unique index on the objectId column; accelerates retrieval of light curves for Objects
     columns:
-    - '#ForcedSource.objectId'
+    - 'objectId'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -1609,33 +1615,39 @@ tables:
     description: Unique constraint on diaSourceId
     '@type': Unique
     columns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
   - name: fk_DiaSource_Visit
     description: Link a DiaSource to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#DiaSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   - name: fk_DiaSource_DiaObject
     description: Link a DiaObject to its associated DiaSources
     '@type': ForeignKey
     columns:
-    - '#DiaSource.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_DiaSource_SSObject
     description: Link a DiaSource to its associated SSObject, if any
     '@type': ForeignKey
     columns:
-    - '#DiaSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_DiaSource_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -1716,7 +1728,7 @@ tables:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column
     columns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
 - name: ForcedSourceOnDiaObject
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
@@ -1759,21 +1771,25 @@ tables:
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_ForcedSourceOnDiaObject_Visit
     description: Link a ForcedSourceOnDiaObject to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSourceOnDiaObject_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
+    - "diaObjectId"
 - name: CoaddPatches
   description: "Static information about the subset of tracts and patches from the standard
     LSST skymap that apply to coadds in these catalogs"
@@ -1790,11 +1806,11 @@ tables:
   - name: idx_CoaddPatches_lsst_patch
     description: Non-unique index on the lsst_patch column
     columns:
-    - "#CoaddPatches.lsst_patch"
+    - "lsst_patch"
   - name: idx_CoaddPatches_lsst_tract
     description: Non-unique index on the lsst_tract column
     columns:
-    - "#CoaddPatches.lsst_tract"
+    - "lsst_tract"
 - name: Visit
   description: "Metadata about the pointings of the telescope,
     largely associated with the boresight of the LSSTCam focal plane as a whole."
@@ -1822,7 +1838,7 @@ tables:
   - name: idx_Visit_visit
     description: Unique index on the visit column
     columns:
-    - "#Visit.visit"
+    - "visit"
 - name: VisitDetector
   primaryKey:
   - "#VisitDetector.visitId"
@@ -1909,19 +1925,21 @@ tables:
     description: Link a Visit to the CCD-level images it contains
     '@type': ForeignKey
     columns:
-    - '#VisitDetector.visitId'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visitId'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_VisitDetector_visitId
     description: Non-unique index on visitId column; accelerates retrieval of data for all detectors for a visit
     columns:
-    - "#VisitDetector.visitId"
+    - "visitId"
   - name: idx_VisitDetector_visitId_detector
     description: Unique index on visit and detector columns in CcdVisit table
     columns:
-    - "#VisitDetector.visitId"
-    - "#VisitDetector.detector"
+    - "visitId"
+    - "detector"
 - name: SSObject
   description: LSST-computed per-object quantities.
   tap:table_index: 110
@@ -2014,19 +2032,21 @@ tables:
     description: Link an SSObject to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSObject.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
   - name: unique_SSObject_designation
     description: Unique index on the designation column
     '@type': Unique
     columns:
-    - "#SSObject.designation"
+    - "designation"
   indexes:
   - name: idx_SSObject_MOIDEarth
     description: Index on the MOIDEarth column
     columns:
-    - "#SSObject.MOIDEarth"
+    - "MOIDEarth"
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
   tap:table_index: 120
@@ -2078,36 +2098,42 @@ tables:
     description: Link an SSSource to its associated DiaSource
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   - name: fk_SSSource_mpc_orbits
     description: Link an SSSource to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSSource.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
   indexes:
   - name: idx_SSSource_ssObjectId
     description: >
       Non-unique index on the ssObjectId column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
   - name: idx_SSSource_designation
     description: >
       Non-unique index on the designation column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.designation"
+    - "designation"
 - name: mpc_orbits
   description: Table of orbital elements and related information of known (sun-orbiting and unbound) Solar
     System objects. Replicated from the Minor Planet Center (Postgres) database. This schema will
@@ -2176,17 +2202,17 @@ tables:
     description: Uniqueness of unpacked_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'
   - name: unique_mpc_orbits_designation
     description: Uniqueness of designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.designation'
+    - 'designation'
   - name: unique_mpc_orbits_packed_primary_provisional_designation
     description: Uniqueness of packed_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
 - name: current_identifications
   description: All single-designations, and all identifications between designations. Always uses primary
     provisional designation (even for numbered objects). Includes all comets and satellites.
@@ -2214,12 +2240,12 @@ tables:
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#current_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: uniq_current_identifications_packed_secondary_provisional_desig
     "@type": Unique
     description: Unique index on the packed_secondary_provisional_designation column
     columns:
-    - '#current_identifications.packed_secondary_provisional_designation'
+    - 'packed_secondary_provisional_designation'
 - name: numbered_identifications
   description: The numbered identification table contains all the numbered objects (minor planets, comets and
     natural satellites) with their primary provisional designations. The table is continously
@@ -2247,22 +2273,22 @@ tables:
     "@type": Unique
     description: Unique index on the iau_name column
     columns:
-    - '#numbered_identifications.iau_name'
+    - 'iau_name'
   - name: unique_numbered_identifications_packed_primary_prov_desig
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: unique_numbered_identifications_permid
     "@type": Unique
     description: Unique index on the permid column
     columns:
-    - '#numbered_identifications.permid'
+    - 'permid'
   - name: uniq_numbered_identifications_unpacked_primary_prov_desig
     "@type": Unique
     description: Unique index on the unpacked_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'
 - name: Parent
   description: "Descriptions of the parent objects in the deblending hierarchy."
   tap:table_index: 160

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lsst-felis @ git+https://github.com/lsst/felis.git@main
+lsst-felis @ git+https://github.com/lsst/felis.git@tickets/DM-51789
 
 # This is here for setup in CI and using sdm_tools ticket branches 
 # easily. It is deliberately not included in the pyproject deps


### PR DESCRIPTION
This converts all column references in the schemas to use names instead of IDs as part of implementing RFC-1111.

NB: This depends on https://github.com/lsst/felis/pull/189 .

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
