### PR TITLE
DM-55392: Add CoaddPatches to DP2 schema

### DIFF
--- a/docs/changes/DM-55392.dr.md
+++ b/docs/changes/DM-55392.dr.md
@@ -1,0 +1,1 @@
+Add `CoaddPatches` table to DP2 schema (`dp2.yaml`).

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1768,18 +1768,18 @@ tables:
     columns:
     - "#ForcedSourceOnDiaObject.diaObjectId"
 
-# - name: CoaddPatches
-#   description: "Static information about the subset of tracts and patches from the standard
-#   LSST skymap that apply to coadds in these catalogs"
-#   tap:table_index: 70
-#   columnRefs:
-#     base:
-#       CoaddPatches:
-#         lsst_tract:
-#         lsst_patch:
-#         s_ra:
-#         s_dec:
-#         s_region:
+- name: CoaddPatches
+  description: "Static information about the subset of tracts and patches from the standard
+    LSST skymap that apply to coadds in these catalogs."
+  tap:table_index: 70
+  columnRefs:
+    base:
+      CoaddPatches:
+        lsst_tract:
+        lsst_patch:
+        s_ra:
+        s_dec:
+        s_region:
 
 - name: Visit
   description: "Metadata about the pointings of the telescope,


### PR DESCRIPTION
This adds the `CoaddPatches` to the DP2 schema (`dp2.yaml`).

The change was checked on `data-int` and looks good. The table can be queried through the portal.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
