### PR TITLE
DM-55637: Reorder ObsTAP columns for DP1/DP2 clarity

### DIFF
--- a/docs/changes/DM-55637.dr.md
+++ b/docs/changes/DM-55637.dr.md
@@ -1,0 +1,2 @@
+Reordered ObsTAP columns to make DP1/DP2 distinction more visible
+* Also moved some standard columns up in the order for clarity

--- a/python/lsst/sdm/schemas/ivoa_obscore.yaml
+++ b/python/lsst/sdm/schemas/ivoa_obscore.yaml
@@ -80,7 +80,7 @@ tables:
     length: 128
     nullable: false
     ivoa:ucd: meta.id
-    tap:column_index: 190
+    tap:column_index: 5
     tap:principal: 1
     tap:std: 1
   - name: obs_publisher_did
@@ -116,7 +116,7 @@ tables:
     datatype: double
     ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
-    tap:column_index: 150
+    tap:column_index: 42
     tap:principal: 1
     tap:std: 1
   - name: s_dec
@@ -125,7 +125,7 @@ tables:
     datatype: double
     ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
-    tap:column_index: 160
+    tap:column_index: 44
     tap:principal: 1
     tap:std: 1
   - name: s_fov
@@ -182,7 +182,7 @@ tables:
     datatype: double
     ivoa:ucd: time.start;obs.exposure
     ivoa:unit: d
-    tap:column_index: 130
+    tap:column_index: 46
     tap:principal: 1
     tap:std: 1
   - name: t_max
@@ -191,7 +191,7 @@ tables:
     datatype: double
     ivoa:ucd: time.end;obs.exposure
     ivoa:unit: d
-    tap:column_index: 140
+    tap:column_index: 48
     tap:principal: 1
     tap:std: 1
   - name: t_exptime
@@ -265,7 +265,7 @@ tables:
     datatype: string
     length: 128
     ivoa:ucd: meta.id;instr
-    tap:column_index: 220
+    tap:column_index: 115
     tap:principal: 1
     tap:std: 1
   - name: lsst_visit

--- a/python/lsst/sdm/schemas/ivoa_obscore.yaml
+++ b/python/lsst/sdm/schemas/ivoa_obscore.yaml
@@ -182,7 +182,7 @@ tables:
     datatype: double
     ivoa:ucd: time.start;obs.exposure
     ivoa:unit: d
-    tap:column_index: 46
+    tap:column_index: 117
     tap:principal: 1
     tap:std: 1
   - name: t_max
@@ -191,7 +191,7 @@ tables:
     datatype: double
     ivoa:ucd: time.end;obs.exposure
     ivoa:unit: d
-    tap:column_index: 48
+    tap:column_index: 118
     tap:principal: 1
     tap:std: 1
   - name: t_exptime


### PR DESCRIPTION
Also move some standard columns up for clarity

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
