### PR TITLE
DM-51789: Convert column references in APDB schema to use names instead of IDs

### DIFF
--- a/docs/changes/DM-51789.ap.md
+++ b/docs/changes/DM-51789.ap.md
@@ -1,0 +1,1 @@
+Convert column references in APDB schema to use names instead of IDs

--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -414,7 +414,7 @@ tables:
   indexes:
   - name: IDX_DiaObject_validityStart
     columns:
-    - "#DiaObject.validityStartMjdTai"
+    - "validityStartMjdTai"
 - name: DiaSource
   description: Table to store 'difference image sources'; - sources detected at
     SNR >=5 on difference images.
@@ -896,14 +896,14 @@ tables:
   indexes:
   - name: IDX_DiaSource_visitDetector
     columns:
-    - "#DiaSource.visit"
-    - "#DiaSource.detector"
+    - "visit"
+    - "detector"
   - name: IDX_DiaSource_diaObjectId
     columns:
-    - "#DiaSource.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaSource_ssObjectId
     columns:
-    - "#DiaSource.ssObjectId"
+    - "ssObjectId"
 - name: DiaForcedSource
   description: Forced-photometry source measurement on an individual difference Exposure
     for all objects in the DiaObject table.
@@ -990,8 +990,8 @@ tables:
   indexes:
   - name: IDX_DiaForcedSource_visitDetector
     columns:
-    - "#DiaForcedSource.visit"
-    - "#DiaForcedSource.detector"
+    - "visit"
+    - "detector"
 - name: DiaObject_To_Object_Match
   description: The table stores mapping of diaObjects to the nearby objects.
   columns:
@@ -1016,10 +1016,10 @@ tables:
   indexes:
   - name: IDX_DiaObjectToObjectMatch_diaObjectId
     columns:
-    - "#DiaObject_To_Object_Match.diaObjectId"
+    - "diaObjectId"
   - name: IDX_DiaObjectToObjectMatch_objectId
     columns:
-    - "#DiaObject_To_Object_Match.objectId"
+    - "objectId"
 - name: DiaObjectLast
   description: Table with a subset of DiaObject columns used to store only the
     latest version of each object.
@@ -1741,19 +1741,21 @@ tables:
     description: Link an SSObject to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSObject.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
   - name: unique_SSObject_designation
     description: Unique index on the designation column
     '@type': Unique
     columns:
-    - "#SSObject.designation"
+    - "designation"
   indexes:
   - name: idx_SSObject_MOIDEarth
     description: Index on the MOIDEarth column
     columns:
-    - "#SSObject.MOIDEarth"
+    - "MOIDEarth"
 
 - name: SSSource
   description: LSST-computed per-source quantities. 1::1 relationship with DiaSource.
@@ -1984,25 +1986,31 @@ tables:
     description: Link an SSSource to its associated DiaSource
     '@type': ForeignKey
     columns:
-    - '#SSSource.diaSourceId'
-    referencedColumns:
-    - '#DiaSource.diaSourceId'
+    - 'diaSourceId'
+    reference:
+      table: 'DiaSource'
+      columns:
+      - 'diaSourceId'
 
   - name: fk_SSSource_SSObject
     description: Link an SSObject to its associated SSSources
     '@type': ForeignKey
     columns:
-    - '#SSSource.ssObjectId'
-    referencedColumns:
-    - '#SSObject.ssObjectId'
+    - 'ssObjectId'
+    reference:
+      table: 'SSObject'
+      columns:
+      - 'ssObjectId'
 
   - name: fk_SSSource_mpc_orbits
     description: Link an SSSource to its associated mpc_orbits
     '@type': ForeignKey
     columns:
-    - '#SSSource.designation'
-    referencedColumns:
-    - '#mpc_orbits.designation'
+    - 'designation'
+    reference:
+      table: 'mpc_orbits'
+      columns:
+      - 'designation'
 
   indexes:
   - name: idx_SSSource_ssObjectId
@@ -2010,14 +2018,14 @@ tables:
       Non-unique index on the ssObjectId column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.ssObjectId"
+    - "ssObjectId"
 
   - name: idx_SSSource_designation
     description: >
       Non-unique index on the designation column; accelerates retrieval of
       single-epoch data for SSObjects.
     columns:
-    - "#SSSource.designation"
+    - "designation"
 
 - name: mpc_orbits
   description: Table of orbital elements and related information of known (sun-orbiting and unbound) Solar
@@ -2266,17 +2274,17 @@ tables:
     description: Uniqueness of unpacked_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'
   - name: unique_mpc_orbits_designation
     description: Uniqueness of designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.designation'
+    - 'designation'
   - name: unique_mpc_orbits_packed_primary_provisional_designation
     description: Uniqueness of packed_primary_provisional_designation
     '@type': Unique
     columns:
-    - '#mpc_orbits.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
 
 - name: current_identifications
   description: All single-designations, and all identifications between designations. Always uses primary
@@ -2349,12 +2357,12 @@ tables:
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#current_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: uniq_current_identifications_packed_secondary_provisional_desig
     "@type": Unique
     description: Unique index on the packed_secondary_provisional_designation column
     columns:
-    - '#current_identifications.packed_secondary_provisional_designation'
+    - 'packed_secondary_provisional_designation'
 
 - name: numbered_identifications
   description: The numbered identification table contains all the numbered objects (minor planets, comets and
@@ -2423,19 +2431,19 @@ tables:
     "@type": Unique
     description: Unique index on the iau_name column
     columns:
-    - '#numbered_identifications.iau_name'
+    - 'iau_name'
   - name: unique_numbered_identifications_packed_primary_prov_desig
     "@type": Unique
     description: Unique index on the packed_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.packed_primary_provisional_designation'
+    - 'packed_primary_provisional_designation'
   - name: unique_numbered_identifications_permid
     "@type": Unique
     description: Unique index on the permid column
     columns:
-    - '#numbered_identifications.permid'
+    - 'permid'
   - name: uniq_numbered_identifications_unpacked_primary_prov_desig
     "@type": Unique
     description: Unique index on the unpacked_primary_provisional_designation column
     columns:
-    - '#numbered_identifications.unpacked_primary_provisional_designation'
+    - 'unpacked_primary_provisional_designation'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lsst-felis @ git+https://github.com/lsst/felis.git@main
+lsst-felis @ git+https://github.com/lsst/felis.git@tickets/DM-51789
 
 # This is here for setup in CI and using sdm_tools ticket branches 
 # easily. It is deliberately not included in the pyproject deps


### PR DESCRIPTION
## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
