### PR TITLE
DM-51789: Convert column references in Data Preview schemas to use names instead of IDs

### DIFF
--- a/docs/changes/DM-51789.dr.md
+++ b/docs/changes/DM-51789.dr.md
@@ -1,0 +1,1 @@
+Converted column references in DR schemas to use names instead of IDs

--- a/python/lsst/sdm/schemas/dp02_dc2.yaml
+++ b/python/lsst/sdm/schemas/dp02_dc2.yaml
@@ -5731,9 +5731,11 @@ tables:
     "@id": "#FK_Source_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated Sources
     columns:
-    - "#Source.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: ForcedSource
   "@id": "#ForcedSource"
   description: "Forced-photometry measurements on individual single-epoch visit images and
@@ -6063,17 +6065,21 @@ tables:
     "@id": "#FK_ForcedSource_objectId_Object_objectId"
     description: Link Objects to associated ForcedSources
     columns:
-    - "#ForcedSource.objectId"
-    referencedColumns:
-    - "#Object.objectId"
+    - "objectId"
+    reference:
+      table: "Object"
+      columns:
+      - "objectId"
   - name: CcdV_FS
     "@type": "ForeignKey"
     "@id": "#FK_ForcedSource_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated ForcedSources
     columns:
-    - "#ForcedSource.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: DiaObject
   "@id": "#DiaObject"
   description: "Properties of time-varying astronomical objects based on association
@@ -6995,17 +7001,21 @@ tables:
     "@id": "#FK_DiaSource_diaObjectId_DiaObject_diaObjectId"
     description: Link DiaObjects to associated DiaSources
     columns:
-    - "#DiaSource.diaObjectId"
-    referencedColumns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
+    reference:
+      table: "DiaObject"
+      columns:
+      - "diaObjectId"
   - name: CcdV_DiaS
     "@type": "ForeignKey"
     "@id": "#FK_DiaSource_ccdVisitId_CcdVisit_ccdVisitId"
     description: Link CCD-level images to associated DiaSources
     columns:
-    - "#DiaSource.ccdVisitId"
-    referencedColumns:
-    - "#CcdVisit.ccdVisitId"
+    - "ccdVisitId"
+    reference:
+      table: "CcdVisit"
+      columns:
+      - "ccdVisitId"
 - name: ForcedSourceOnDiaObject
   "@id": "#ForcedSourceOnDiaObject"
   description: "Point-source forced-photometry measurements on individual single-epoch
@@ -7310,9 +7320,11 @@ tables:
     "@id": "#FK_ForcedSourceOnDiaObject_diaObjectId_DiaObject_diaObjectId"
     description: Link DiaObject to associated ForcedSourceOnDiaObjects
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
-    referencedColumns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
+    reference:
+      table: "DiaObject"
+      columns:
+      - "diaObjectId"
 - name: Visit
   '@id': '#Visit'
   description: "Metadata about the pointings of the DC2 simulated survey,
@@ -7701,9 +7713,11 @@ tables:
     "@id": "#FK_CcdVisit_visitId_Visit_visitId"
     description: Link Visits to the CcdVisits they contain
     columns:
-    - "#CcdVisit.visitId"
-    referencedColumns:
-    - "#Visit.visit"
+    - "visitId"
+    reference:
+      table: "Visit"
+      columns:
+      - "visit"
 - name: CoaddPatches
   "@id": "#coaddpatches"
   description: "Static information about the subset of tracts and patches from the standard
@@ -7840,17 +7854,21 @@ tables:
     "@id": "#FK_MatchesTruth_match_objectId_Object_objectId"
     description: Link Object to potential matches to Truth entries
     columns:
-    - "#MatchesTruth.match_objectId"
-    referencedColumns:
-    - "#Object.objectId"
+    - "match_objectId"
+    reference:
+      table: "Object"
+      columns:
+      - "objectId"
   - name: Tru_MatTru
     "@type": "ForeignKey"
     "@id": "#FK_MatchesTruth_id_truth_type_TruthSummary_id_truth_type"
     description: Link Truth entries to potential matches to Objects
     columns:
-    - "#MatchesTruth.id_truth_type"
-    referencedColumns:
-    - "#TruthSummary.id_truth_type"
+    - "id_truth_type"
+    reference:
+      table: "TruthSummary"
+      columns:
+      - "id_truth_type"
 # - name: MatchesObject
 #   '@id': '#MatchesObject'
 #   description: Match information for objectTable_tract sources

--- a/python/lsst/sdm/schemas/dp03_10yr.yaml
+++ b/python/lsst/sdm/schemas/dp03_10yr.yaml
@@ -417,24 +417,26 @@ tables:
   - name: IDX_DiaSource_ccdVisitId
     "@id": "#IDX_DiaSource_ccdVisitId"
     columns:
-    - "#DiaSource.ccdVisitId"
+    - "ccdVisitId"
   - name: IDX_DiaSource_diaObjectId
     "@id": "#IDX_DiaSource_diaObjectId"
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     "@id": "#IDX_DiaSource_ssObjectId"
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
   constraints:
   - name: SSO_DS_10yr
     "@type": "ForeignKey"
     "@id": "#FK_DiaSource_ssObjectId_SSObject_ssObjectId_10yr"
     description: Link SSObjects to associated DiaSources
     columns:
-    - "#DiaSource.ssObjectId"
-    referencedColumns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
+    reference:
+      table: "SSObject"
+      columns:
+      - "ssObjectId"
   mysql:engine: MyISAM
   mysql:charset: latin1
 - name: SSSource
@@ -596,9 +598,11 @@ tables:
     "@id": "#FK_SSSource_ssObjectId_SSObject_ssObjectId_10yr"
     description: Link SSObjects to associated SSSources
     columns:
-    - "#SSSource.ssObjectId"
-    referencedColumns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
+    reference:
+      table: "SSObject"
+      columns:
+      - "ssObjectId"
 - name: MPCORB
   "@id": "#MPCORB"
   description: The orbit catalog produced by the Minor Planet Center. Ingested daily.

--- a/python/lsst/sdm/schemas/dp03_1yr.yaml
+++ b/python/lsst/sdm/schemas/dp03_1yr.yaml
@@ -417,15 +417,15 @@ tables:
   - name: IDX_DiaSource_ccdVisitId
     "@id": "#IDX_DiaSource_ccdVisitId"
     columns:
-    - "#DiaSource.ccdVisitId"
+    - "ccdVisitId"
   - name: IDX_DiaSource_diaObjectId
     "@id": "#IDX_DiaSource_diaObjectId"
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     "@id": "#IDX_DiaSource_ssObjectId"
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
   mysql:engine: MyISAM
   mysql:charset: latin1
 - name: SSSource

--- a/python/lsst/sdm/schemas/dp1.yaml
+++ b/python/lsst/sdm/schemas/dp1.yaml
@@ -4879,7 +4879,7 @@ tables:
   - name: idx_Object_objectId
     description: Unique index on objectId column
     columns:
-    - "#Object.objectId"
+    - "objectId"
 - name: Source
   description: "Properties of detections on the single-epoch visit images, performed
     independently of the Object detections on coadded images."
@@ -5445,14 +5445,16 @@ tables:
     description: Link a Source to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#Source.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_Source_sourceId
     description: Unique index on sourceId column
     columns:
-    - "#Source.sourceId"
+    - "sourceId"
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit images and
     difference images, based on and linked to the entries in the Object table. Point-source
@@ -5597,21 +5599,25 @@ tables:
     description: Link an Object to its associated ForcedSources
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.objectId'
-    referencedColumns:
-    - '#Object.objectId'
+    - 'objectId'
+    reference:
+      table: 'Object'
+      columns:
+      - 'objectId'
   - name: fk_ForcedSource_Visit
     description: Link a ForcedSource to its associated visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSource_objectId
     description: Non-unique index on the objectId column; accelerates retrieval of light curves for Objects
     columns:
-    - '#ForcedSource.objectId'
+    - 'objectId'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -5957,33 +5963,39 @@ tables:
     description: Unique constraint on diaSourceId
     '@type': Unique
     columns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
   - name: fk_DiaSource_Visit
     description: Link a DiaSource to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#DiaSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   - name: fk_DiaSource_DiaObject
     description: Link a DiaObject to its associated DiaSources
     '@type': ForeignKey
     columns:
-    - '#DiaSource.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_DiaSource_SSObject
     description: Link a DiaSource to its associated SSObject, if any
     '@type': ForeignKey
     columns:
-    - '#DiaSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_DiaSource_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -6564,7 +6576,7 @@ tables:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column
     columns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
 - name: ForcedSourceOnDiaObject
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
@@ -6708,21 +6720,25 @@ tables:
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_ForcedSourceOnDiaObject_Visit
     description: Link a ForcedSourceOnDiaObject to its associated Visit
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSourceOnDiaObject_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
+    - "diaObjectId"
 - name: CoaddPatches
   description: "Static information about the subset of tracts and patches from the standard
     LSST skymap that apply to coadds in these catalogs"
@@ -6781,11 +6797,11 @@ tables:
   - name: idx_CoaddPatches_lsst_patch
     description: Non-unique index on the lsst_patch column
     columns:
-    - "#CoaddPatches.lsst_patch"
+    - "lsst_patch"
   - name: idx_CoaddPatches_lsst_tract
     description: Non-unique index on the lsst_tract column
     columns:
-    - "#CoaddPatches.lsst_tract"
+    - "lsst_tract"
 - name: Visit
   description: "Metadata about the pointings of the telescope,
     largely associated with the boresight of the LSSTComCam focal plane as a whole."
@@ -6885,7 +6901,7 @@ tables:
   - name: idx_Visit_visit
     description: Unique index on the visit column
     columns:
-    - "#Visit.visit"
+    - "visit"
 - name: CcdVisit
   primaryKey:
   - "#CcdVisit.visitId"
@@ -7158,19 +7174,21 @@ tables:
     description: Link a Visit to the CCD-level images it contains
     '@type': ForeignKey
     columns:
-    - '#CcdVisit.visitId'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visitId'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_CcdVisit_visitId
     description: Non-unique index on visitId column; accelerates retrieval of data for all detectors for a visit
     columns:
-    - "#CcdVisit.visitId"
+    - "visitId"
   - name: idx_CcdVisit_visitId_detector
     description: Unique index on visit and detector columns in CcdVisit table
     columns:
-    - "#CcdVisit.visitId"
-    - "#CcdVisit.detector"
+    - "visitId"
+    - "detector"
 - name: SSObject
   description: LSST-computed per-object quantities. 1:1 relationship with MPCORB.
   tap:table_index: 110
@@ -7194,7 +7212,7 @@ tables:
   - name: idx_SSObject_ssObjectId
     description: Unique index on the ssObjectId column
     columns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
 - name: SSSource
   description: LSST-computed per-source quantities. 1:1 relationship with DiaSource.
   tap:table_index: 120
@@ -7297,25 +7315,29 @@ tables:
     description: Link an SSSource to its associated DiaSource
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_SSSource_diaSourceId
     description: Unique index on the diaSourceId column; accelerates joins between DiaSource and SSSource
     columns:
-    - "#SSSource.diaSourceId"
+    - "diaSourceId"
   - name: idx_SSSource_ssObjectId
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 - name: MPCORB
   description: Orbit catalog produced by the Minor Planet Center based on submissions from DP1 processing.
     The columns are described at https://minorplanetcenter.net//iau/info/MPOrbitFormat.html .
@@ -7368,15 +7390,17 @@ tables:
     description: Link an MPCORB record to its associated SSObject
     '@type': ForeignKey
     columns:
-    - '#MPCORB.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_MPCORB_mpcDesignation
     description: Non-unique index on the mpcDesignation column
     columns:
-    - "#MPCORB.mpcDesignation"
+    - "mpcDesignation"
   - name: idx_MPCORB_ssObjectId
     description: Unique index on the ssObjectId column
     columns:
-    - "#MPCORB.ssObjectId"
+    - "ssObjectId"

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1267,7 +1267,7 @@ tables:
   - name: idx_Object_objectId
     description: Unique index on objectId column.
     columns:
-    - "#Object.objectId"
+    - "objectId"
 - name: Source
   description: "Properties of detections on the single-epoch visit images,
     performed independently of the Object detections on coadded images."
@@ -1437,14 +1437,16 @@ tables:
     description: Link a Source to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#Source.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_Source_sourceId
     description: Unique index on sourceId column.
     columns:
-    - "#Source.sourceId"
+    - "sourceId"
 - name: ForcedSource
   description: "Forced-photometry measurements on individual single-epoch visit
     images and difference images, based on and linked to the entries in the
@@ -1488,21 +1490,25 @@ tables:
     description: Link an Object to its associated ForcedSources.
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.objectId'
-    referencedColumns:
-    - '#Object.objectId'
+    - 'objectId'
+    reference:
+      table: 'Object'
+      columns:
+      - 'objectId'
   - name: fk_ForcedSource_Visit
     description: Link a ForcedSource to its associated visit.
     '@type': ForeignKey
     columns:
-    - '#ForcedSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSource_objectId
     description: Non-unique index on the objectId column; accelerates retrieval of light curves for Objects.
     columns:
-    - '#ForcedSource.objectId'
+    - 'objectId'
 - name: DiaSource
   description: "Properties of transient-object detections on the single-epoch difference images."
   tap:table_index: 50
@@ -1606,33 +1612,39 @@ tables:
     description: Unique constraint on diaSourceId.
     '@type': Unique
     columns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
   - name: fk_DiaSource_Visit
     description: Link a DiaSource to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   - name: fk_DiaSource_DiaObject
     description: Link a DiaObject to its associated DiaSources.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_DiaSource_SSObject
     description: Link a DiaSource to its associated SSObject, if any.
     '@type': ForeignKey
     columns:
-    - '#DiaSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_DiaSource_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects.
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
 - name: DiaObject
   description: "Properties of time-varying astronomical objects based on association
     of data from one or more spatially-related DiaSource detections on individual
@@ -1710,7 +1722,7 @@ tables:
   - name: idx_DiaObject_diaObjectId
     description: Unique index on the diaObjectId column.
     columns:
-    - "#DiaObject.diaObjectId"
+    - "diaObjectId"
 - name: ForcedSourceOnDiaObject
   description: "Point-source forced-photometry measurements on individual single-epoch
     visit images and difference images, based on and linked to the entries in the
@@ -1752,21 +1764,25 @@ tables:
     description: Link a DiaObject to its associated ForcedSourceOnDiaObjects.
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.diaObjectId'
-    referencedColumns:
-    - '#DiaObject.diaObjectId'
+    - 'diaObjectId'
+    reference:
+      table: 'DiaObject'
+      columns:
+      - 'diaObjectId'
   - name: fk_ForcedSourceOnDiaObject_Visit
     description: Link a ForcedSourceOnDiaObject to its associated Visit.
     '@type': ForeignKey
     columns:
-    - '#ForcedSourceOnDiaObject.visit'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visit'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_ForcedSourceOnDiaObject_diaObjectId
     description: Non-unique index on the diaObjectId column; accelerates retrieval of light curves for DiaObjects.
     columns:
-    - "#ForcedSourceOnDiaObject.diaObjectId"
+    - "diaObjectId"
 
 - name: CoaddPatches
   description: "Static information about the subset of tracts and patches from the standard
@@ -1808,7 +1824,7 @@ tables:
   - name: idx_Visit_visit
     description: Unique index on the visit column.
     columns:
-    - "#Visit.visit"
+    - "visit"
 - name: VisitDetector
   primaryKey:
   - "#VisitDetector.visitId"
@@ -1879,19 +1895,21 @@ tables:
     description: Link a Visit to the CCD-level images it contains.
     '@type': ForeignKey
     columns:
-    - '#VisitDetector.visitId'
-    referencedColumns:
-    - '#Visit.visit'
+    - 'visitId'
+    reference:
+      table: 'Visit'
+      columns:
+      - 'visit'
   indexes:
   - name: idx_VisitDetector_visitId
     description: Non-unique index on visitId column; accelerates retrieval of data for all detectors for a visit.
     columns:
-    - "#VisitDetector.visitId"
+    - "visitId"
   - name: idx_VisitDetector_visitId_detector
     description: Unique index on visit and detector columns in VisitDetector table.
     columns:
-    - "#VisitDetector.visitId"
-    - "#VisitDetector.detector"
+    - "visitId"
+    - "detector"
 - name: SSObject
   description: LSST-computed per-object quantities.
   tap:table_index: 110
@@ -1983,7 +2001,7 @@ tables:
   - name: idx_SSObject_ssObjectId
     description: Unique index on the ssObjectId column.
     columns:
-    - "#SSObject.ssObjectId"
+    - "ssObjectId"
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
   tap:table_index: 120
@@ -2035,25 +2053,29 @@ tables:
     description: Link an SSSource to its associated DiaSource.
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources.
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
   indexes:
   - name: idx_SSSource_diaSourceId
     description: Unique index on the diaSourceId column; accelerates joins between DiaSource and SSSource.
     columns:
-    - "#SSSource.diaSourceId"
+    - "diaSourceId"
   - name: idx_SSSource_ssObjectId
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects.
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 # - name: mpc_orbits
 #   description: Table of orbital elements and related information of known
 #     (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
@@ -2246,7 +2268,7 @@ tables:
   - name: idx_ShearObject_shearObjectId
     description: Unique index on the shearObjectId column.
     columns:
-    - "#ShearObject.shearObjectId"
+    - "shearObjectId"
 - name: IsolatedStarStellarMotions
   description: Position, proper motion, and parallax for isolated stars, fit using
     associated source measurements, with positions for associated reference objects
@@ -2288,8 +2310,8 @@ tables:
   - name: idx_IsolatedStarStellarMotions_isolated_star_id
     description: Unique index on the isolated_star_id column.
     columns:
-    - "#IsolatedStarStellarMotions.isolated_star_id"
+    - "isolated_star_id"
   - name: idx_IsolatedStarStellarMotions_referenceId
     description: Non-unique index on the referenceId column; accelerates retrieval of stellar motions for reference objects.
     columns:
-    - "#IsolatedStarStellarMotions.referenceId"
+    - "referenceId"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lsst-felis @ git+https://github.com/lsst/felis.git@main
+lsst-felis @ git+https://github.com/lsst/felis.git@tickets/DM-51789
 
 # This is here for setup in CI and using sdm_tools ticket branches 
 # easily. It is deliberately not included in the pyproject deps


### PR DESCRIPTION
## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
