### PR TITLE
DM-55610: Set column ref index increment when generating YAML for the browser

### DIFF
--- a/docs/changes/DM-55610.misc.md
+++ b/docs/changes/DM-55610.misc.md
@@ -1,0 +1,1 @@
+Added `--column-ref-index-index-increment 10` to script which generates the YAML for the browser

--- a/docs/changes/DM-55610.misc.md
+++ b/docs/changes/DM-55610.misc.md
@@ -1,1 +1,2 @@
-Added `--column-ref-index-index-increment 10` to script which generates the YAML for the browser
+Added `--column-ref-index-index-increment 10` to script which generates the YAML for the browser; this ensures that the schema browser can replicate the
+column ordering in the deployed schema.

--- a/scripts/dereference-yaml-for-browser.sh
+++ b/scripts/dereference-yaml-for-browser.sh
@@ -5,5 +5,7 @@ set -euo pipefail
 mkdir -p browser/yml
 for schema in yml/*.yaml; do
     base=$(basename "$schema")
-    felis --log-level ERROR dump "$schema" "browser/yml/$base" --dereference-resources --strip-ids
+    felis --log-level ERROR --column-ref-index-increment 10 dump \
+        "$schema" "browser/yml/$base" \
+        --dereference-resources --strip-ids
 done


### PR DESCRIPTION
https://github.com/lsst/felis/pull/192 must be merged before this.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
