### PR TITLE
DM-55504: Add time series DataLink snippets for DP2

### DIFF
--- a/datalink/columns-minimal.yaml
+++ b/datalink/columns-minimal.yaml
@@ -5,6 +5,34 @@
 # build_datalink_metadata.py, run during the build.
 
 tables:
+  dp2.Object:
+    lsst:minimal: []
+  dp2.Source:
+    lsst:minimal: []
+  dp2.ForcedSource:
+    lsst:minimal: []
+  dp2.DiaSource:
+    lsst:minimal: []
+  dp2.DiaObject:
+    lsst:minimal: []
+  dp2.ForcedSourceOnDiaObject:
+    lsst:minimal: []
+  dp2.CoaddPatches:
+    lsst:minimal: []
+  dp2.Visit:
+    lsst:minimal: []
+  dp2.VisitDetector:
+    lsst:minimal: []
+  dp2.SSObject:
+    lsst:minimal: []
+  dp2.SSSource:
+    lsst:minimal: []
+  dp2.mpc_orbits:
+    lsst:minimal: []
+  dp2.ShearObject:
+    lsst:minimal: []
+  dp2.IsolatedStarStellarMotions:
+    lsst:minimal: []
   dp1.CcdVisit:
     lsst:minimal: []
   dp1.CoaddPatches:

--- a/datalink/datalink-manifest.json
+++ b/datalink/datalink-manifest.json
@@ -5,5 +5,8 @@
     "dp02_object_to_fs_timeseries": ["dp02_dc2_catalogs_Object_objectId"],
     "dp02_diaobject_to_dias_timeseries": ["dp02_dc2_catalogs_DiaObject_diaObjectId"],
     "dp02_diaobject_to_diafs_timeseries": ["dp02_dc2_catalogs_DiaObject_diaObjectId"],
+    "dp2_object_to_fs_timeseries": ["dp2_Object_objectId"],
+    "dp2_diaobject_to_dias_timeseries": ["dp2_DiaObject_diaObjectId"],
+    "dp2_diaobject_to_diafs_timeseries": ["dp2_DiaObject_diaObjectId"],
     "obscore_links": ["ivoa_ObsCore_access_url"]
 }

--- a/datalink/datalink-manifest.json
+++ b/datalink/datalink-manifest.json
@@ -1,12 +1,12 @@
 {
+    "dp2_object_to_fs_timeseries": ["dp2_Object_objectId"],
+    "dp2_diaobject_to_dias_timeseries": ["dp2_DiaObject_diaObjectId"],
+    "dp2_diaobject_to_diafs_timeseries": ["dp2_DiaObject_diaObjectId"],
     "dp1_object_to_fs_timeseries": ["dp1_Object_objectId"],
     "dp1_diaobject_to_dias_timeseries": ["dp1_DiaObject_diaObjectId"],
     "dp1_diaobject_to_diafs_timeseries": ["dp1_DiaObject_diaObjectId"],
     "dp02_object_to_fs_timeseries": ["dp02_dc2_catalogs_Object_objectId"],
     "dp02_diaobject_to_dias_timeseries": ["dp02_dc2_catalogs_DiaObject_diaObjectId"],
     "dp02_diaobject_to_diafs_timeseries": ["dp02_dc2_catalogs_DiaObject_diaObjectId"],
-    "dp2_object_to_fs_timeseries": ["dp2_Object_objectId"],
-    "dp2_diaobject_to_dias_timeseries": ["dp2_DiaObject_diaObjectId"],
-    "dp2_diaobject_to_diafs_timeseries": ["dp2_DiaObject_diaObjectId"],
     "obscore_links": ["ivoa_ObsCore_access_url"]
 }

--- a/datalink/dp2_diaobject_to_diafs_timeseries.xml
+++ b/datalink/dp2_diaobject_to_diafs_timeseries.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+
+    <INFO name="$dp2_DiaObject_diaObjectId$" ID="$dp2_DiaObject_diaObjectId$" value="this will be dropped..." />
+
+    <RESOURCE type="meta" utype="adhoc:service">
+      <DESCRIPTION>DiaSource time series</DESCRIPTION>
+      <GROUP name="inputParams">
+        <PARAM name="id" datatype="long" ref="$dp2_DiaObject_diaObjectId$" value="" ucd="meta.id">
+          <DESCRIPTION>DiaObject ID for time series</DESCRIPTION>
+        </PARAM>
+        <PARAM name="table" datatype="char" arraysize="*" value="dp2.DiaSource">
+          <DESCRIPTION>Table containing time series data</DESCRIPTION>
+        </PARAM>
+        <PARAM name="id_column" datatype="char" arraysize="*" value="diaObjectId">
+          <DESCRIPTION>Foreign key in time series table</DESCRIPTION>
+        </PARAM>
+        <PARAM name="band" datatype="char" arraysize="*" value="all">
+          <DESCRIPTION>Filter band to retrieve (default: all)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="all"/>
+            <OPTION value="u"/>
+            <OPTION value="g"/>
+            <OPTION value="r"/>
+            <OPTION value="i"/>
+            <OPTION value="z"/>
+            <OPTION value="y"/>
+          </VALUES>
+        </PARAM>
+        <PARAM name="detail" datatype="char" arraysize="*" value="principal">
+          <DESCRIPTION>Level of detail for time series (default: principal)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="full"/>
+            <OPTION value="principal"/>
+            <OPTION value="minimal"/>
+          </VALUES>
+        </PARAM>
+      </GROUP>
+      <PARAM name="accessURL" datatype="char" arraysize="*" value="$baseUrl$/api/datalink/timeseries"/>
+      <PARAM name="standardID" datatype="char" arraysize="*" value="lsst://api.data.lsst.cloud/datalink/timeseries#v0.1"/>
+    </RESOURCE>
+</VOTABLE>

--- a/datalink/dp2_diaobject_to_diafs_timeseries.xml
+++ b/datalink/dp2_diaobject_to_diafs_timeseries.xml
@@ -4,16 +4,22 @@
     <INFO name="$dp2_DiaObject_diaObjectId$" ID="$dp2_DiaObject_diaObjectId$" value="this will be dropped..." />
 
     <RESOURCE type="meta" utype="adhoc:service">
-      <DESCRIPTION>DiaSource time series</DESCRIPTION>
+      <DESCRIPTION>ForcedSourceOnDiaObject time series</DESCRIPTION>
       <GROUP name="inputParams">
         <PARAM name="id" datatype="long" ref="$dp2_DiaObject_diaObjectId$" value="" ucd="meta.id">
           <DESCRIPTION>DiaObject ID for time series</DESCRIPTION>
         </PARAM>
-        <PARAM name="table" datatype="char" arraysize="*" value="dp2.DiaSource">
+        <PARAM name="table" datatype="char" arraysize="*" value="dp2.ForcedSourceOnDiaObject">
           <DESCRIPTION>Table containing time series data</DESCRIPTION>
         </PARAM>
         <PARAM name="id_column" datatype="char" arraysize="*" value="diaObjectId">
           <DESCRIPTION>Foreign key in time series table</DESCRIPTION>
+        </PARAM>
+        <PARAM name="join_time_column" datatype="char" arraysize="*" value="dp2.VisitDetector.expMidptMJD">
+          <DESCRIPTION>Foreign column spec for time retrieval</DESCRIPTION>
+        </PARAM>
+        <PARAM name="join_style" datatype="char" arraysize="*" value="visit_detector">
+          <DESCRIPTION>Single-column (ccdVisit) or composite-key (visit_detector) JOIN</DESCRIPTION>
         </PARAM>
         <PARAM name="band" datatype="char" arraysize="*" value="all">
           <DESCRIPTION>Filter band to retrieve (default: all)</DESCRIPTION>

--- a/datalink/dp2_diaobject_to_dias_timeseries.xml
+++ b/datalink/dp2_diaobject_to_dias_timeseries.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+
+    <INFO name="$dp2_DiaObject_diaObjectId$" ID="$dp2_DiaObject_diaObjectId$" value="this will be dropped..." />
+
+    <RESOURCE type="meta" utype="adhoc:service">
+      <DESCRIPTION>DiaSource time series</DESCRIPTION>
+      <GROUP name="inputParams">
+        <PARAM name="id" datatype="long" ref="$dp2_DiaObject_diaObjectId$" value="" ucd="meta.id">
+          <DESCRIPTION>DiaObject ID for time series</DESCRIPTION>
+        </PARAM>
+        <PARAM name="table" datatype="char" arraysize="*" value="dp2.DiaSource">
+          <DESCRIPTION>Table containing time series data</DESCRIPTION>
+        </PARAM>
+        <PARAM name="id_column" datatype="char" arraysize="*" value="diaObjectId">
+          <DESCRIPTION>Foreign key in time series table</DESCRIPTION>
+        </PARAM>
+        <PARAM name="band" datatype="char" arraysize="*" value="all">
+          <DESCRIPTION>Filter band to retrieve (default: all)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="all"/>
+            <OPTION value="u"/>
+            <OPTION value="g"/>
+            <OPTION value="r"/>
+            <OPTION value="i"/>
+            <OPTION value="z"/>
+            <OPTION value="y"/>
+          </VALUES>
+        </PARAM>
+        <PARAM name="detail" datatype="char" arraysize="*" value="principal">
+          <DESCRIPTION>Level of detail for time series (default: principal)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="full"/>
+            <OPTION value="principal"/>
+            <OPTION value="minimal"/>
+          </VALUES>
+        </PARAM>
+      </GROUP>
+      <PARAM name="accessURL" datatype="char" arraysize="*" value="$baseUrl$/api/datalink/timeseries"/>
+      <PARAM name="standardID" datatype="char" arraysize="*" value="lsst://api.data.lsst.cloud/datalink/timeseries#v0.1"/>
+    </RESOURCE>
+</VOTABLE>

--- a/datalink/dp2_object_to_fs_timeseries.xml
+++ b/datalink/dp2_object_to_fs_timeseries.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2">
+
+    <INFO name="$dp2_Object_objectId$" ID="$dp2_Object_objectId$" value="this will be dropped..." />
+
+    <RESOURCE type="meta" utype="adhoc:service">
+      <DESCRIPTION>ForcedSource time series</DESCRIPTION>
+      <GROUP name="inputParams">
+        <PARAM name="id" datatype="long" ref="$dp2_Object_objectId$" value="" ucd="meta.id">
+          <DESCRIPTION>Object ID for time series</DESCRIPTION>
+        </PARAM>
+        <PARAM name="table" datatype="char" arraysize="*" value="dp2.ForcedSource">
+          <DESCRIPTION>Table containing time series data</DESCRIPTION>
+        </PARAM>
+        <PARAM name="id_column" datatype="char" arraysize="*" value="objectId">
+          <DESCRIPTION>Foreign key in time series table</DESCRIPTION>
+        </PARAM>
+        <PARAM name="join_time_column" datatype="char" arraysize="*" value="dp2.VisitDetector.expMidptMJD">
+          <DESCRIPTION>Foreign column spec for time retrieval</DESCRIPTION>
+        </PARAM>
+        <PARAM name="join_style" datatype="char" arraysize="*" value="visit_detector">
+          <DESCRIPTION>Single-column (ccdVisit) or composite-key (visit_detector) JOIN</DESCRIPTION>
+        </PARAM>
+        <PARAM name="band" datatype="char" arraysize="*" value="all">
+          <DESCRIPTION>Filter band to retrieve (default: all)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="all"/>
+            <OPTION value="u"/>
+            <OPTION value="g"/>
+            <OPTION value="r"/>
+            <OPTION value="i"/>
+            <OPTION value="z"/>
+            <OPTION value="y"/>
+          </VALUES>
+        </PARAM>
+        <PARAM name="detail" datatype="char" arraysize="*" value="principal">
+          <DESCRIPTION>Level of detail for time series (default: principal)</DESCRIPTION>
+          <VALUES>
+            <OPTION value="full"/>
+            <OPTION value="principal"/>
+            <OPTION value="minimal"/>
+          </VALUES>
+        </PARAM>
+      </GROUP>
+      <PARAM name="accessURL" datatype="char" arraysize="*" value="$baseUrl$/api/datalink/timeseries"/>
+      <PARAM name="standardID" datatype="char" arraysize="*" value="lsst://api.data.lsst.cloud/datalink/timeseries#v0.1"/>
+    </RESOURCE>
+</VOTABLE>

--- a/docs/changes/DM-55504.dr.md
+++ b/docs/changes/DM-55504.dr.md
@@ -1,0 +1,1 @@
+Added light curve DataLink snippets for DP2


### PR DESCRIPTION
This adds the DataLink XML snippets for the DP2 light curve (time series) service.

This is deployed and seems to be functioning on the `data-int` RSP environment.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
