### PR TITLE
DM-55642: Revert PPDB schema to 9.1.1 version of APDB

### DIFF
--- a/docs/changes/DM-55642.ap.md
+++ b/docs/changes/DM-55642.ap.md
@@ -1,0 +1,1 @@
+Reverted the PPDB schema to version 9.1.1 of the APDB

--- a/python/lsst/sdm/schemas/ppdb.yaml
+++ b/python/lsst/sdm/schemas/ppdb.yaml
@@ -4,7 +4,7 @@ description: |
   The Prompt Products Database stores results from nightly and daily processing
   that detects time-variable astrophysical phenomena, including
   difference-image detections, associated objects, and Solar System objects.
-version: "10.0.0"
+version: "9.1.1"
 resources:
   apdb:
     uri: "apdb.yaml"
@@ -114,7 +114,7 @@ tables:
         parentDiaSourceId:
         ssObjectReassocTimeMjdTai:
         midpointMjdTai:
-        exposureTime:
+        # exposureTime:
         ra:
         raErr:
         dec:
@@ -139,7 +139,7 @@ tables:
         psfFlux_flag:
         psfFlux_flag_edge:
         psfFlux_flag_noGoodPixels:
-        trailAlgorithm:
+        # trailAlgorithm:
         trailFlux:
         trailFluxErr:
         trailRa:
@@ -152,7 +152,7 @@ tables:
         trailAngleErr:
         trailChi2:
         trailNdata:
-        trail_flag:
+        # trail_flag:
         trail_flag_edge:
         dipoleMeanFlux:
         dipoleMeanFluxErr:
@@ -181,7 +181,7 @@ tables:
         shape_flag_parent_source:
         extendedness:
         reliability:
-        reliabilityVersion:
+        # reliabilityVersion:
         band:
         isDipole:
         dipoleFitAttempted:


### PR DESCRIPTION
Current version of the PPDB is not compatible with version 10 of the APDB and should be reverted back to 9.1.1, temporarily.

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [x] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
