### PR TITLE
DM-55698: Backports to v30 for EDP2

### DIFF
--- a/docs/changes/DM-55392.dr.md
+++ b/docs/changes/DM-55392.dr.md
@@ -1,0 +1,1 @@
+Add `CoaddPatches` table to DP2 schema (`dp2.yaml`).

--- a/docs/changes/DM-55438.dr.md
+++ b/docs/changes/DM-55438.dr.md
@@ -1,0 +1,1 @@
+Added `mpc_orbits` table to DP2 schema

--- a/docs/changes/DM-55449.sci.md
+++ b/docs/changes/DM-55449.sci.md
@@ -1,1 +1,5 @@
-Fixed IsolatedStarStellarMotions data types.
+IsolatedStarStellarMotions changes:
+* Fixed data types.
+* Updated some UCDs.
+* Removed off-diagonal covariance terms from the `principal` subset.
+* Documented Gaia DR3 as the reference dataset.

--- a/docs/changes/DM-55449.sci.md
+++ b/docs/changes/DM-55449.sci.md
@@ -1,0 +1,1 @@
+Fixed IsolatedStarStellarMotions data types.

--- a/docs/changes/DM-55508.dr.md
+++ b/docs/changes/DM-55508.dr.md
@@ -1,0 +1,1 @@
+Hid redundant or unnecessary coord_ra, coord_dec columns

--- a/docs/changes/DM-55597.dr.md
+++ b/docs/changes/DM-55597.dr.md
@@ -1,0 +1,3 @@
+* Restored current_identifications and numbered_identifications SSO tables,
+  less array-valued columns
+* Reordered tables for final EDP2 presentation sequence

--- a/docs/changes/DM-55607.dr.md
+++ b/docs/changes/DM-55607.dr.md
@@ -1,0 +1,3 @@
+DP2 Object column presentation order:
+* Restored ugrizy column order throughout
+* Moved a small number of general columns to the top

--- a/docs/changes/DM-55637.dr.md
+++ b/docs/changes/DM-55637.dr.md
@@ -1,0 +1,2 @@
+Reordered ObsTAP columns to make DP1/DP2 distinction more visible
+* Also moved some standard columns up in the order for clarity

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2118,55 +2118,6 @@ tables:
         normalized_rms:
         earth_moid:
         fitting_datetime:
-# - name: current_identifications
-#   description: All single-designations, and all identifications between
-#     designations. Always uses primary provisional designation (even for
-#     numbered objects). Includes all comets and satellites. Replicated from the
-#     Minor Planet Center (Postgres) database. This schema will generally closely
-#     follow the schema of the upstream table, to allow end-users to rerun
-#     queries developed elsewhere on the RSP.
-#   tap:table_index: 140
-#   primaryKey: '#current_identifications.id'
-#   columnRefs:
-#     base:
-#       current_identifications:
-#         id:
-#         packed_primary_provisional_designation:
-#         packed_secondary_provisional_designation:
-#         unpacked_primary_provisional_designation:
-#         unpacked_secondary_provisional_designation:
-#         published:
-#         identifier_ids:
-#         object_type:
-#         numbered:
-#         created_at:
-#         updated_at:
-
-# - name: numbered_identifications
-  # description: The numbered identification table contains all the numbered
-  #   objects (minor planets, comets and natural satellites) with their primary
-  #   provisional designations. The table is continously updated everytime a new
-  #   object is numbered. Replicated from the Minor Planet Center (Postgres)
-  #   database. This schema will generally closely follow the schema of the
-  #   upstream table, to allow end-users to rerun queries developed elsewhere on
-  #   the RSP.
-  # tap:table_index: 150
-  # primaryKey: '#numbered_identifications.id'
-  # columnRefs:
-  #   base:
-  #     numbered_identifications:
-  #       id:
-  #       packed_primary_provisional_designation:
-  #       unpacked_primary_provisional_designation:
-  #       permid:
-  #       iau_designation:
-  #       iau_name:
-  #       numbered_publication_references:
-  #       named_publication_references:
-  #       naming_credit:
-  #       created_at:
-  #       updated_at:
-
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."
   tap:table_index: 170

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2192,7 +2192,7 @@ tables:
 - name: IsolatedStarStellarMotions
   description: Position, proper motion, and parallax for isolated stars, fit using
     associated source measurements, with positions for associated reference objects
-    if available.
+    from Gaia DR3 where available.
   primaryKey: '#IsolatedStarStellarMotions.isolated_star_id'
   tap:table_index: 180
   columnRefs:

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1457,8 +1457,6 @@ tables:
       ForcedSource:
         objectId:
         parentObjectId:
-        coord_ra:
-        coord_dec:
         visit:
         detector:
         band:
@@ -1721,8 +1719,6 @@ tables:
       ForcedSourceOnDiaObject:
         diaObjectId:
         parentObjectId:
-        coord_ra:
-        coord_dec:
         visit:
         detector:
         band:

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1276,8 +1276,6 @@ tables:
   columnRefs:
     base:
       Source:
-        coord_ra:
-        coord_dec:
         parentSourceId:
         x:
         y:

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2110,6 +2110,55 @@ tables:
         normalized_rms:
         earth_moid:
         fitting_datetime:
+# - name: current_identifications
+#   description: All single-designations, and all identifications between
+#     designations. Always uses primary provisional designation (even for
+#     numbered objects). Includes all comets and satellites. Replicated from the
+#     Minor Planet Center (Postgres) database. This schema will generally closely
+#     follow the schema of the upstream table, to allow end-users to rerun
+#     queries developed elsewhere on the RSP.
+#   tap:table_index: 140
+#   primaryKey: '#current_identifications.id'
+#   columnRefs:
+#     base:
+#       current_identifications:
+#         id:
+#         packed_primary_provisional_designation:
+#         packed_secondary_provisional_designation:
+#         unpacked_primary_provisional_designation:
+#         unpacked_secondary_provisional_designation:
+#         published:
+#         identifier_ids:
+#         object_type:
+#         numbered:
+#         created_at:
+#         updated_at:
+
+# - name: numbered_identifications
+  # description: The numbered identification table contains all the numbered
+  #   objects (minor planets, comets and natural satellites) with their primary
+  #   provisional designations. The table is continously updated everytime a new
+  #   object is numbered. Replicated from the Minor Planet Center (Postgres)
+  #   database. This schema will generally closely follow the schema of the
+  #   upstream table, to allow end-users to rerun queries developed elsewhere on
+  #   the RSP.
+  # tap:table_index: 150
+  # primaryKey: '#numbered_identifications.id'
+  # columnRefs:
+  #   base:
+  #     numbered_identifications:
+  #       id:
+  #       packed_primary_provisional_designation:
+  #       unpacked_primary_provisional_designation:
+  #       permid:
+  #       iau_designation:
+  #       iau_name:
+  #       numbered_publication_references:
+  #       named_publication_references:
+  #       naming_credit:
+  #       created_at:
+  #       updated_at:
+
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."
   tap:table_index: 170

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -15,199 +15,19 @@ tables:
   columnRefs:
     base:
       Object:
+        objectId:
         tract:
         patch:
-        z_ra:
-        z_dec:
-        z_raErr:
-        z_decErr:
-        z_ra_dec_Cov:
-        z_psfFlux:
-        z_psfFluxErr:
-        z_psfMag:
-        z_psfMagErr:
-        z_free_psfFlux:
-        z_free_psfFluxErr:
-        z_free_psfFlux_flag:
-        z_gaapPsfFlux:
-        z_gaapPsfFluxErr:
-        z_gaap0p7Flux:
-        z_gaap0p7FluxErr:
-        z_gaap1p0Flux:
-        z_gaap1p0FluxErr:
-        z_ixx:
-        z_iyy:
-        z_ixy:
-        z_i_flag:
-        z_ixxPSF:
-        z_iyyPSF:
-        z_ixyPSF:
-        z_iPSF_flag:
-        z_kronRad:
-        z_kronFlux:
-        z_kronFluxErr:
-        z_ap03Flux:
-        z_ap03FluxErr:
-        z_ap03Flux_flag:
-        z_ap06Flux:
-        z_ap06FluxErr:
-        z_ap06Flux_flag:
-        z_ap09Flux:
-        z_ap09FluxErr:
-        z_ap09Flux_flag:
-        z_ap12Flux:
-        z_ap12FluxErr:
-        z_ap12Flux_flag:
-        z_ap17Flux:
-        z_ap17FluxErr:
-        z_ap17Flux_flag:
-        z_ap25Flux:
-        z_ap25FluxErr:
-        z_ap25Flux_flag:
-        z_ap35Flux:
-        z_ap35FluxErr:
-        z_ap35Flux_flag:
-        z_ap50Flux:
-        z_ap50FluxErr:
-        z_ap50Flux_flag:
-        z_ap70Flux:
-        z_ap70FluxErr:
-        z_ap70Flux_flag:
-        z_extendedness:
-        z_sizeExtendedness:
-        z_model_extendedness:
-        z_blendedness:
-        z_cModelFlux:
-        z_cModelFluxErr:
-        z_cModelMag:
-        z_cModelMagErr:
-        z_cModelFlux_inner:
-        z_cModel_fracDev:
-        z_free_cModelFlux:
-        z_free_cModelFluxErr:
-        z_free_cModelFlux_inner:
-        z_free_cModel_fracDev:
-        z_free_cModelFlux_flag:
-        z_free_cModel_devFlux:
-        z_free_cModel_devFluxErr:
-        z_free_cModel_expFlux:
-        z_free_cModel_expFluxErr:
-        z_cModel_dev_reff_major:
-        z_cModel_dev_reff_minor:
-        z_cModel_dev_theta:
-        z_cModel_exp_reff_major:
-        z_cModel_exp_reff_minor:
-        z_cModel_exp_theta:
-        z_cModel_chi2:
-        z_cModel_devFlux:
-        z_cModel_devFluxErr:
-        z_cModel_expFlux:
-        z_cModel_expFluxErr:
-        z_moments_g1:
-        z_moments_g2:
-        z_moments_trace:
-        z_moments_flag:
-        z_moments_psf_g1:
-        z_moments_psf_g2:
-        z_moments_psf_trace:
-        z_moments_psf_flag:
-        z_moments_psf_debiased_g1:
-        z_moments_psf_debiased_g2:
-        z_moments_psf_debiased_trace:
-        z_moments_psf_debiased_flag:
-        z_hsmShapeRegauss_e1:
-        z_hsmShapeRegauss_e2:
-        z_hsmShapeRegauss_sigma:
-        z_hsmShapeRegauss_flag:
-        z_hsm_moments_30:
-        z_hsm_momentsPsf_30:
-        z_hsm_moments_21:
-        z_hsm_momentsPsf_21:
-        z_hsm_moments_12:
-        z_hsm_momentsPsf_12:
-        z_hsm_moments_03:
-        z_hsm_momentsPsf_03:
-        z_hsm_moments_40:
-        z_hsm_momentsPsf_40:
-        z_hsm_moments_31:
-        z_hsm_momentsPsf_31:
-        z_hsm_moments_22:
-        z_hsm_momentsPsf_22:
-        z_hsm_moments_13:
-        z_hsm_momentsPsf_13:
-        z_hsm_moments_04:
-        z_hsm_momentsPsf_04:
-        z_hsm_moments_flag:
-        z_hsm_momentsPsf_flag:
-        z_inputCount:
-        z_deblend_dataCoverage:
-        z_deblend_blendedness:
-        z_deblend_fluxOverlap:
-        z_deblend_fluxOverlapFraction:
-        z_deblend_zeroFlux:
-        z_psfModel_TwoGaussian_gauss1_sigma_x:
-        z_psfModel_TwoGaussian_gauss1_sigma_y:
-        z_psfModel_TwoGaussian_gauss1_rho:
-        z_psfModel_TwoGaussian_gauss1_fluxfrac:
-        z_psfModel_TwoGaussian_gauss2_sigma_x:
-        z_psfModel_TwoGaussian_gauss2_sigma_y:
-        z_psfModel_TwoGaussian_gauss2_rho:
-        z_psfModel_TwoGaussian_n_iter:
-        z_psfModel_TwoGaussian_chi2_reduced:
-        z_psfModel_TwoGaussian_unknown_flag:
-        z_psfModel_TwoGaussian_no_inputs_flag:
-        z_inputCount_flag:
-        z_inputCount_flag_noInputs:
-        z_psfFlux_area:
-        z_psfFlux_flag:
-        z_psfFlux_flag_apCorr:
-        z_psfFlux_flag_edge:
-        z_psfFlux_flag_noGoodPixels:
-        z_cModel_flag:
-        z_cModel_flag_apCorr:
-        z_gaapFlux_flag:
-        z_gaapFlux_flag_edge:
-        z_blendedness_flag:
-        z_pixelFlags_bad:
-        z_pixelFlags_clipped:
-        z_pixelFlags_clippedCenter:
-        z_pixelFlags_cr:
-        z_pixelFlags_crCenter:
-        z_pixelFlags_edge:
-        z_pixelFlags_inexact_psf:
-        z_pixelFlags_inexact_psfCenter:
-        z_pixelFlags_interpolated:
-        z_pixelFlags_interpolatedCenter:
-        z_pixelFlags_nodata:
-        z_pixelFlags_offimage:
-        z_pixelFlags_saturated:
-        z_pixelFlags_saturatedCenter:
-        z_pixelFlags_sensor_edge:
-        z_pixelFlags_sensor_edgeCenter:
-        z_pixelFlags_suspect:
-        z_pixelFlags_suspectCenter:
-        z_extendedness_flag:
-        z_sizeExtendedness_flag:
-        z_invalidPsfFlag:
-        z_calib_astrometry_used:
-        z_calib_photometry_used:
-        z_calib_psf_candidate:
-        z_calib_psf_reserved:
-        z_calib_psf_used:
-        z_apFlux_flag:
-        z_apFlux_flag_apertureTruncated:
-        z_apFlux_flag_sincCoeffsTruncated:
-        z_centroid_flag:
-        z_kronFlux_flag:
-        z_kronFlux_flag_bad_radius:
-        z_kronFlux_flag_bad_shape:
-        z_kronFlux_flag_bad_shape_no_psf:
-        z_kronFlux_flag_edge:
-        z_kronFlux_flag_no_fallback_radius:
-        z_kronFlux_flag_no_minimum_radius:
-        z_kronFlux_flag_small_radius:
-        z_kronFlux_flag_used_minimum_radius:
-        z_kronFlux_flag_used_psf_radius:
+        coord_ra:
+        coord_dec:
+        coord_raErr:
+        coord_decErr:
+        coord_ra_dec_Cov:
+        coord_flag:
+        refBand:
+        refExtendedness:
+        refSizeExtendedness:
+        griz_model_extendedness:
         u_ra:
         u_dec:
         u_raErr:
@@ -469,7 +289,6 @@ tables:
         g_extendedness:
         g_sizeExtendedness:
         g_model_extendedness:
-        griz_model_extendedness:
         g_blendedness:
         g_cModelFlux:
         g_cModelFluxErr:
@@ -973,6 +792,197 @@ tables:
         i_kronFlux_flag_small_radius:
         i_kronFlux_flag_used_minimum_radius:
         i_kronFlux_flag_used_psf_radius:
+        z_ra:
+        z_dec:
+        z_raErr:
+        z_decErr:
+        z_ra_dec_Cov:
+        z_psfFlux:
+        z_psfFluxErr:
+        z_psfMag:
+        z_psfMagErr:
+        z_free_psfFlux:
+        z_free_psfFluxErr:
+        z_free_psfFlux_flag:
+        z_gaapPsfFlux:
+        z_gaapPsfFluxErr:
+        z_gaap0p7Flux:
+        z_gaap0p7FluxErr:
+        z_gaap1p0Flux:
+        z_gaap1p0FluxErr:
+        z_ixx:
+        z_iyy:
+        z_ixy:
+        z_i_flag:
+        z_ixxPSF:
+        z_iyyPSF:
+        z_ixyPSF:
+        z_iPSF_flag:
+        z_kronRad:
+        z_kronFlux:
+        z_kronFluxErr:
+        z_ap03Flux:
+        z_ap03FluxErr:
+        z_ap03Flux_flag:
+        z_ap06Flux:
+        z_ap06FluxErr:
+        z_ap06Flux_flag:
+        z_ap09Flux:
+        z_ap09FluxErr:
+        z_ap09Flux_flag:
+        z_ap12Flux:
+        z_ap12FluxErr:
+        z_ap12Flux_flag:
+        z_ap17Flux:
+        z_ap17FluxErr:
+        z_ap17Flux_flag:
+        z_ap25Flux:
+        z_ap25FluxErr:
+        z_ap25Flux_flag:
+        z_ap35Flux:
+        z_ap35FluxErr:
+        z_ap35Flux_flag:
+        z_ap50Flux:
+        z_ap50FluxErr:
+        z_ap50Flux_flag:
+        z_ap70Flux:
+        z_ap70FluxErr:
+        z_ap70Flux_flag:
+        z_extendedness:
+        z_sizeExtendedness:
+        z_model_extendedness:
+        z_blendedness:
+        z_cModelFlux:
+        z_cModelFluxErr:
+        z_cModelMag:
+        z_cModelMagErr:
+        z_cModelFlux_inner:
+        z_cModel_fracDev:
+        z_free_cModelFlux:
+        z_free_cModelFluxErr:
+        z_free_cModelFlux_inner:
+        z_free_cModel_fracDev:
+        z_free_cModelFlux_flag:
+        z_free_cModel_devFlux:
+        z_free_cModel_devFluxErr:
+        z_free_cModel_expFlux:
+        z_free_cModel_expFluxErr:
+        z_cModel_dev_reff_major:
+        z_cModel_dev_reff_minor:
+        z_cModel_dev_theta:
+        z_cModel_exp_reff_major:
+        z_cModel_exp_reff_minor:
+        z_cModel_exp_theta:
+        z_cModel_chi2:
+        z_cModel_devFlux:
+        z_cModel_devFluxErr:
+        z_cModel_expFlux:
+        z_cModel_expFluxErr:
+        z_moments_g1:
+        z_moments_g2:
+        z_moments_trace:
+        z_moments_flag:
+        z_moments_psf_g1:
+        z_moments_psf_g2:
+        z_moments_psf_trace:
+        z_moments_psf_flag:
+        z_moments_psf_debiased_g1:
+        z_moments_psf_debiased_g2:
+        z_moments_psf_debiased_trace:
+        z_moments_psf_debiased_flag:
+        z_hsmShapeRegauss_e1:
+        z_hsmShapeRegauss_e2:
+        z_hsmShapeRegauss_sigma:
+        z_hsmShapeRegauss_flag:
+        z_hsm_moments_30:
+        z_hsm_momentsPsf_30:
+        z_hsm_moments_21:
+        z_hsm_momentsPsf_21:
+        z_hsm_moments_12:
+        z_hsm_momentsPsf_12:
+        z_hsm_moments_03:
+        z_hsm_momentsPsf_03:
+        z_hsm_moments_40:
+        z_hsm_momentsPsf_40:
+        z_hsm_moments_31:
+        z_hsm_momentsPsf_31:
+        z_hsm_moments_22:
+        z_hsm_momentsPsf_22:
+        z_hsm_moments_13:
+        z_hsm_momentsPsf_13:
+        z_hsm_moments_04:
+        z_hsm_momentsPsf_04:
+        z_hsm_moments_flag:
+        z_hsm_momentsPsf_flag:
+        z_inputCount:
+        z_deblend_dataCoverage:
+        z_deblend_blendedness:
+        z_deblend_fluxOverlap:
+        z_deblend_fluxOverlapFraction:
+        z_deblend_zeroFlux:
+        z_psfModel_TwoGaussian_gauss1_sigma_x:
+        z_psfModel_TwoGaussian_gauss1_sigma_y:
+        z_psfModel_TwoGaussian_gauss1_rho:
+        z_psfModel_TwoGaussian_gauss1_fluxfrac:
+        z_psfModel_TwoGaussian_gauss2_sigma_x:
+        z_psfModel_TwoGaussian_gauss2_sigma_y:
+        z_psfModel_TwoGaussian_gauss2_rho:
+        z_psfModel_TwoGaussian_n_iter:
+        z_psfModel_TwoGaussian_chi2_reduced:
+        z_psfModel_TwoGaussian_unknown_flag:
+        z_psfModel_TwoGaussian_no_inputs_flag:
+        z_inputCount_flag:
+        z_inputCount_flag_noInputs:
+        z_psfFlux_area:
+        z_psfFlux_flag:
+        z_psfFlux_flag_apCorr:
+        z_psfFlux_flag_edge:
+        z_psfFlux_flag_noGoodPixels:
+        z_cModel_flag:
+        z_cModel_flag_apCorr:
+        z_gaapFlux_flag:
+        z_gaapFlux_flag_edge:
+        z_blendedness_flag:
+        z_pixelFlags_bad:
+        z_pixelFlags_clipped:
+        z_pixelFlags_clippedCenter:
+        z_pixelFlags_cr:
+        z_pixelFlags_crCenter:
+        z_pixelFlags_edge:
+        z_pixelFlags_inexact_psf:
+        z_pixelFlags_inexact_psfCenter:
+        z_pixelFlags_interpolated:
+        z_pixelFlags_interpolatedCenter:
+        z_pixelFlags_nodata:
+        z_pixelFlags_offimage:
+        z_pixelFlags_saturated:
+        z_pixelFlags_saturatedCenter:
+        z_pixelFlags_sensor_edge:
+        z_pixelFlags_sensor_edgeCenter:
+        z_pixelFlags_suspect:
+        z_pixelFlags_suspectCenter:
+        z_extendedness_flag:
+        z_sizeExtendedness_flag:
+        z_invalidPsfFlag:
+        z_calib_astrometry_used:
+        z_calib_photometry_used:
+        z_calib_psf_candidate:
+        z_calib_psf_reserved:
+        z_calib_psf_used:
+        z_apFlux_flag:
+        z_apFlux_flag_apertureTruncated:
+        z_apFlux_flag_sincCoeffsTruncated:
+        z_centroid_flag:
+        z_kronFlux_flag:
+        z_kronFlux_flag_bad_radius:
+        z_kronFlux_flag_bad_shape:
+        z_kronFlux_flag_bad_shape_no_psf:
+        z_kronFlux_flag_edge:
+        z_kronFlux_flag_no_fallback_radius:
+        z_kronFlux_flag_no_minimum_radius:
+        z_kronFlux_flag_small_radius:
+        z_kronFlux_flag_used_minimum_radius:
+        z_kronFlux_flag_used_psf_radius:
         y_ra:
         y_dec:
         y_raErr:
@@ -1164,22 +1174,13 @@ tables:
         y_kronFlux_flag_small_radius:
         y_kronFlux_flag_used_minimum_radius:
         y_kronFlux_flag_used_psf_radius:
-        g_epoch:
-        i_epoch:
-        r_epoch:
         u_epoch:
-        y_epoch:
+        g_epoch:
+        r_epoch:
+        i_epoch:
         z_epoch:
+        y_epoch:
         parentObjectId:
-        coord_ra:
-        coord_dec:
-        coord_raErr:
-        coord_decErr:
-        coord_ra_dec_Cov:
-        coord_flag:
-        refBand:
-        refExtendedness:
-        refSizeExtendedness:
         footprintArea:
         ebv:
         shape_xx:
@@ -1210,18 +1211,18 @@ tables:
         exponential_reff_major:
         exponential_reff_minor:
         exponential_theta:
-        g_exponentialFlux:
-        g_exponentialFluxErr:
-        i_exponentialFlux:
-        i_exponentialFluxErr:
-        r_exponentialFlux:
-        r_exponentialFluxErr:
         u_exponentialFlux:
         u_exponentialFluxErr:
-        y_exponentialFlux:
-        y_exponentialFluxErr:
+        g_exponentialFlux:
+        g_exponentialFluxErr:
+        r_exponentialFlux:
+        r_exponentialFluxErr:
+        i_exponentialFlux:
+        i_exponentialFluxErr:
         z_exponentialFlux:
         z_exponentialFluxErr:
+        y_exponentialFlux:
+        y_exponentialFluxErr:
         exponential_n_eval_jac:
         exponential_n_iter:
         exponential_chi2_reduced:
@@ -1243,18 +1244,18 @@ tables:
         sersic_reff_major:
         sersic_reff_minor:
         sersic_theta:
-        g_sersicFlux:
-        g_sersicFluxErr:
-        i_sersicFlux:
-        i_sersicFluxErr:
-        r_sersicFlux:
-        r_sersicFluxErr:
         u_sersicFlux:
         u_sersicFluxErr:
-        y_sersicFlux:
-        y_sersicFluxErr:
+        g_sersicFlux:
+        g_sersicFluxErr:
+        r_sersicFlux:
+        r_sersicFluxErr:
+        i_sersicFlux:
+        i_sersicFluxErr:
         z_sersicFlux:
         z_sersicFluxErr:
+        y_sersicFlux:
+        y_sersicFluxErr:
         sersic_index:
         sersic_indexErr:
         sersic_n_eval_jac:
@@ -1262,7 +1263,6 @@ tables:
         sersic_chi2_reduced:
         sersic_unknown_flag:
         sersic_no_data_flag:
-        objectId:
   indexes:
   - name: idx_Object_objectId
     description: Unique index on objectId column.

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1512,8 +1512,6 @@ tables:
         ssObjectId:
         parentDiaSourceId:
         midpointMjdTai:
-        coord_dec:
-        coord_ra:
         ra:
         dec:
         raErr:

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1768,18 +1768,18 @@ tables:
     columns:
     - "#ForcedSourceOnDiaObject.diaObjectId"
 
-# - name: CoaddPatches
-#   description: "Static information about the subset of tracts and patches from the standard
-#   LSST skymap that apply to coadds in these catalogs"
-#   tap:table_index: 70
-#   columnRefs:
-#     base:
-#       CoaddPatches:
-#         lsst_tract:
-#         lsst_patch:
-#         s_ra:
-#         s_dec:
-#         s_region:
+- name: CoaddPatches
+  description: "Static information about the subset of tracts and patches from the standard
+    LSST skymap that apply to coadds in these catalogs."
+  tap:table_index: 70
+  columnRefs:
+    base:
+      CoaddPatches:
+        lsst_tract:
+        lsst_patch:
+        s_ra:
+        s_dec:
+        s_region:
 
 - name: Visit
   description: "Metadata about the pointings of the telescope,

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2054,71 +2054,70 @@ tables:
     description: Non-unique index on the ssObjectId column; accelerates retrieval of single-epoch data for SSObjects.
     columns:
     - "#SSSource.ssObjectId"
-# - name: mpc_orbits
-#   description: Table of orbital elements and related information of known
-#     (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
-#     Planet Center (Postgres) database. This schema will generally closely
-#     follow the schema of the upstream table, to allow end-users to rerun
-#     queries developed elsewhere on the RSP.
-#   tap:table_index: 130
-#   primaryKey: '#mpc_orbits.id'
-#   columnRefs:
-#     base:
-#       mpc_orbits:
-#         id:
-#         designation:
-#         packed_primary_provisional_designation:
-#         unpacked_primary_provisional_designation:
-#         mpc_orb_jsonb:
-#         created_at:
-#         updated_at:
-#         orbit_type_int:
-#         u_param:
-#         nopp:
-#         arc_length_total:
-#         arc_length_sel:
-#         nobs_total:
-#         nobs_total_sel:
-#         a:
-#         q:
-#         e:
-#         i:
-#         node:
-#         argperi:
-#         peri_time:
-#         yarkovsky:
-#         srp:
-#         a1:
-#         a2:
-#         a3:
-#         dt:
-#         mean_anomaly:
-#         period:
-#         mean_motion:
-#         a_unc:
-#         q_unc:
-#         e_unc:
-#         i_unc:
-#         node_unc:
-#         argperi_unc:
-#         peri_time_unc:
-#         yarkovsky_unc:
-#         srp_unc:
-#         a1_unc:
-#         a2_unc:
-#         a3_unc:
-#         dt_unc:
-#         mean_anomaly_unc:
-#         period_unc:
-#         mean_motion_unc:
-#         epoch_mjd:
-#         h:
-#         g:
-#         not_normalized_rms:
-#         normalized_rms:
-#         earth_moid:
-#         fitting_datetime:
-
+- name: mpc_orbits
+  description: Table of orbital elements and related information of known
+    (sun-orbiting and unbound) Solar System objects. Replicated from the Minor
+    Planet Center (Postgres) database. This schema will generally closely
+    follow the schema of the upstream table, to allow end-users to rerun
+    queries developed elsewhere on the RSP.
+  tap:table_index: 130
+  primaryKey: '#mpc_orbits.id'
+  columnRefs:
+    base:
+      mpc_orbits:
+        id:
+        designation:
+        packed_primary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        mpc_orb_jsonb:
+        created_at:
+        updated_at:
+        orbit_type_int:
+        u_param:
+        nopp:
+        arc_length_total:
+        arc_length_sel:
+        nobs_total:
+        nobs_total_sel:
+        a:
+        q:
+        e:
+        i:
+        node:
+        argperi:
+        peri_time:
+        yarkovsky:
+        srp:
+        a1:
+        a2:
+        a3:
+        dt:
+        mean_anomaly:
+        period:
+        mean_motion:
+        a_unc:
+        q_unc:
+        e_unc:
+        i_unc:
+        node_unc:
+        argperi_unc:
+        peri_time_unc:
+        yarkovsky_unc:
+        srp_unc:
+        a1_unc:
+        a2_unc:
+        a3_unc:
+        dt_unc:
+        mean_anomaly_unc:
+        period_unc:
+        mean_motion_unc:
+        epoch_mjd:
+        h:
+        g:
+        not_normalized_rms:
+        normalized_rms:
+        earth_moid:
+        fitting_datetime:
 # - name: current_identifications
 #   description: All single-designations, and all identifications between
 #     designations. Always uses primary provisional designation (even for

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1,7 +1,7 @@
 ---
 name: dp2
 description: "Data Preview 2"
-version: 1.0.0
+version: 1.1.0
 resources:
   base:
     uri: "drp_base.yaml"

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -2110,54 +2110,54 @@ tables:
         normalized_rms:
         earth_moid:
         fitting_datetime:
-# - name: current_identifications
-#   description: All single-designations, and all identifications between
-#     designations. Always uses primary provisional designation (even for
-#     numbered objects). Includes all comets and satellites. Replicated from the
-#     Minor Planet Center (Postgres) database. This schema will generally closely
-#     follow the schema of the upstream table, to allow end-users to rerun
-#     queries developed elsewhere on the RSP.
-#   tap:table_index: 140
-#   primaryKey: '#current_identifications.id'
-#   columnRefs:
-#     base:
-#       current_identifications:
-#         id:
-#         packed_primary_provisional_designation:
-#         packed_secondary_provisional_designation:
-#         unpacked_primary_provisional_designation:
-#         unpacked_secondary_provisional_designation:
-#         published:
+- name: current_identifications
+  description: All single-designations, and all identifications between
+    designations. Always uses primary provisional designation (even for
+    numbered objects). Includes all comets and satellites. Replicated from the
+    Minor Planet Center (Postgres) database. This schema will generally closely
+    follow the schema of the upstream table, to allow end-users to rerun
+    queries developed elsewhere on the RSP.
+  tap:table_index: 140
+  primaryKey: '#current_identifications.id'
+  columnRefs:
+    base:
+      current_identifications:
+        id:
+        packed_primary_provisional_designation:
+        packed_secondary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        unpacked_secondary_provisional_designation:
+        published:
 #         identifier_ids:
-#         object_type:
-#         numbered:
-#         created_at:
-#         updated_at:
+        object_type:
+        numbered:
+        created_at:
+        updated_at:
 
-# - name: numbered_identifications
-  # description: The numbered identification table contains all the numbered
-  #   objects (minor planets, comets and natural satellites) with their primary
-  #   provisional designations. The table is continously updated everytime a new
-  #   object is numbered. Replicated from the Minor Planet Center (Postgres)
-  #   database. This schema will generally closely follow the schema of the
-  #   upstream table, to allow end-users to rerun queries developed elsewhere on
-  #   the RSP.
-  # tap:table_index: 150
-  # primaryKey: '#numbered_identifications.id'
-  # columnRefs:
-  #   base:
-  #     numbered_identifications:
-  #       id:
-  #       packed_primary_provisional_designation:
-  #       unpacked_primary_provisional_designation:
-  #       permid:
-  #       iau_designation:
-  #       iau_name:
+- name: numbered_identifications
+  description: The numbered identification table contains all the numbered
+    objects (minor planets, comets and natural satellites) with their primary
+    provisional designations. The table is continously updated everytime a new
+    object is numbered. Replicated from the Minor Planet Center (Postgres)
+    database. This schema will generally closely follow the schema of the
+    upstream table, to allow end-users to rerun queries developed elsewhere on
+    the RSP.
+  tap:table_index: 150
+  primaryKey: '#numbered_identifications.id'
+  columnRefs:
+    base:
+      numbered_identifications:
+        id:
+        packed_primary_provisional_designation:
+        unpacked_primary_provisional_designation:
+        permid:
+        iau_designation:
+        iau_name:
   #       numbered_publication_references:
   #       named_publication_references:
-  #       naming_credit:
-  #       created_at:
-  #       updated_at:
+        naming_credit:
+        created_at:
+        updated_at:
 
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."

--- a/python/lsst/sdm/schemas/dp2.yaml
+++ b/python/lsst/sdm/schemas/dp2.yaml
@@ -1271,7 +1271,7 @@ tables:
 - name: Source
   description: "Properties of detections on the single-epoch visit images,
     performed independently of the Object detections on coadded images."
-  tap:table_index: 20
+  tap:table_index: 63
   primaryKey: '#Source.sourceId'
   columnRefs:
     base:
@@ -2052,7 +2052,7 @@ tables:
     Planet Center (Postgres) database. This schema will generally closely
     follow the schema of the upstream table, to allow end-users to rerun
     queries developed elsewhere on the RSP.
-  tap:table_index: 130
+  tap:table_index: 100
   primaryKey: '#mpc_orbits.id'
   columnRefs:
     base:
@@ -2161,7 +2161,7 @@ tables:
 
 - name: ShearObject
   description: "Descriptions of shear objects detected and measured on coadds with metadetection."
-  tap:table_index: 170
+  tap:table_index: 66
   primaryKey: '#ShearObject.shearObjectId'
   columnRefs:
     base:
@@ -2243,7 +2243,7 @@ tables:
     associated source measurements, with positions for associated reference objects
     from Gaia DR3 where available.
   primaryKey: '#IsolatedStarStellarMotions.isolated_star_id'
-  tap:table_index: 180
+  tap:table_index: 68
   columnRefs:
     base:
       IsolatedStarStellarMotions:

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -5190,12 +5190,12 @@ tables:
   - name: coord_dec
     description: Fiducial ICRS Declination of centroid used for database indexing
     datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
   - name: coord_ra
     description: Fiducial ICRS Right Ascension of centroid used for database indexing
     datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
   - name: deblend_deblendedAsPsf
     description: Deblender thought this source looked like a PSF
@@ -5228,7 +5228,7 @@ tables:
   - name: dec
     description: Position in declination.
     datatype: double
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;meta.main
     ivoa:unit: deg
   - name: decErr
     description: Error in declination.
@@ -5465,7 +5465,7 @@ tables:
   - name: ra
     description: Position in right ascension.
     datatype: double
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;meta.main
     ivoa:unit: deg
   - name: raErr
     description: Angular error in right ascension (∂RA*cos(Dec)).

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -8218,165 +8218,165 @@ tables:
   columns:
   - name: dec
     description: Position in declination at the reference epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
     tap:principal: 1
   - name: decErr
     description: Error in declination at the reference epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.error;pos.eq.dec
     ivoa:unit: deg
     tap:principal: 1
   - name: decPM
     description: Proper motion in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.pm;pos.eq.dec
     ivoa:unit: mas/yr
     tap:principal: 1
   - name: decPMErr
     description: Error in proper motion in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.error;pos.pm;pos.eq.dec
     ivoa:unit: mas/yr
     tap:principal: 1
   - name: decPM_parallax_Cov
     description: Covariance between proper motion in declination and parallax.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.dec;pos.parallax
     ivoa:unit: mas**2/yr
     tap:principal: 1
   - name: dec_decPM_Cov
     description: Covariance between declination and proper motion in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.dec
     ivoa:unit: deg*mas/yr
     tap:principal: 1
   - name: dec_parallax_Cov
     description: Covariance between declination and parallax.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.parallax
     ivoa:unit: deg*mas
     tap:principal: 1
   - name: dec_raPM_Cov
     description: Covariance between declination and proper motion in right ascension.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.ra
     ivoa:unit: deg*mas/yr
     tap:principal: 1
   - name: epoch
     description: Epoch in MJD to which the position corresponds.
-    datatype: float
+    datatype: double
     ivoa:ucd: time.epoch
     ivoa:unit: d
     tap:principal: 1
   - name: isolated_star_id
     description: Unique id of isolated star
-    datatype: int
+    datatype: long
     ivoa:ucd: meta.id;meta.main
     tap:principal: 1
   - name: parallax
     description: Parallax
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.parallax
     ivoa:unit: mas
     tap:principal: 1
   - name: parallaxErr
     description: Error in parallax.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.error;pos.parallax
     ivoa:unit: mas
     tap:principal: 1
   - name: ra
     description: Position in right ascension at the reference epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
     tap:principal: 1
   - name: raErr
     description: Angular error in right ascension (∂RA*cos(Dec)) at the reference epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.error;pos.eq.ra
     ivoa:unit: deg
     tap:principal: 1
   - name: raPM
     description: Proper motion in right ascension.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.pm;pos.eq.ra
     ivoa:unit: mas/yr
     tap:principal: 1
   - name: raPMErr
     description: Error in proper motion in right ascension.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.error;pos.pm;pos.eq.ra
     ivoa:unit: mas/yr
     tap:principal: 1
   - name: raPM_decPM_Cov
     description: Covariance between proper motion in right ascension and proper motion
       in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.pm;pos.eq.dec
     ivoa:unit: mas**2/yr**2
     tap:principal: 1
   - name: raPM_parallax_Cov
     description: Covariance between proper motion in right ascension and parallax.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.parallax
     ivoa:unit: mas**2/yr
     tap:principal: 1
   - name: ra_decPM_Cov
     description: Covariance between right ascension and proper motion in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.dec
     ivoa:unit: deg*mas/yr
     tap:principal: 1
   - name: ra_dec_Cov
     description: Covariance between right ascension (RA*cos(Dec)) and
       declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
     ivoa:unit: deg**2
     tap:principal: 1
   - name: ra_parallax_Cov
     description: Covariance between right ascension and parallax.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.parallax
     ivoa:unit: deg*mas
     tap:principal: 1
   - name: ra_raPM_Cov
     description: Covariance between right ascension and proper motion in right ascension.
-    datatype: float
+    datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.ra
     ivoa:unit: deg*mas/yr
     tap:principal: 1
   - name: ref_dec
     description: Position of the reference object in declination at the reference
       epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
   - name: ref_decPM
     description: Proper motion of the reference object in declination.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.pm;pos.eq.dec
     ivoa:unit: mas/yr
   - name: ref_parallax
     description: Parallax of the reference object
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.parallax
     ivoa:unit: mas
   - name: ref_ra
     description: Position of the reference object in right ascension at the reference
       epoch.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
   - name: ref_raPM
     description: Proper motion of the reference object in right ascension.
-    datatype: float
+    datatype: double
     ivoa:ucd: pos.pm;pos.eq.ra
     ivoa:unit: mas/yr
   - name: referenceId
     description: Id of the reference object if available.
-    datatype: float
+    datatype: long
     tap:principal: 1

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -8245,25 +8245,25 @@ tables:
     datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.dec;pos.parallax
     ivoa:unit: mas**2/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: dec_decPM_Cov
     description: Covariance between declination and proper motion in declination.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.dec
     ivoa:unit: deg*mas/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: dec_parallax_Cov
     description: Covariance between declination and parallax.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.parallax
     ivoa:unit: deg*mas
-    tap:principal: 1
+    tap:principal: 0
   - name: dec_raPM_Cov
     description: Covariance between declination and proper motion in right ascension.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.dec;pos.pm;pos.eq.ra
     ivoa:unit: deg*mas/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: epoch
     description: Epoch in MJD to which the position corresponds.
     datatype: double
@@ -8317,65 +8317,70 @@ tables:
     datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.pm;pos.eq.dec
     ivoa:unit: mas**2/yr**2
-    tap:principal: 1
+    tap:principal: 0
   - name: raPM_parallax_Cov
     description: Covariance between proper motion in right ascension and parallax.
     datatype: double
     ivoa:ucd: stat.covariance;pos.pm;pos.eq.ra;pos.parallax
     ivoa:unit: mas**2/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: ra_decPM_Cov
     description: Covariance between right ascension and proper motion in declination.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.dec
     ivoa:unit: deg*mas/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: ra_dec_Cov
     description: Covariance between right ascension (RA*cos(Dec)) and
       declination.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.eq.dec
     ivoa:unit: deg**2
-    tap:principal: 1
+    tap:principal: 0
   - name: ra_parallax_Cov
     description: Covariance between right ascension and parallax.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.parallax
     ivoa:unit: deg*mas
-    tap:principal: 1
+    tap:principal: 0
   - name: ra_raPM_Cov
     description: Covariance between right ascension and proper motion in right ascension.
     datatype: double
     ivoa:ucd: stat.covariance;pos.eq.ra;pos.pm;pos.eq.ra
     ivoa:unit: deg*mas/yr
-    tap:principal: 1
+    tap:principal: 0
   - name: ref_dec
     description: Position of the reference object in declination at the reference
       epoch.
     datatype: double
     ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
+    tap:principal: 0
   - name: ref_decPM
     description: Proper motion of the reference object in declination.
     datatype: double
     ivoa:ucd: pos.pm;pos.eq.dec
     ivoa:unit: mas/yr
+    tap:principal: 0
   - name: ref_parallax
     description: Parallax of the reference object
     datatype: double
     ivoa:ucd: pos.parallax
     ivoa:unit: mas
+    tap:principal: 0
   - name: ref_ra
     description: Position of the reference object in right ascension at the reference
       epoch.
     datatype: double
     ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
+    tap:principal: 0
   - name: ref_raPM
     description: Proper motion of the reference object in right ascension.
     datatype: double
     ivoa:ucd: pos.pm;pos.eq.ra
     ivoa:unit: mas/yr
+    tap:principal: 0
   - name: referenceId
     description: Id of the reference object if available.
     datatype: long

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -8219,7 +8219,7 @@ tables:
   - name: dec
     description: Position in declination at the reference epoch.
     datatype: double
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;meta.main
     ivoa:unit: deg
     tap:principal: 1
   - name: decErr
@@ -8290,7 +8290,7 @@ tables:
   - name: ra
     description: Position in right ascension at the reference epoch.
     datatype: double
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;meta.main
     ivoa:unit: deg
     tap:principal: 1
   - name: raErr
@@ -8382,6 +8382,7 @@ tables:
     ivoa:unit: mas/yr
     tap:principal: 0
   - name: referenceId
-    description: Id of the reference object if available.
+    description: ID of the reference object if available, from Gaia DR3.
     datatype: long
     tap:principal: 1
+    ivoa:ucd: meta.id.assoc

--- a/python/lsst/sdm/schemas/drp_base.yaml
+++ b/python/lsst/sdm/schemas/drp_base.yaml
@@ -5691,18 +5691,18 @@ tables:
   - name: coord_dec
     description: Fiducial ICRS Declination of centroid used for database indexing.
     datatype: double
-    ivoa:ucd: pos.eq.dec;meta.main
+    ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
   - name: coord_ra
     description: Fiducial ICRS Right Ascension of centroid used for database indexing.
     datatype: double
-    ivoa:ucd: pos.eq.ra;meta.main
+    ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
   - name: dec
     description: Declination coordinate of the center of this diaSource.
     datatype: double
     nullable: false
-    ivoa:ucd: pos.eq.dec
+    ivoa:ucd: pos.eq.dec;meta.main
     ivoa:unit: deg
   - name: decErr
     description: Error in declination.
@@ -5958,7 +5958,7 @@ tables:
     description: Right ascension coordinate of the center of this diaSource.
     datatype: double
     nullable: false
-    ivoa:ucd: pos.eq.ra
+    ivoa:ucd: pos.eq.ra;meta.main
     ivoa:unit: deg
   - name: raErr
     description: Angular error in right ascension (∂RA*cos(Dec)).

--- a/python/lsst/sdm/schemas/ivoa_obscore.yaml
+++ b/python/lsst/sdm/schemas/ivoa_obscore.yaml
@@ -80,7 +80,7 @@ tables:
     length: 128
     nullable: false
     ivoa:ucd: meta.id
-    tap:column_index: 190
+    tap:column_index: 5
     tap:principal: 1
     tap:std: 1
   - name: obs_publisher_did
@@ -116,7 +116,7 @@ tables:
     datatype: double
     ivoa:ucd: pos.eq.ra
     ivoa:unit: deg
-    tap:column_index: 150
+    tap:column_index: 42
     tap:principal: 1
     tap:std: 1
   - name: s_dec
@@ -125,7 +125,7 @@ tables:
     datatype: double
     ivoa:ucd: pos.eq.dec
     ivoa:unit: deg
-    tap:column_index: 160
+    tap:column_index: 44
     tap:principal: 1
     tap:std: 1
   - name: s_fov
@@ -182,7 +182,7 @@ tables:
     datatype: double
     ivoa:ucd: time.start;obs.exposure
     ivoa:unit: d
-    tap:column_index: 130
+    tap:column_index: 46
     tap:principal: 1
     tap:std: 1
   - name: t_max
@@ -191,7 +191,7 @@ tables:
     datatype: double
     ivoa:ucd: time.end;obs.exposure
     ivoa:unit: d
-    tap:column_index: 140
+    tap:column_index: 48
     tap:principal: 1
     tap:std: 1
   - name: t_exptime
@@ -265,7 +265,7 @@ tables:
     datatype: string
     length: 128
     ivoa:ucd: meta.id;instr
-    tap:column_index: 220
+    tap:column_index: 115
     tap:principal: 1
     tap:std: 1
   - name: lsst_visit

--- a/python/lsst/sdm/schemas/ivoa_obscore.yaml
+++ b/python/lsst/sdm/schemas/ivoa_obscore.yaml
@@ -182,7 +182,7 @@ tables:
     datatype: double
     ivoa:ucd: time.start;obs.exposure
     ivoa:unit: d
-    tap:column_index: 46
+    tap:column_index: 117
     tap:principal: 1
     tap:std: 1
   - name: t_max
@@ -191,7 +191,7 @@ tables:
     datatype: double
     ivoa:ucd: time.end;obs.exposure
     ivoa:unit: d
-    tap:column_index: 48
+    tap:column_index: 118
     tap:principal: 1
     tap:std: 1
   - name: t_exptime


### PR DESCRIPTION
This bundles v30 backports for EPD2 with changes to the DP2 schema, `dp2.yaml`, as well as `drp_base.yaml` and `ivoa_obscore.yaml`.

Relevant tickets are listed on [this search](https://github.com/lsst/sdm_schemas/pulls?q=is%3Apr+label%3Abackport-v30+is%3Aclosed) and on the [Jira ticket](https://rubinobs.atlassian.net/browse/DM-55698).

## Checklist

When making changes to YAML files in the [schemas](/lsst/sdm_schemas/blob/main/python/lsst/sdm/schemas) directory:

- [ ] If applicable, incremented the schema version number, following the guidelines in the [contribution guide](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md)
- [ ] Referred to the [documentation on specific schemas](/lsst/sdm_schemas/blob/main/CONTRIBUTING.md#specific-schema-documentation) for additional versioning information, change constraints, or tasks that may need to be performed, based on which schema is being updated
- [ ] Ran Jenkins
- [ ] Added a news fragment [describing the changes](/lsst/sdm_schemas/blob/main/docs/changes/README.md)
