### PR TITLE
u/sarahgreenstreet/correct non-grav units in apdb schema 

### DIFF
--- a/python/lsst/sdm/schemas/apdb.yaml
+++ b/python/lsst/sdm/schemas/apdb.yaml
@@ -2130,15 +2130,15 @@ tables:
     datatype: double
     ivoa:unit: m2.t-1
   - name: a1
-    description: "A1 non-grav components [m^2/ton]"
+    description: "A1 non-grav components [10^(-10)*au/day^2]"
     datatype: double
     ivoa:unit: m2.t-1
   - name: a2
-    description: "A2 non-grav components [m^2/ton]"
+    description: "A2 non-grav components [10^(-10)*au/day^2]"
     datatype: double
     ivoa:unit: m2.t-1
   - name: a3
-    description: "A3 non-grav components [m^2/ton]"
+    description: "A3 non-grav components [10^(-10)*au/day^2]"
     datatype: double
     ivoa:unit: m2.t-1
   - name: dt


### PR DESCRIPTION
Opening a small PR to correct units for comet non-grav accelerations in mpc_orbits table in apdb schema. No ticket has been made for this PR.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
