### PR TITLE
DM-55438: Add mpc_orbits table to DP2 schema

### DIFF
--- a/docs/changes/DM-55438.dr.md
+++ b/docs/changes/DM-55438.dr.md
@@ -1,0 +1,1 @@
+Added `mpc_orbits` table to DP2 schema

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2118,55 +2118,6 @@ tables:
         normalized_rms:
         earth_moid:
         fitting_datetime:
-# - name: current_identifications
-#   description: All single-designations, and all identifications between
-#     designations. Always uses primary provisional designation (even for
-#     numbered objects). Includes all comets and satellites. Replicated from the
-#     Minor Planet Center (Postgres) database. This schema will generally closely
-#     follow the schema of the upstream table, to allow end-users to rerun
-#     queries developed elsewhere on the RSP.
-#   tap:table_index: 140
-#   primaryKey: '#current_identifications.id'
-#   columnRefs:
-#     base:
-#       current_identifications:
-#         id:
-#         packed_primary_provisional_designation:
-#         packed_secondary_provisional_designation:
-#         unpacked_primary_provisional_designation:
-#         unpacked_secondary_provisional_designation:
-#         published:
-#         identifier_ids:
-#         object_type:
-#         numbered:
-#         created_at:
-#         updated_at:
-
-# - name: numbered_identifications
-  # description: The numbered identification table contains all the numbered
-  #   objects (minor planets, comets and natural satellites) with their primary
-  #   provisional designations. The table is continously updated everytime a new
-  #   object is numbered. Replicated from the Minor Planet Center (Postgres)
-  #   database. This schema will generally closely follow the schema of the
-  #   upstream table, to allow end-users to rerun queries developed elsewhere on
-  #   the RSP.
-  # tap:table_index: 150
-  # primaryKey: '#numbered_identifications.id'
-  # columnRefs:
-  #   base:
-  #     numbered_identifications:
-  #       id:
-  #       packed_primary_provisional_designation:
-  #       unpacked_primary_provisional_designation:
-  #       permid:
-  #       iau_designation:
-  #       iau_name:
-  #       numbered_publication_references:
-  #       named_publication_references:
-  #       naming_credit:
-  #       created_at:
-  #       updated_at:
-
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."
   tap:table_index: 170

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2054,71 +2054,70 @@ tables:
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects.
     columns:
     - "#SSSource.ssObjectId"
-# - name: mpc_orbits
-#   description: Table of orbital elements and related information of known
-#     (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
-#     Planet Center (Postgres) database. This schema will generally closely
-#     follow the schema of the upstream table, to allow end-users to rerun
-#     queries developed elsewhere on the RSP.
-#   tap:table_index: 130
-#   primaryKey: '#mpc_orbits.id'
-#   columnRefs:
-#     base:
-#       mpc_orbits:
-#         id:
-#         designation:
-#         packed_primary_provisional_designation:
-#         unpacked_primary_provisional_designation:
-#         mpc_orb_jsonb:
-#         created_at:
-#         updated_at:
-#         orbit_type_int:
-#         u_param:
-#         nopp:
-#         arc_length_total:
-#         arc_length_sel:
-#         nobs_total:
-#         nobs_total_sel:
-#         a:
-#         q:
-#         e:
-#         i:
-#         node:
-#         argperi:
-#         peri_time:
-#         yarkovsky:
-#         srp:
-#         a1:
-#         a2:
-#         a3:
-#         dt:
-#         mean_anomaly:
-#         period:
-#         mean_motion:
-#         a_unc:
-#         q_unc:
-#         e_unc:
-#         i_unc:
-#         node_unc:
-#         argperi_unc:
-#         peri_time_unc:
-#         yarkovsky_unc:
-#         srp_unc:
-#         a1_unc:
-#         a2_unc:
-#         a3_unc:
-#         dt_unc:
-#         mean_anomaly_unc:
-#         period_unc:
-#         mean_motion_unc:
-#         epoch_mjd:
-#         h:
-#         g:
-#         not_normalized_rms:
-#         normalized_rms:
-#         earth_moid:
-#         fitting_datetime:
-
+- name: mpc_orbits
+  description: Table of orbital elements and related information of known
+    (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
+    Planet Center (Postgres) database. This schema will generally closely
+    follow the schema of the upstream table, to allow end-users to rerun
+    queries developed elsewhere on the RSP.
+  tap:table_index: 130
+  primaryKey: '#mpc_orbits.id'
+  columnRefs:
+    base:
+      mpc_orbits:
+        id:
+        designation:
+        packed_primary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        mpc_orb_jsonb:
+        created_at:
+        updated_at:
+        orbit_type_int:
+        u_param:
+        nopp:
+        arc_length_total:
+        arc_length_sel:
+        nobs_total:
+        nobs_total_sel:
+        a:
+        q:
+        e:
+        i:
+        node:
+        argperi:
+        peri_time:
+        yarkovsky:
+        srp:
+        a1:
+        a2:
+        a3:
+        dt:
+        mean_anomaly:
+        period:
+        mean_motion:
+        a_unc:
+        q_unc:
+        e_unc:
+        i_unc:
+        node_unc:
+        argperi_unc:
+        peri_time_unc:
+        yarkovsky_unc:
+        srp_unc:
+        a1_unc:
+        a2_unc:
+        a3_unc:
+        dt_unc:
+        mean_anomaly_unc:
+        period_unc:
+        mean_motion_unc:
+        epoch_mjd:
+        h:
+        g:
+        not_normalized_rms:
+        normalized_rms:
+        earth_moid:
+        fitting_datetime:
 # - name: current_identifications
 #   description: All single-designations, and all identifications between
 #     designations. Always uses primary provisional designation (even for


### PR DESCRIPTION
This adds the `mpc_orbits` table to the DP2 schema and drops the (commented-out) `numbered_identifications` and `current_identifications` tables, which are not planned to be included.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
